### PR TITLE
Indexed FIFO in cppds-v2

### DIFF
--- a/pretext/LinearBasic/WhatIsaQueue.ptx
+++ b/pretext/LinearBasic/WhatIsaQueue.ptx
@@ -8,7 +8,7 @@
             element enters the queue it starts at the rear and makes its way toward
             the front, waiting until that time when it is the next element to be
             removed.</p>
-        <p>The most recently added item in the queue must wait at the end of the
+        <p><idx>FIFO</idx>The most recently added item in the queue must wait at the end of the
             collection. The item that has been in the collection the longest is at
             the front. This ordering principle is sometimes called <term>FIFO</term>,
             <term>first-in first-out</term>. It is also known as <q>first-come first-served.</q></p>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description
<!--- Describe your changes in detail -->
In WhatIsaQueue.ptx the term FIFO ( first in first out) is not indexed.

## Related Issue
<!--- This project prefers pull requests related to open issues -->
<!--- If suggesting a change, please discuss it in an issue first -->
<!--- Please link to the issue here: -->
fix #381
Reviewed by: @njounkengdaizem 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
1. Save the changes.
2. Build and run locally.
3. Take a screenshot of the changes.
![image](https://github.com/pearcej/cppds/assets/117699634/17902644-5473-4f80-82f6-1a99bbce858c)


