### PR TITLE
Indexed linear data structures in section 3.3 WhatAreLinearStructures.ptx

### DIFF
--- a/pretext/LinearBasic/WhatAreLinearStructures.ptx
+++ b/pretext/LinearBasic/WhatAreLinearStructures.ptx
@@ -1,6 +1,6 @@
 <section xml:id="linear-basic_what-are-linear-structures">
         <title>What Are Linear Structures?</title>
-        <p>We will begin our study of data structures by
+        <p><idx>linear data structures</idx>We will begin our study of data structures by
             considering four simple but very powerful concepts. Vectors, stacks, queues,
             deques are examples of data collections whose items are
             ordered depending on how they are added or removed. Once an item is


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Indexed linear data structures in section 3.3 WhatAreLinearStructures.ptx

# Description
<!--- Describe your changes in detail -->
In WhatAreLinearStructures.ptx, the term `linear data structures ` was not included as an index for easy reference.

## Related Issue
<!--- This project prefers pull requests related to open issues -->
<!--- If suggesting a change, please discuss it in an issue first -->
<!--- Please link to the issue here: -->
fix #379 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
PR reviewed by @demekenega 
Here's the local build including my change

<img width="562" alt="lds" src="https://github.com/pearcej/cppds/assets/89226977/68390ffc-2587-4484-a452-22b4d4116d2c">
