### PR TITLE
Fixed cross reference issue loacted in section 3.4 in cppds-v2

### DIFF
--- a/pretext/LinearBasic/TheStackAbstractDataType.ptx
+++ b/pretext/LinearBasic/TheStackAbstractDataType.ptx
@@ -37,7 +37,7 @@
             stack operations. Under stack contents, the top item is listed at the
             far right.</p>
         
-        <table xml:id="linear-basic_id1"><tabular>
+        <table xml:id="linear-basic_tbl-stackops"><tabular>
             <title><term>Table 1: Sample Stack Operations</term></title>
                     <row header="yes">
                         <cell>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description
<!--- Describe your changes in detail -->
I changed the reference name to match the xml:id it was supposed to link to. This has removed the error message from the text and allows the reader to click on the link.

## Related Issue
<!--- This project prefers pull requests related to open issues -->
<!--- If suggesting a change, please discuss it in an issue first -->
<!--- Please link to the issue here: -->
Fix #450 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
I tested this by building the code with my changes locally and making sure the link worked. 

![image](https://github.com/pearcej/cppds/assets/112132745/e3521478-867e-49c1-acb7-57efc0c27a62)