### PR TITLE
Add "complete binary tree" and "heap order property" to index

### DIFF
--- a/pretext/Trees/BinaryHeapImplementation.ptx
+++ b/pretext/Trees/BinaryHeapImplementation.ptx
@@ -2,7 +2,7 @@
         <title>Binary Heap Implementation</title>
         <subsection xml:id="trees_the-structure-property">
             <title>The Structure Property</title>
-            <p>In order to make our heap work efficiently, we will take advantage of
+            <p><idx>complete binary tree</idx>In order to make our heap work efficiently, we will take advantage of
                 the logarithmic nature of the binary tree to represent our heap. In order to guarantee logarithmic
                 performance, we must keep our tree balanced. A balanced binary tree has
                 roughly the same number of nodes in the left and right subtrees of the
@@ -31,7 +31,7 @@
         </subsection>
         <subsection xml:id="trees_the-heap-order-property">
             <title>The Heap Order Property</title>
-            <p>The method that we will use to store items in a heap relies on
+            <p><idx>heap order property</idx>The method that we will use to store items in a heap relies on
                 maintaining the heap order property. The <term>heap order property</term> is as
                 follows: In a heap, for every node <math>x</math> with parent <math>p</math>,
                 the key in <math>p</math> is smaller than or equal to the key in

--- a/pretext/Trees/TreeTraversals.ptx
+++ b/pretext/Trees/TreeTraversals.ptx
@@ -16,7 +16,7 @@
             <li>
                 <title>preorder</title>
                 
-                    <p>In a preorder traversal, we visit the root node first, then
+                    <p><idx>preorder</idx>In a preorder traversal, we visit the root node first, then
                         recursively do a preorder traversal of the left subtree, followed by
                         a recursive preorder traversal of the right subtree.</p>
                 
@@ -28,7 +28,7 @@
             <li>
                 <title>inorder</title>
                 
-                    <p>In an inorder traversal, we recursively do an inorder traversal on
+                    <p><idx>inorder</idx>In an inorder traversal, we recursively do an inorder traversal on
                         the left subtree, visit the root node, and finally do a recursive
                         inorder traversal of the right subtree.</p>
                 
@@ -40,7 +40,7 @@
             <li>
                 <title>postorder</title>
                 
-                    <p>In a postorder traversal, we recursively do a postorder traversal of
+                    <p><idx>postorder</idx>In a postorder traversal, we recursively do a postorder traversal of
                         the left subtree and the right subtree followed by a visit to the
                         root node.</p>
                 


### PR DESCRIPTION
### Description
Added Section 8.10 terms to index.

### Related Issue
Fix #383 

### Testing

1. Checkout branch and navigate to index.
2. Ensure both terms appear as expected.


![image](https://github.com/pearcej/cppds/assets/97637517/433ac8b5-e17c-400b-ba9a-66076aca5d1c)

