### PR TITLE
add queue into the index 

### DIFF
--- a/pretext/LinearBasic/WhatIsaQueue.ptx
+++ b/pretext/LinearBasic/WhatIsaQueue.ptx
@@ -1,6 +1,8 @@
 <section xml:id="linear-basic_what-is-a-queue">
         <title>What Is a Queue?</title>
-        <p>A <term>queue</term> is an ordered collection of items where the addition of new
+        <p>
+        <idx>queue</idx>
+        A <term>queue</term> is an ordered collection of items where the addition of new
             items happens at one end, called the <q>rear,</q> and the removal of existing
             items occurs at the other end, commonly called the <q>front.</q> As an
             element enters the queue it starts at the rear and makes its way toward


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description
<!--- Describe your changes in detail -->
In WhatIsaQueue.ptx the term deque is not indexed. but in the old version of the textbook, we index that term.

## Related Issue
<!--- This project prefers pull requests related to open issues -->
<!--- If suggesting a change, please discuss it in an issue first -->
<!--- Please link to the issue here: -->
fix #337 
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
By running locally. 
![image](https://github.com/pearcej/cppds/assets/117699634/bb62b896-777e-49b0-b3af-62da97828acb)

