### PR TITLE
Added indexing for term linked data structure in section 4.2

### DIFF
--- a/pretext/LinearLinked/WhatAreLinkedStructures.ptx
+++ b/pretext/LinearLinked/WhatAreLinkedStructures.ptx
@@ -1,6 +1,6 @@
 <section xml:id="linear-linked_what-are-linked-structures">
         <title>What Are Linked Structures?</title>
-        <p>A <term>linked data structure</term> is a data structure which consists of a
+        <p> <idx>linked data structure</idx> A <term>linked data structure</term> is a data structure which consists of a
             set of data structures called nodes which are linked together and organized
             by links created via references or pointers.</p>
         <p>Linked data structures include linear linked structures like linked lists


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description
<!--- Describe your changes in detail -->
I indexed the term linear linked data in section 4.2. What are linked Structures?  It is the only missing term in this section.

## Related Issue
<!--- This project prefers pull requests related to open issues -->
<!--- If suggesting a change, please discuss it in an issue first -->
<!--- Please link to the issue here: -->
fix #338 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
I have tested this by building the book locally and making sure the links worked in that local build. Index term is lower case.