### PR TITLE
Resolves #286

### DIFF
--- a/_sources/Sort/Summary.rst
+++ b/_sources/Sort/Summary.rst
@@ -5,14 +5,6 @@
 Summary
 -------
 
--  A sequential search is :math:`O(n)` for ordered and unordered
-   lists.
-
--  A binary search of an ordered list is :math:`O(\log n)` in the
-   worst case.
-
--  Hash tables can provide constant time searching.
-
 -  A bubble sort, a selection sort, and an insertion sort are
    :math:`O(n^{2})` algorithms.
 


### PR DESCRIPTION
Removed redundant items from Chapter 7 Summary. Items about searches from the Chapter 6 Summary were duplicated into the Chapter 7 Summary about sorts, and needed to be removed.