### PR TITLE
Add Section 8.13 terms to index

### DIFF
--- a/pretext/Trees/SearchTreeImplementation.ptx
+++ b/pretext/Trees/SearchTreeImplementation.ptx
@@ -467,14 +467,14 @@ TreeNode  *_get(int key, TreeNode *currentNode){
 }</pre>
         
         <figure align="center" xml:id="id4"><caption xmlns:c="https://www.sphinx-doc.org/" xmlns:changeset="https://www.sphinx-doc.org/" xmlns:citation="https://www.sphinx-doc.org/" xmlns:cpp="https://www.sphinx-doc.org/" xmlns:index="https://www.sphinx-doc.org/" xmlns:js="https://www.sphinx-doc.org/" xmlns:math="https://www.sphinx-doc.org/" xmlns:py="https://www.sphinx-doc.org/" xmlns:rst="https://www.sphinx-doc.org/" xmlns:std="https://www.sphinx-doc.org/">Figure 4: Deleting Node 25, a Node That Has a Single Child</caption><image source="Trees/Figures/bstdel2.png" width="50%"/></figure>
-        <p><idx>successor</idx>The third case is the most difficult case to handle (see <xref ref="lst-bst7"/>). If a node has two
+        <p><idx>successor node</idx>The third case is the most difficult case to handle (see <xref ref="lst-bst7"/>). If a node has two
             children, then it is unlikely that we can simply promote one of them to
             take the node's place. We can, however, search the tree for a node that
             can be used to replace the one scheduled for deletion. What we need is a
             node that will preserve the binary search tree relationships for both of
             the existing left and right subtrees. The node that will do this is the
             node that has the next-largest key in the tree. We call this node the
-            <term>successor</term>, and we will look at a way to find the successor shortly.
+            <term>successor node</term>, and we will look at a way to find the successor shortly.
             The successor is guaranteed to have no more than one child, so we know
             how to remove it using the two cases for deletion that we have already
             implemented. Once the successor has been removed, we simply put it in

--- a/pretext/Trees/SearchTreeImplementation.ptx
+++ b/pretext/Trees/SearchTreeImplementation.ptx
@@ -1,6 +1,6 @@
 <section xml:id="trees_search-tree-implementation">
         <title>Search Tree Implementation</title>
-        <p>A binary search tree relies on the property that
+        <p><idx>bst property</idx>A binary search tree relies on the property that
             keys that are less than the parent are found in the left subtree, and
             keys that are greater than the parent are found in the right subtree. We
             will call this the <term>bst property</term>. As we implement the Map interface
@@ -467,7 +467,7 @@ TreeNode  *_get(int key, TreeNode *currentNode){
 }</pre>
         
         <figure align="center" xml:id="id4"><caption xmlns:c="https://www.sphinx-doc.org/" xmlns:changeset="https://www.sphinx-doc.org/" xmlns:citation="https://www.sphinx-doc.org/" xmlns:cpp="https://www.sphinx-doc.org/" xmlns:index="https://www.sphinx-doc.org/" xmlns:js="https://www.sphinx-doc.org/" xmlns:math="https://www.sphinx-doc.org/" xmlns:py="https://www.sphinx-doc.org/" xmlns:rst="https://www.sphinx-doc.org/" xmlns:std="https://www.sphinx-doc.org/">Figure 4: Deleting Node 25, a Node That Has a Single Child</caption><image source="Trees/Figures/bstdel2.png" width="50%"/></figure>
-        <p>The third case is the most difficult case to handle (see <xref ref="lst-bst7"/>). If a node has two
+        <p><idx>successor</idx>The third case is the most difficult case to handle (see <xref ref="lst-bst7"/>). If a node has two
             children, then it is unlikely that we can simply promote one of them to
             take the node's place. We can, however, search the tree for a node that
             can be used to replace the one scheduled for deletion. What we need is a


### PR DESCRIPTION
### Description
Added **successor** and **bst property** to index.

### Related Issue
fix #399 

### Testing
1. Checkout this branch and navigate to the index.
2. Ensure the terms appear in the index.

![image](https://github.com/pearcej/cppds/assets/97637517/6aa43265-35fc-447b-95c1-d0f197c7832f)

