### PR TITLE
Update PreTeXt CLI to 2.0.3

### DIFF
--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -1,0 +1,73 @@
+// <!-- Managed automatically by PreTeXt authoring tools -->
+// (delete the above line to manage this file manually)
+{
+  "name": "PreTeXt-Codespaces",
+
+  // This Docker image includes some LaTeX support, but is still not to large.  Note that if you keep your codespace running, it will use up your GitHub free storage quota.  Additional options are listed below.
+  "image": "oscarlevin/pretext:small",
+  // If you need to generate more complicated assets (such as sageplots) or use additional fonts when building to PDF, comment out the above line and uncomment the following line.
+  // "image": "oscarlevin/pretext:full",
+  // If you only intend to build for web and don't have any latex-image generated assets, you can use a smaller image:
+  // "image": "oscarlevin/pretext:lite",
+
+  // Add gh cli as a feature (to support chodechat)
+  "features": {
+    "ghcr.io/devcontainers/features/github-cli:1": {}
+  },
+
+  // Port forwarding
+  // ---------------
+  // This is needed by the CodeChat Server.
+  "forwardPorts": [
+    // The port used for a Thrift connection between the VSCode CodeChat
+    // extension and the CodeChat Server.
+    27376,
+    // The port used for an HTTP connection from the CodeChat Client to
+    // the CodeChat Server.
+    27377,
+    // The port used by a websocket connection between the CodeChat
+    // Server and the CodeChat Client.
+    27378
+  ],
+  // See the [docs](https://containers.dev/implementors/json_reference/#port-attributes).
+  "portsAttributes": {
+    "27376": {
+      "label": "VSCode extension <-> CodeChat Server",
+      "requireLocalPort": true
+    },
+    "27377": {
+      "label": "CodeChat Client",
+      "requireLocalPort": true
+    },
+    "27378": {
+      "label": "CodeChat Client<->Server websocket",
+      "requireLocalPort": true
+      // This port needs to be public; however, there's no way to specify port visibility here. See `server.py` in the CodeChat Server for details.
+    }
+  },
+
+  // Configure tool-specific properties.
+  "customizations": {
+    "codespaces": {
+      "openFiles": ["source/main.ptx"]
+    },
+    "vscode": {
+      "settings": {
+        "editor.quickSuggestions": {
+          "other": "off"
+        },
+        "editor.snippetSuggestions": "top",
+        "xml.validation.enabled": false,
+        "CodeChat.CodeChatServer.Command": "CodeChat_Server"
+      },
+      "extensions": [
+        "ms-vscode.live-server",
+        "oscarlevin.pretext-tools",
+        "CodeChat.codechat"
+      ]
+    }
+  }
+
+  // Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+  // "remoteUser": "root"
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,3 @@
-# <!-- Managed automatically by PreTeXt authoring tools -->
-# (delete the above line to manage this file manually)
-
 # Boilerplate list of files in a PreTeXt project for git to ignore
 # ensure this file is tracked
 !.gitignore
@@ -19,6 +16,8 @@ node_modules
 
 # don't track error logs
 .error_schema.log
+cli.log
+**/cli.log
 logs
 
 # don't track OS related files (windows/macos/linux)
@@ -94,6 +93,38 @@ GitHub.sublime-settings
 .dropbox
 .dropbox.attr
 .dropbox.cache
+
+# Additionals based upon Pretextbook .gitignore
+user/*
+
+script/mjsre/node_modules/
+script/mjsre/package-lock.json
+pretext/__pycache__/**
+
+# any file ending in ~ (backups, usually)
+*~
+
+build_info
+**/_build
+**/rsbuild
+**/build
+build/*
+published
+
+# Codespaces set-up
+.devcontainer.json
+
+# ignore temp files
+temp-*
+
+# Ignore the following (from runestone .gitignore):
+
+*.pyc
+__pycache__/
+
+sphinx-enki-info.txt
+sphinx_settings.json
+pavement.py
 
 # Don't track codechat config (will be generated automatically)
 codechat_config.yaml

--- a/.gitignore
+++ b/.gitignore
@@ -1,21 +1,25 @@
+# <!-- Managed automatically by PreTeXt authoring tools -->
+# (delete the above line to manage this file manually)
+
 # Boilerplate list of files in a PreTeXt project for git to ignore
 # ensure this file is tracked
 !.gitignore
 
-# don't track unpublished builds
+# don't track unpublished builds or stage
 output
-**/output
 
 # don't track assets generated from source
 generated-assets
+
+# don't track the executables.ptx file
+executables.ptx
 
 # don't track node packages
 node_modules
 
 # don't track error logs
 .error_schema.log
-cli.log
-**/cli.log
+logs
 
 # don't track OS related files (windows/macos/linux)
 .DS_Store
@@ -85,39 +89,11 @@ bh_unicode_properties.cache
 # https://packagecontrol.io/packages/sublime-github
 GitHub.sublime-settings
 
+
 # Don't include Dropbox settings and caches
 .dropbox
 .dropbox.attr
 .dropbox.cache
 
-# Additionals based upon Pretextbook .gitignore
-user/*
-
-script/mjsre/node_modules/
-script/mjsre/package-lock.json
-pretext/__pycache__/**
-
-# any file ending in ~ (backups, usually)
-*~
-
-build_info
-**/_build
-**/rsbuild
-**/build
-build/*
-published
-
-# Codespaces set-up
-.devcontainer.json
-
-# ignore temp files
-temp-*
-
-# Ignore the following (from runestone .gitignore):
-
-*.pyc
-__pycache__/
-
-sphinx-enki-info.txt
-sphinx_settings.json
-pavement.py
+# Don't track codechat config (will be generated automatically)
+codechat_config.yaml

--- a/project.ptx
+++ b/project.ptx
@@ -1,70 +1,19 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-    This file provides the overall configuration for your PreTeXt
-    project. To edit the content of your document, open `source/main.ptx`
-    (default location).
+    This file, the project manifest, provides the overall configuration for
+    your PreTeXt project. To edit the content of your document, open
+    `source/main.ptx`. See
+    https://pretextbook.org/doc/guide/html/processing-CLI.html#cli-project-manifest.
 -->
-<project>
+<project ptx-version="2" source="pretext">
   <targets>
-    <target name="web">
-      <format>html</format>
-      <source>pretext/main.ptx</source>
-      <publication>pretext/publication-rs-for-all.xml</publication>
-      <output-dir>output/html</output-dir>
-    </target>
-    <target name="runestone">
-      <format>html</format>
-      <source>pretext/main.ptx</source>
-      <publication>pretext/publication-rs-academy.xml</publication>
-      <output-dir>published/cpp4py2</output-dir>
-    </target>
-    <target name="epub">
-      <format>epub</format>
-      <source>pretext/main.ptx</source>
-      <publication>pretext/publication-pub.xml</publication>
-      <output-dir>published/epub</output-dir>
-    </target>
-    <target name="latex">
-      <format>latex</format>
-      <source>pretext/main.ptx</source>
-      <publication>pretext/publication-rs-for-all.xml</publication>
-      <output-dir>output/latex</output-dir>
-    </target>
-    <target name="pdf" pdf-method="xelatex">
-      <format>pdf</format>
-      <source>source/main.ptx</source>
-      <publication>pretext/publication-rs-for-all.xml</publication>
-      <output-dir>output/pdf</output-dir>
-    </target>
-    <target name="print-latex">
-      <format>latex</format>
-      <source>source/main.ptx</source>
-      <publication>publication/publication.ptx</publication>
-      <output-dir>output/print-latex</output-dir>
-    </target>
-    <target name="subset">
-      <format>html</format>
-      <source>source/main.ptx</source>
-      <publication>publication/publication.ptx</publication>
-      <output-dir>output/subset</output-dir>
-      <stringparam key="debug.skip-knowls" value="yes"/>
-      <!-- edit this to change the section/chapter/etc. to include
-           in your subset build -->
-      <xmlid-root>ch_first</xmlid-root>
-    </target>
+    <target name="web" format="html"/>
+    <target name="runestone" format="html"/>
+    <target name="epub" format="epub"/>
+    <target name="latex" format="latex"/>
+    <target name="pdf" format="pdf"/>
+    <target name="print" format="pdf"/>
+    <target name="print-latex" format="latex"/>
+    <target name="subset" format="html"/>
   </targets>
-  <executables>
-      <latex>latex</latex>
-      <pdflatex>pdflatex</pdflatex>
-      <xelatex>xelatex</xelatex>
-      <pdfsvg>pdf2svg</pdfsvg>
-      <asy>asy</asy>
-      <sage>sage</sage>
-      <pdfpng>convert</pdfpng>
-      <pdfeps>pdftops</pdfeps>
-      <pdfcrop>pdf-crop-margins</pdfcrop>
-      <pageres>pageres</pageres>
-      <node>node</node>
-      <liblouis>file2brl</liblouis>
-    </executables>
 </project>

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
+pretext>=2.0.3
 runestone>=3.0.0b5
 SQLAlchemy>=1.0.8
-pretext>=1.6.0


### PR DESCRIPTION
### Description
In this update, the PreTeXt CLI has been upgraded to version 2.0.3 from 1.6.0. Additionally, a `devcontainer.json` file has been included, which offers the flexibility to potentially utilize GitHub Codespaces in the future. The `project.ptx` file has also been reformatted to ensure compatibility with V2. Furthermore, the `.gitignore` file has been updated for future codechat compatibility. 

### Related Issue
Issue #371

### Testing
1. Build the project locally and confirm that the build process is completed successfully.
2. Deploy the project locally and verify that it functions as expected without any errors in the console.

The testing instructions are relatively simple. Just make sure the project builds and can be viewed as expected. The documentation for this upgrade is relatively sparse and there is a lot of autogeneration of files for V2. I may have missed something so if you notice anything that needs/doesn't need to be included let me know!
