### PR TITLE
Add terms from Section 6.4 Binary Search to Index

### DIFF
--- a/pretext/SearchHash/TheBinarySearch.ptx
+++ b/pretext/SearchHash/TheBinarySearch.ptx
@@ -3,7 +3,8 @@
         <p>It is possible to take greater advantage of the ordered vector if we are
             clever with our comparisons. In the sequential search, when we compare
             against the first item, there are at most <math>n-1</math> more items to
-            look through if the first item is not what we are looking for. Instead
+            look through if the first item is not what we are looking for. <idx>binary search</idx>
+            Instead
             of searching the vector in sequence, a <term>binary search</term> will start by
             examining the middle item. If that item is the one we are searching for,
             we are done. If it is not the correct item, we can use the ordered


### PR DESCRIPTION
Added terms found in Section 6.4 of the textbook to the Index.

The Index was missing terms since the textbook migrated to Pretext. I focused on adding terms from Section 6.4 specifically so that they would be searchable in the Index. This will resolve Issue #334.

This issue was tested using pretext build to view it in the webpage before officially pushing changes. The changes that I made were peer reviewed by @timalsinab.
