### PR TITLE
Added sequential search term to the index appendices

### DIFF
--- a/pretext/SearchHash/TheSequentialSearch.ptx
+++ b/pretext/SearchHash/TheSequentialSearch.ptx
@@ -1,5 +1,6 @@
 <section xml:id="search-hash_the-sequential-search">
         <title>The Sequential Search</title>
+        <idx> sequential search </idx> 
         <p>When data items are stored in a container type such as a Python list or a C++
             array/vector, we say that they have a linear or sequential relationship. Each data
             item is stored in a position relative to the others. In Python lists, these

--- a/pretext/SearchHash/TheSequentialSearch.ptx
+++ b/pretext/SearchHash/TheSequentialSearch.ptx
@@ -1,6 +1,6 @@
 <section xml:id="search-hash_the-sequential-search">
         <title>The Sequential Search</title>
-        <idx> sequential search </idx> 
+        <idx>sequential search</idx> 
         <p>When data items are stored in a container type such as a Python list or a C++
             array/vector, we say that they have a linear or sequential relationship. Each data
             item is stored in a position relative to the others. In Python lists, these


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
I added a sequential search to the index.
# Description
<!--- Describe your changes in detail -->
Sequential search was missing in the term appendices. I added it. 

## Related Issue
<!--- This project prefers pull requests related to open issues -->
Fix #335 
<!--- If suggesting a change, please discuss it in an issue first -->
<!--- Please link to the issue here: -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
I build the book locally and also is reviewed by @conderp
