### PR TITLE
Added links to the C-Turtle GitHub repository

### DIFF
--- a/_sources/Introduction/Graphics.rst
+++ b/_sources/Introduction/Graphics.rst
@@ -34,7 +34,7 @@ This is particularly useful for abstract concepts such as recursion and iteratio
 For C++, a library titled C-Turtle is used to provide an equivalent of Python's Turtles.
 It acts as a close replacement to provide easy to use graphics to C++, while maintaining
 the objects and commands present in Python. It was developed by Jesse Walker-Schadler
-at Berea College during the summer of 2019.
+at Berea College during the summer of 2019 and can be found on GitHub here: https://github.com/walkerje/C-Turtle/
 
 Below is a comparison of two versions, C++ and Python, which should do
 the same thing. Try running both and comparing how the code looks between the two versions.

--- a/_sources/Recursion/pythondsSierpinskiTriangle.rst
+++ b/_sources/Recursion/pythondsSierpinskiTriangle.rst
@@ -177,14 +177,11 @@ finished with the bottom left it moves to the bottom middle, and so on.
 
     Figure 4: Building a Sierpinski Triangle
 
-The ``sierpinski`` function relies heavily on the ``getMid`` function.
-``getMid`` takes as arguments two endpoints and returns the point
+The ``sierpinski`` function relies heavily on the ``middle`` function.
+``middle`` takes as arguments two endpoints and returns the point
 halfway between them. In addition, :ref:`ActiveCode 1 <lst_st>` has a function that
 draws a filled triangle using the ``begin_fill`` and ``end_fill`` turtle
 methods.
 
-Visual Studio can be used to create similar turtle-like graphics in C++ using the provided class
-"Turtle.cpp". Visual Studio files can be opened together with the as a .sln file. Try downloading and running
-the following code from GitHub. https://github.com/CodyWMitchell/TestVSGraphics
-
-Look at the Turtle.cpp file. Try changing the code within the turtle's draw loop and using the predefined functions.
+The above sierpinski triangle visualization utilizes C-Turtle, a C++ equivalent of
+Python's ``turtle`` library, and can be found on GitHub here: https://github.com/walkerje/C-Turtle/


### PR DESCRIPTION
Added small notes on pages 1.14 and 5.8 that link back to the C-Turtle repository. Removed an outdated reference to a previous implementation on 5.8 and changed references from "get_mid" to "middle" to reflect the API update.