### PR TITLE
fix393, add terms from 1.8 +1.9 to index

### DIFF
--- a/pretext/Introduction/GettingStartedwithData.ptx
+++ b/pretext/Introduction/GettingStartedwithData.ptx
@@ -1,6 +1,8 @@
 <section xml:id="introduction_getting-started-with-data">
         <title>Getting Started with Data</title>
-        <p>C++ considers data to be the focal point of the problem-solving process.
+        <p> <idx>class</idx>
+            <idx>object</idx>
+            C++ considers data to be the focal point of the problem-solving process.
             We stated above that C++ supports the object-oriented programming
             paradigm. In C++, as well as in any other
             object-oriented programming language, we define a <term>class</term> to be a


### PR DESCRIPTION

# Description
terms needed to be added from 1.8: class, object
terms needed to be added from 1.9: collection, Arrays, vector, strings, hash tables, Unordered Sets, immutable,

## Related Issue
issue #393 

## How Has This Been Tested?
1. locally build
2. navigate to index
3. click on the words that were added in the index page, and follow the in-context to see if it goes to the right section of the page
