### PR TITLE
Add terms from 6.2 Searching to Index

### DIFF
--- a/pretext/SearchHash/searching.ptx
+++ b/pretext/SearchHash/searching.ptx
@@ -4,7 +4,7 @@
             most common problems that arise in computing: searching and sorting.
             In this chapter we will study searching and return to sorting
             in the next chapter.</p>
-        <p><term>Searching</term> is the algorithmic process of finding a particular item in a
+        <p><idx>searching</idx><term>Searching</term> is the algorithmic process of finding a particular item in a
             collection of items. A search typically answers either <c>True</c> or
             <c>False</c> as to whether the item is present. On occasion it may be
             modified to return where the item is found. For our purposes here, we


### PR DESCRIPTION
The textbook's Index is missing terms from Section 6.2. I have added from that section specifically.

This issue is suggested in order to make the Index more useful and accessible. Hopefully, students utilizing the book will be able to find the terms that they are looking for and want to reference quickly. 

I tested this by using pretext build and viewing it in the web. It was reviewed by @timalsinab.