### PR TITLE
Add 7.4 selection sort to index

### DIFF
--- a/pretext/Sort/TheSelectionSort.ptx
+++ b/pretext/Sort/TheSelectionSort.ptx
@@ -1,6 +1,6 @@
 <section xml:id="sort_the-selection-sort">
         <title>The Selection Sort</title>
-        <p>The <term>selection sort</term> improves on the bubble sort by making only one
+        <p><idx>selection sort</idx> The <term>selection sort</term> improves on the bubble sort by making only one
             exchange for every pass through the first part of the vector.
             We will call this a step.
             In order to do this, a


### PR DESCRIPTION
# Description
Took term 'selection sort' from Section 7.4 of the textbook cppds-v2 and added it to the index. This was the only term in this particular file to add.

## Related Issue
Fix #376 

## How Has This Been Tested?
- Built and deployed a pretext preview in the web to make sure the term showed up properly in the index.
- Previewed by @timalsinab 
