### PR TITLE
Issue405 indexed stack abstract data type section 3.4

### DIFF
--- a/pretext/LinearBasic/TheStackAbstractDataType.ptx
+++ b/pretext/LinearBasic/TheStackAbstractDataType.ptx
@@ -1,6 +1,6 @@
 <section xml:id="linear-basic_the-stack-abstract-data-type">
+    <idx>stack abstract data type</idx>
         <title>The Stack Abstract Data Type</title>
-        <idx>stack abstract data type</idx>
         <p> The <term>stack abstract data type</term> is defined by the following structure and
             operations. A stack is structured, as described above, as an ordered
             collection of items where items are added to and removed from the end

--- a/pretext/LinearBasic/TheStackAbstractDataType.ptx
+++ b/pretext/LinearBasic/TheStackAbstractDataType.ptx
@@ -1,6 +1,7 @@
 <section xml:id="linear-basic_the-stack-abstract-data-type">
         <title>The Stack Abstract Data Type</title>
-        <p>The stack abstract data type is defined by the following structure and
+        <idx>stack abstract data type</idx>
+        <p> The <term>stack abstract data type</term> is defined by the following structure and
             operations. A stack is structured, as described above, as an ordered
             collection of items where items are added to and removed from the end
             called the <q>top.</q> Stacks are ordered LIFO. The stack operations are

--- a/pretext/LinearBasic/TheStackAbstractDataType.ptx
+++ b/pretext/LinearBasic/TheStackAbstractDataType.ptx
@@ -1,7 +1,7 @@
 <section xml:id="linear-basic_the-stack-abstract-data-type">
-    <idx>stack abstract data type</idx>
+    <idx>stack abstract data type</idx> <idx>stack ADT</idx>
         <title>The Stack Abstract Data Type</title>
-        <p>The <term>stack abstract data type</term> is defined by the following structure and
+        <p>The <term>stack abstract data type</term> or <term>stack ADT</term> is defined by the following structure and
             operations. A stack is structured, as described above, as an ordered
             collection of items where items are added to and removed from the end
             called the <q>top.</q> Stacks are ordered LIFO. The stack operations are

--- a/pretext/LinearBasic/TheStackAbstractDataType.ptx
+++ b/pretext/LinearBasic/TheStackAbstractDataType.ptx
@@ -1,7 +1,7 @@
 <section xml:id="linear-basic_the-stack-abstract-data-type">
     <idx>stack abstract data type</idx>
         <title>The Stack Abstract Data Type</title>
-        <p> The <term>stack abstract data type</term> is defined by the following structure and
+        <p>The <term>stack abstract data type</term> is defined by the following structure and
             operations. A stack is structured, as described above, as an ordered
             collection of items where items are added to and removed from the end
             called the <q>top.</q> Stacks are ordered LIFO. The stack operations are


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Added term and index tags for section on stack abstract data type

# Description
<!--- Describe your changes in detail -->
Added term tag for `stack abstract data type` and indexed the entire section

## Related Issue
<!--- This project prefers pull requests related to open issues -->
<!--- If suggesting a change, please discuss it in an issue first -->
<!--- Please link to the issue here: -->
fix #405 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
Reviewed by @demekenega 
Change was tested successfully in a local build
<img width="472" alt="stack abstract data type" src="https://github.com/pearcej/cppds/assets/89226977/67453b5a-8d73-4599-a416-df460958df52">


