### PR TITLE
Indexed terms in section 9.3 of cppds v_2

### DIFF
--- a/pretext/Graphs/TheGraphAbstractDataType.ptx
+++ b/pretext/Graphs/TheGraphAbstractDataType.ptx
@@ -33,7 +33,7 @@
             we can implement the graph ADT in Python. We will see that there are
             trade-offs in using different representations to implement the ADT
             described above. There are two well-known implementations of a graph,
-            the <term>adjacency matrix</term> and the <term>adjacency list</term>. We will explain
+            the <idx>adjacency matrix</idx><term>adjacency matrix</term> and the <idx>adjacency list</idx><term>adjacency list</term>. We will explain
             both of these options, and then implement one as a Python class.</p>
 
 <exercise label="gadt">


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description
<!--- Describe your changes in detail -->
In section 9.3 of cppds_v2, the terms have not been indexed.
Fixed the indexes of terms in TheGraphAbstractDataType.ptx
## Related Issue
<!--- This project prefers pull requests related to open issues -->
<!--- If suggesting a change, please discuss it in an issue first -->
<!--- Please link to the issue here: -->
fix #445
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
To see new changes;
1. checkout out to issue445
2. run "pretext build web" followed by "pretext view web"
3. View changes in the book by navigating to the course page.

![image](https://github.com/pearcej/cppds/assets/97652878/ee136ce6-dcae-4413-a3bd-e5f3b8ba73fc)

