### PR TITLE
Add parsons problem in 2.13

### DIFF
--- a/pretext/AlgorithmAnalysis/Glossary.ptx
+++ b/pretext/AlgorithmAnalysis/Glossary.ptx
@@ -116,5 +116,42 @@
                 </gi>
             
         </glossary>
+
+                  
+
+    <exercise label="matching_algorithmana0">
+        <statement><p>Drag the word on the left to its corresponding definition.</p></statement>
+        <feedback><p>Review classes and their properties.</p></feedback>
+    <matches>
+    <match order="1"><premise>algorithm</premise><response>Step-by-step list of instructions for solving a problem.</response></match>
+    <match order="2"><premise>average case</premise><response>When an algorithm performs between its worst and best case given a certain data set or circumstance.</response></match>
+    <match order="3"><premise>vector</premise><response>Sequence container storing data of a single type in a dynamically allocated array.</response></match>
+    <match order="4"><premise>worst case</premise><response>When an algorithm performs especially poorly given a certain data set or circumstance.</response></match>
+    <match order="5"><premise>dynamic size</premise><response>Able to change size automatically</response></match>
+    </matches></exercise> 
+
+    <exercise label="matching_algorithmana1">
+        <statement><p>Drag the word on the left to its corresponding definition.</p></statement>
+        <feedback><p>Review classes and their properties.</p></feedback>
+    <matches>
+    <match order="1"><premise>quadratic</premise><response>Function describing a relationship who's highest order is a number squared</response></match>
+    <match order="2"><premise>best case</premise><response>When an algorithm performs especially good given a certain data set or circumstance</response></match>
+    <match order="3"><premise>Big-O notation</premise><response>another term for order of magnitude</response></match>
+    <match order="4"><premise>brute force</premise><response>Technique that tries to exhaust all possibilities of a problem.</response></match>
+    <match order="5"><premise>contiguous</premise><response>Adjacent</response></match>
+    </matches></exercise> 
+
+    <exercise label="matching_algorithmana2">
+        <statement><p>Drag the word on the left to its corresponding definition.</p></statement>
+        <feedback><p>Review classes and their properties.</p></feedback>
+    <matches>
+    
+    <match order="1"><premise>hash table</premise><response>A collection consisting of key-value pairs with an associated hash function that maps the key to the associated value.</response></match>
+    <match order="2"><premise>linear</premise><response>Function that grows in a one to one relationship with its input.</response></match>
+    <match order="3"><premise>logarithmic</premise><response>functions that are the inverse of exponential functions</response></match>
+    <match order="4"><premise>order of magnitude</premise><response>a function describing an algorithm's steps as the size of the problem increases.</response></match>
+    <match order="5"><premise>exponential</premise><response>Function represented as a number being raised to a power that increases.</response></match>
+    </matches></exercise> 
+        
     </section>
     


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description
<!--- Describe your changes in detail -->
I added a parsons problem in 2.13 on the old book. There was a Pearson's problem on the glossary page for chapter two, but that is missing in the new version of the book and needs to be added. Because of that, I said those problems also; in the previous book, the parsons problem for that section was very long I even created an issue for it but now for the book I divide the parsons problem into three parts which makes it easy for users to answer each question.
## Related Issue
<!--- This project prefers pull requests related to open issues -->
<!--- If suggesting a change, please discuss it in an issue first -->
<!--- Please link to the issue here: -->
fix #497 

## How Has This Been Tested?
1. make change locally.
2. see the changes locally.
![image](https://github.com/pearcej/cppds/assets/117699634/fa6abe91-ea41-40be-99bb-164d287f4008)

<!--- Please describe in detail how you tested your changes. -->
