### PR TITLE
Add index for stack section 3.3

### DIFF
--- a/pretext/LinearBasic/WhatisaStack.ptx
+++ b/pretext/LinearBasic/WhatisaStack.ptx
@@ -1,6 +1,8 @@
 <section xml:id="linear-basic_what-is-a-stack">
         <title>What is a Stack?</title>
-        <p>A <term>stack</term> (sometimes called a <q>push-down stack</q>) is an ordered
+        <p>
+            <idx>stack</idx>
+            A <term>stack</term> (sometimes called a <q>push-down stack</q>) is an ordered
             collection of items where the addition of new items and the removal of
             existing items always takes place at the same end. This end is commonly
             referred to as the <q>top.</q> The end opposite the top is known as the


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
In WhatisaStack.ptx of the restructured textbook stack was indexed. In the pretext version, this index is missing.

# Description
<!--- Describe your changes in detail -->
Stack should be indexed in section 3.3 What is a Stack?

## Related Issue
fix #331  
<!--- This project prefers pull requests related to open issues -->
<!--- If suggesting a change, please discuss it in an issue first -->
<!--- Please link to the issue here: -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
The change was tested locally and ran successfully
<img width="674" alt="index" src="https://github.com/pearcej/cppds/assets/89226977/4ba14279-c8bd-48a6-ad86-dedc10002884">

