### PR TITLE
Index terms from section 8.15 in cppds-v2

### DIFF
--- a/pretext/Trees/BalancedBinarySearchTrees.ptx
+++ b/pretext/Trees/BalancedBinarySearchTrees.ptx
@@ -1,6 +1,6 @@
 <section xml:id="trees_balanced-binary-search-trees">
         <title>Balanced Binary Search Trees</title>
-        <p><idx>AVL tree</idx> the previous section we looked at building a binary search tree. As
+        <p><idx>AVL tree</idx> The previous section we looked at building a binary search tree. As
             we learned, the performance of the binary search tree can degrade to
             <math>O(n)</math> for operations like <c>get</c> and <c>put</c> when the tree
             becomes unbalanced. In this section we will look at a special kind of

--- a/pretext/Trees/BalancedBinarySearchTrees.ptx
+++ b/pretext/Trees/BalancedBinarySearchTrees.ptx
@@ -1,13 +1,13 @@
 <section xml:id="trees_balanced-binary-search-trees">
         <title>Balanced Binary Search Trees</title>
-        <p>In the previous section we looked at building a binary search tree. As
+        <p><idx>AVL tree</idx> the previous section we looked at building a binary search tree. As
             we learned, the performance of the binary search tree can degrade to
             <math>O(n)</math> for operations like <c>get</c> and <c>put</c> when the tree
             becomes unbalanced. In this section we will look at a special kind of
             binary search tree that automatically makes sure that the tree remains
             balanced at all times. This tree is called an <term>AVL tree</term> and is named
             for its inventors: G.M. Adelson-Velskii and E.M. Landis.</p>
-        <p>An AVL tree implements the Map abstract data type just like a regular
+        <p><idx>balance factor</idx>An AVL tree implements the Map abstract data type just like a regular
             binary search tree, the only difference is in how the tree performs. To
             implement our AVL tree we need to keep track of a <term>balance factor</term> for
             each node in the tree. We do this by looking at the heights of the left


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description
<!--- Describe your changes in detail -->
Indexed terms 'AVL tree' and 'balance factor' terms to section 8.15 on BalancedBinarySearchTrees.ptx

## Related Issue
<!--- This project prefers pull requests related to open issues -->
<!--- If suggesting a change, please discuss it in an issue first -->
<!--- Please link to the issue here: -->
fix #384 
Reviewed by: @Boorclark 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
1. Saved the changes
2. Built the textbook locally
![image](https://github.com/pearcej/cppds/assets/97714804/7cd133a5-e8ef-4570-8173-eacc178870d7)


