### PR TITLE
Indexed deque in cppds-v2

### DIFF
--- a/pretext/LinearBasic/WhatIsaDeque.ptx
+++ b/pretext/LinearBasic/WhatIsaDeque.ptx
@@ -1,6 +1,6 @@
 <section xml:id="linear-basic_what-is-a-deque">
         <title>What Is a Deque?</title>
-        <p>A <term>deque</term>, also known as a double-ended queue, is an ordered
+        <p><idx>deque</idx>A <term>deque</term>, also known as a double-ended queue, is an ordered
             collection of items similar to the queue. It has two ends, a front and a
             rear, and the items remain positioned in the collection. What makes a
             deque different is the unrestrictive nature of adding and removing


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description
<!--- Describe your changes in detail -->
In WhatIsaDeque.ptx, the Deque term definition was not included as an index for easy reference.
This issue is not in the cppds-v2
## Related Issue
fix #367
Reviewed by @demekenega 
<!--- This project prefers pull requests related to open issues -->
<!--- If suggesting a change, please discuss it in an issue first -->
<!--- Please link to the issue here: -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
To test the new change:
1. Run local repo of the new branch where change was made
2. View the changes to make it is registered
3. Screenshot the changes.
![image](https://github.com/pearcej/cppds/assets/97652878/b9519484-ae35-46f6-8dd3-fd901ccfa532)

