### PR TITLE
Add index to terms in section 4.5 in cppds_v2

### DIFF
--- a/pretext/LinearLinked/TheOrderedListAbstractDataType.ptx
+++ b/pretext/LinearLinked/TheOrderedListAbstractDataType.ptx
@@ -95,7 +95,7 @@
         </subsection>
         <subsection xml:id="linear-linked_lists">
             <title>Lists</title>
-            <p><idx>list</idx>The STL also has a <term>list</term> container which is different from the forward list container in that while a forward list holds a link to the next element in the sequence, a list holds a link to the previous element and the next element. Lists are implemented as doubly-linked-lists. This allows the list to have efficient iteration in both directions. However because of the additional storage space required to store the link to the previous element and the time it takes to insert and remove an element, a forward list is more efficient than a list.</p>
+            <p><idx>list container</idx>The STL also has a <term>list container</term> which is different from the forward list container in that while a forward list holds a link to the next element in the sequence, a list holds a link to the previous element and the next element. Lists are implemented as doubly-linked-lists. This allows the list to have efficient iteration in both directions. However because of the additional storage space required to store the link to the previous element and the time it takes to insert and remove an element, a forward list is more efficient than a list.</p>
             <p>Click here for more information about STL <url href="http://www.cplusplus.com/reference/list/list/" visual="http://www.cplusplus.com/reference/list/list/">lists</url>.</p>
         </subsection>
     </section>

--- a/pretext/LinearLinked/TheOrderedListAbstractDataType.ptx
+++ b/pretext/LinearLinked/TheOrderedListAbstractDataType.ptx
@@ -1,6 +1,6 @@
 <section xml:id="linear-linked_the-ordered-list-abstract-data-type">
         <title>The Ordered List Abstract Data Type</title>
-        <p>We will now consider a type of list known as an <term>ordered list</term>. For
+        <p><idx>ordered list</idx>We will now consider a type of list known as an <term>ordered list</term>. For
             example, if the list of integers shown above were an ordered list
             (ascending order), then it could be written as 17, 26, 31, 54, 77, and
             93. Since 17 is the smallest item, it occupies the first position in the
@@ -52,7 +52,7 @@
         </ul></p>
         <subsection xml:id="linear-linked_forward-lists">
             <title>Forward lists</title>
-            <p><term>Forward lists</term> are sequence containers in the STL that allow you to do constant time insert and delete operations.</p>
+            <p><idx>forward list</idx><term>Forward lists</term> are sequence containers in the STL that allow you to do constant time insert and delete operations.</p>
             <p>These containers are implemented as ordered singly-linked lists. Singly linked
                 lists are able to store each list element in different storage locations as opposed
                 to regular arrays which each element has to be stored next to each other. Each
@@ -95,7 +95,7 @@
         </subsection>
         <subsection xml:id="linear-linked_lists">
             <title>Lists</title>
-            <p>The STL also has a <term>list</term> container which is different from the forward list container in that while a forward list holds a link to the next element in the sequence, a list holds a link to the previous element and the next element. Lists are implemented as doubly-linked-lists. This allows the list to have efficient iteration in both directions. However because of the additional storage space required to store the link to the previous element and the time it takes to insert and remove an element, a forward list is more efficient than a list.</p>
+            <p><idx>list</idx>The STL also has a <term>list</term> container which is different from the forward list container in that while a forward list holds a link to the next element in the sequence, a list holds a link to the previous element and the next element. Lists are implemented as doubly-linked-lists. This allows the list to have efficient iteration in both directions. However because of the additional storage space required to store the link to the previous element and the time it takes to insert and remove an element, a forward list is more efficient than a list.</p>
             <p>Click here for more information about STL <url href="http://www.cplusplus.com/reference/list/list/" visual="http://www.cplusplus.com/reference/list/list/">lists</url>.</p>
         </subsection>
     </section>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description
<!--- Describe your changes in detail -->
Added idx tags to terms in section 4.5 of the cppds_v2 section of the textbook.

## Related Issue
<!--- This project prefers pull requests related to open issues -->
<!--- If suggesting a change, please discuss it in an issue first -->
<!--- Please link to the issue here: -->
fix #382 
reviewed by @njounkengdaizem 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
To test these changes, ran pretext build and pretext view, and reviewed the index to ensure proper rendering and correct references to paragraphs in the section. 
![image](https://github.com/pearcej/cppds/assets/97543993/7d244b5c-6bf1-4ea6-aafc-db701ccb0228)
