### PR TITLE
Add definition for an Ordered Linked List in cppds-v2

### DIFF
--- a/pretext/LinearLinked/ImplementinganOrderedList.ptx
+++ b/pretext/LinearLinked/ImplementinganOrderedList.ptx
@@ -4,7 +4,7 @@
         <idx>ordered linked list</idx>
             <statement>
              <p>
-               <term>Ordered linked list</term> is a linear data structure consisting of a collection of nodes, each containing two main components: a data element, often referred to as the "value" or "key", and a "reference" or "link" to the next node in the sequence. These nodes are organized in a specific order based on the values of their data elements, typically in ascending or descending order.
+              An <term>ordered linked list</term> is a linear data structure consisting of a collection of nodes, each containing two main components: a data element, often referred to as the "value" or "key", and a "reference" or "link" to the next node in the sequence. These nodes are organized in a specific order based on the values of their data elements, typically in ascending or descending order.
              </p>
             </statement>
         </definition>

--- a/pretext/LinearLinked/ImplementinganOrderedList.ptx
+++ b/pretext/LinearLinked/ImplementinganOrderedList.ptx
@@ -1,5 +1,13 @@
 <section xml:id="linear-linked_implementing-an-ordered-linked-list">
         <title>Implementing an Ordered Linked List</title>
+        <definition xml:id="def-ordered-linked-list">
+        <idx>ordered linked list</idx>
+            <statement>
+             <p>
+               <term>Ordered linked list</term> is a linear data structure consisting of a collection of nodes, each containing two main components: a data element, often referred to as the "value" or "key", and a "reference" or "link" to the next node in the sequence. These nodes are organized in a specific order based on the values of their data elements, typically in ascending or descending order.
+             </p>
+            </statement>
+        </definition>
         <p>In order to implement the <term>ordered linked list</term>, we must remember that the
             relative positions of the items are based on some underlying
             characteristic. The ordered linked list of integers given above (17, 26, 31,
@@ -353,4 +361,3 @@ int main() {
     </exercise>
         </subsection>
     </section>
-


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description
<!--- Describe your changes in detail -->
I added a definition to an ordered linked list in section 4.4 and the index because there previously wasn't one ready to see.
## Related Issue
<!--- This project prefers pull requests related to open issues -->
<!--- If suggesting a change, please discuss it in an issue first -->
<!--- Please link to the issue here: -->
fix #416 
reviewed by @andersoncedu 
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
I used the pretext build and pretext web command to view my changes.