### PR TITLE
Add index for LIFO on Section 3.3

### DIFF
--- a/pretext/LinearBasic/TheStackAbstractDataType.ptx
+++ b/pretext/LinearBasic/TheStackAbstractDataType.ptx
@@ -38,11 +38,6 @@
         
         <table xml:id="linear-basic_id1"><tabular>
             <title><term>Table 1: Sample Stack Operations</term></title>
-            
-                
-                
-                
-                
                     <row header="yes">
                         <cell>
                             <term>Stack Operation</term>
@@ -54,7 +49,6 @@
                             <term>Return Value</term>
                         </cell>
                     </row>
-                
                 
                     <row>
                         <cell>

--- a/pretext/LinearBasic/WhatisaStack.ptx
+++ b/pretext/LinearBasic/WhatisaStack.ptx
@@ -11,7 +11,7 @@
             that are closer to the base represent those that have been in the stack
             the longest. The most recently added item is the one that is in position
             to be removed first. This ordering principle is sometimes called
-            <idx>LIFO</idx>
+            <idx>LIFO</idx><idx>last-in first-out</idx>
             <term>LIFO</term>, <term>last-in first-out</term>. It provides an ordering based on length
             of time in the collection. Newer items are near the top, while older
             items are near the base.</p>

--- a/pretext/LinearBasic/WhatisaStack.ptx
+++ b/pretext/LinearBasic/WhatisaStack.ptx
@@ -11,6 +11,7 @@
             that are closer to the base represent those that have been in the stack
             the longest. The most recently added item is the one that is in position
             to be removed first. This ordering principle is sometimes called
+            <idx>LIFO</idx>
             <term>LIFO</term>, <term>last-in first-out</term>. It provides an ordering based on length
             of time in the collection. Newer items are near the top, while older
             items are near the base.</p>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
In WhatisaStack.ptx of the restructured textbook LIFO was indexed. In the pretext version, this index is missing.

# Description
<!--- Describe your changes in detail -->
LIFO should be indexed in section 3.3 What is a Stack?
PR also removed extra blank spaces in _TheStackAbstractDataType.ptx_ file

## Related Issue
fix #352 
<!--- This project prefers pull requests related to open issues -->
<!--- If suggesting a change, please discuss it in an issue first -->
<!--- Please link to the issue here: -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
The change was tested locally and ran successfully
<img width="726" alt="index" src="https://github.com/pearcej/cppds/assets/89226977/3f1f5f9c-23b9-4a31-9c37-0c5766d5ef1c">

