### PR TITLE
Add postorder, preorder, inorder to index - Section 8.6

### DIFF
--- a/pretext/Trees/TreeTraversals.ptx
+++ b/pretext/Trees/TreeTraversals.ptx
@@ -16,7 +16,7 @@
             <li>
                 <title>preorder</title>
                 
-                    <p>In a preorder traversal, we visit the root node first, then
+                    <p><idx>preorder</idx>In a preorder traversal, we visit the root node first, then
                         recursively do a preorder traversal of the left subtree, followed by
                         a recursive preorder traversal of the right subtree.</p>
                 
@@ -28,7 +28,7 @@
             <li>
                 <title>inorder</title>
                 
-                    <p>In an inorder traversal, we recursively do an inorder traversal on
+                    <p><idx>inorder</idx>In an inorder traversal, we recursively do an inorder traversal on
                         the left subtree, visit the root node, and finally do a recursive
                         inorder traversal of the right subtree.</p>
                 
@@ -40,7 +40,7 @@
             <li>
                 <title>postorder</title>
                 
-                    <p>In a postorder traversal, we recursively do a postorder traversal of
+                    <p><idx>postorder</idx>In a postorder traversal, we recursively do a postorder traversal of
                         the left subtree and the right subtree followed by a visit to the
                         root node.</p>
                 


### PR DESCRIPTION
### Description
Added 'Tree Traversal' terms to index.

### Related Issue
fix #374 

### Testing
1. Checkout branch and navigate to index.
2. Ensure that you can see terms for **postorder**, **preorder**, and **inorder**.

![image](https://github.com/pearcej/cppds/assets/97637517/b23ac73e-3575-482c-ba60-429d039e224c)
