### PR TITLE
Fix #425 remove term tags from balanced parentheses

### DIFF
--- a/pretext/LinearBasic/SimpleBalancedParentheses.ptx
+++ b/pretext/LinearBasic/SimpleBalancedParentheses.ptx
@@ -11,8 +11,9 @@
         <p>This defines a function called <c>square</c> that will return the square of
             its argument <c>n</c>. Scheme and Lisp are both notorious for using lots and lots of
             parentheses.</p>
-        <p>In both of these examples, parentheses must appear in a balanced
-            fashion. <term>Balanced parentheses</term> means that each opening symbol has a
+        <p>
+            In both of these examples, parentheses must appear in a balanced
+            fashion. "Balanced parentheses" means that each opening symbol has a
             corresponding closing symbol and the pairs of parentheses are properly
             nested. Consider the following correctly balanced strings of
             parentheses:</p>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Added modifications to the word `balanced parentheses`

# Description
<!--- Describe your changes in detail -->
Removed term tags from balanced parentheses and added quotation marks around it. 

## Related Issue
<!--- This project prefers pull requests related to open issues -->
<!--- If suggesting a change, please discuss it in an issue first -->
<!--- Please link to the issue here: -->
fix #425  

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
This has been tested on a local build of the book
<img width="460" alt="balanced parentheses" src="https://github.com/pearcej/cppds/assets/89226977/0529e164-0b01-4301-98ff-74bb12adb78f">


