### PR TITLE
Fix links for all images in Chapter 3 in cppds-v2

### DIFF
--- a/introduction_what-is-computer-science.html
+++ b/introduction_what-is-computer-science.html
@@ -1,0 +1,517 @@
+<!DOCTYPE html>
+<!--********************************************-->
+<!--*       Generated from PreTeXt source      *-->
+<!--*                                          *-->
+<!--*         https://pretextbook.org          *-->
+<!--*                                          *-->
+<!--********************************************-->
+<html lang="en-US" dir="ltr">
+<head xmlns:og="http://ogp.me/ns#" xmlns:book="https://ogp.me/ns/book#">
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>SB What Is Computer Science?</title>
+<meta name="Keywords" content="Authored in PreTeXt">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta property="og:type" content="book">
+<meta property="book:title" content="Problem Solving with Algorithms and Data Structures using C++">
+<script>
+var runestoneMathReady = new Promise((resolve) => window.rsMathReady = resolve);
+window.MathJax = {
+  "tex": {
+    "inlineMath": [
+      [
+        "\\(",
+        "\\)"
+      ]
+    ],
+    "tags": "none",
+    "tagSide": "right",
+    "tagIndent": ".8em",
+    "packages": {
+      "[+]": [
+        "base",
+        "extpfeil",
+        "ams",
+        "amscd",
+        "color",
+        "newcommand",
+        "knowl"
+      ]
+    }
+  },
+  "options": {
+    "ignoreHtmlClass": "tex2jax_ignore|ignore-math",
+    "processHtmlClass": "process-math"
+  },
+  "chtml": {
+    "scale": 0.98,
+    "mtextInheritFont": true
+  },
+  "loader": {
+    "load": [
+      "input/asciimath",
+      "[tex]/extpfeil",
+      "[tex]/amscd",
+      "[tex]/color",
+      "[tex]/newcommand",
+      "[pretext]/mathjaxknowl3.js"
+    ],
+    "paths": {
+      "pretext": "https://pretextbook.org/js/lib"
+    }
+  },
+  "startup": {
+    pageReady() {
+      return MathJax.startup.defaultPageReady().then(function () {
+      console.log("in ready function");
+      rsMathReady();
+      }
+    )}
+  }
+};
+</script><script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-chtml.js"></script><link href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.26.0/themes/prism.css" rel="stylesheet">
+<script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.26.0/components/prism-core.min.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.26.0/plugins/autoloader/prism-autoloader.min.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.26.0/plugins/line-numbers/prism-line-numbers.min.js" integrity="sha512-dubtf8xMHSQlExGRQ5R7toxHLgSDZ0K7AunqPWHXmJQ8XyVIG19S1T95gBxlAeGOK02P4Da2RTnQz0Za0H0ebQ==" crossorigin="anonymous" referrerpolicy="no-referrer"></script><link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.26.0/plugins/line-numbers/prism-line-numbers.min.css" integrity="sha512-cbQXwDFK7lj2Fqfkuxbo5iD1dSbLlJGXGpfTDqbggqjHJeyzx88I3rfwjS38WJag/ihH7lzuGlGHpDBymLirZQ==" crossorigin="anonymous" referrerpolicy="no-referrer">
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.26.0/plugins/line-highlight/prism-line-highlight.min.css" integrity="sha512-nXlJLUeqPMp1Q3+Bd8Qds8tXeRVQscMscwysJm821C++9w6WtsFbJjPenZ8cQVMXyqSAismveQJc0C1splFDCA==" crossorigin="anonymous" referrerpolicy="no-referrer">
+<script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.26.0/plugins/line-highlight/prism-line-highlight.min.js" integrity="sha512-93uCmm0q+qO5Lb1huDqr7tywS8A2TFA+1/WHvyiWaK6/pvsFl6USnILagntBx8JnVbQH5s3n0vQZY6xNthNfKA==" crossorigin="anonymous" referrerpolicy="no-referrer"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/lunr.js/2.3.9/lunr.min.js" integrity="sha512-4xUl/d6D6THrAnXAwGajXkoWaeMNwEKK4iNfq5DotEbLPAfk6FSxSP3ydNxqDgCw1c/0Z1Jg6L8h2j+++9BZmg==" crossorigin="anonymous" referrerpolicy="no-referrer"></script><script src="lunr-pretext-search-index.js" async=""></script><script src="https://pretextbook.org/js/0.33/pretext_search.js"></script><link href="https://pretextbook.org/css/0.83/pretext_search.css" rel="stylesheet" type="text/css">
+<script>js_version = 0.33</script><script src="https://pretextbook.org/js/lib/jquery.min.js"></script><script src="https://pretextbook.org/js/lib/jquery.sticky.js"></script><script src="https://pretextbook.org/js/lib/jquery.espy.min.js"></script><script src="https://pretextbook.org/js/0.33/pretext.js"></script><script>miniversion=0.1</script><script src="https://pretextbook.org/js/0.33/pretext_add_on.js?x=1"></script><script src="https://pretextbook.org/js/0.33/user_preferences.js"></script><script src="https://pretextbook.org/js/lib/knowl.js"></script><!--knowl.js code controls Sage Cells within knowls--><script>sagecellEvalName='Evaluate (Sage)';
+</script><link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="">
+<link href="https://fonts.googleapis.com/css2?family=Inconsolata:wght@400;700&amp;family=Noto+Serif:ital,wght@0,400;0,700;1,400;1,700&amp;family=Tinos:ital,wght@0,400;0,700;1,400;1,700&amp;display=swap" rel="stylesheet">
+<link href="https://fonts.cdnfonts.com/css/dejavu-serif" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Roboto+Serif:opsz,wdth,wght@8..144,50..150,100..900&amp;display=swap" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Open+Sans:wdth,wght@75..100,300..800&amp;display=swap" rel="stylesheet">
+<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200">
+<link href="https://pretextbook.org/css/0.83/pretext.css" rel="stylesheet" type="text/css">
+<link href="https://pretextbook.org/css/0.83/pretext_add_on.css" rel="stylesheet" type="text/css">
+<link href="https://pretextbook.org/css/0.83/shell_default.css" rel="stylesheet" type="text/css">
+<link href="https://pretextbook.org/css/0.83/banner_default.css" rel="stylesheet" type="text/css">
+<link href="https://pretextbook.org/css/0.83/navbar_default.css" rel="stylesheet" type="text/css">
+<link href="https://pretextbook.org/css/0.83/toc_default.css" rel="stylesheet" type="text/css">
+<link href="https://pretextbook.org/css/0.83/knowls_default.css" rel="stylesheet" type="text/css">
+<link href="https://pretextbook.org/css/0.83/style_default.css" rel="stylesheet" type="text/css">
+<link href="https://pretextbook.org/css/0.83/colors_default.css" rel="stylesheet" type="text/css">
+<link href="https://pretextbook.org/css/0.83/setcolors.css" rel="stylesheet" type="text/css">
+<!--** eBookCongig is necessary to configure interactive       **-->
+<!--** Runestone components to run locally in reader's browser **-->
+<!--** No external communication:                              **-->
+<!--**     log level is 0, Runestone Services are disabled     **-->
+<script type="text/javascript">
+eBookConfig = {};
+eBookConfig.useRunestoneServices = false;
+eBookConfig.host = 'http://127.0.0.1:8000';
+eBookConfig.course = 'PTX_Course_Title_Here';
+eBookConfig.basecourse = 'PTX_Base_Course';
+eBookConfig.isLoggedIn = false;
+eBookConfig.email = '';
+eBookConfig.isInstructor = false;
+eBookConfig.logLevel = 0;
+eBookConfig.username = '';
+eBookConfig.readings = null;
+eBookConfig.activities = null;
+eBookConfig.downloadsEnabled = false;
+eBookConfig.allow_pairs = false;
+eBookConfig.enableScratchAC = false;
+eBookConfig.build_info = "";
+eBookConfig.python3 = null;
+eBookConfig.runestone_version = '7.2.9';
+eBookConfig.jobehost = '';
+eBookConfig.proxyuri_runs = '';
+eBookConfig.proxyuri_files = '';
+eBookConfig.enable_chatcodes =  false;
+</script>
+<!--*** Runestone Services ***-->
+<script type="text/javascript" src="https://runestone.academy/cdn/runestone/7.2.9/prefix-runtime.2438a8bdd6d43b5c.bundle.js"></script><script type="text/javascript" src="https://runestone.academy/cdn/runestone/7.2.9/prefix-347.8328b60515045466.bundle.js"></script><script type="text/javascript" src="https://runestone.academy/cdn/runestone/7.2.9/prefix-runestone.aeac7cf9ad5c07ef.bundle.js"></script><link rel="stylesheet" type="text/css" href="https://runestone.academy/cdn/runestone/7.2.9/prefix-347.f9add1ca35d5ad93.css">
+<link rel="stylesheet" type="text/css" href="https://runestone.academy/cdn/runestone/7.2.9/prefix-runestone.f64dcc3632d7a0c3.css">
+</head>
+<body id="cppds2" class="pretext book ignore-math">
+<a class="assistive" href="#ptx-content">Skip to main content</a><header id="ptx-masthead" class="ptx-masthead"><div class="ptx-banner">
+<a id="logo-link" class="logo-link" target="_blank" href=""></a><div class="title-container">
+<h1 class="heading"><a href="cppds.html"><span class="title">Problem Solving with Algorithms and Data Structures using C++:</span> <span class="subtitle">The PreTeXt Interactive Edition</span></a></h1>
+<p class="byline"></p>
+</div>
+</div></header><nav id="ptx-navbar" class="ptx-navbar navbar"><button class="toc-toggle button" title="Contents"><span class="icon material-symbols-outlined" aria-hidden="true">&#xe5d2;</span><span class="name">Contents</span></button><a class="index-button button" href="cppds-12-1.html" title="Index"><span class="icon material-symbols-outlined" aria-hidden="true">&#xe88e;</span><span class="name">Index</span></a><div class="searchbox">
+<div class="searchwidget"><button id="searchbutton" class="searchbutton button" type="button" title="Search book"><span class="icon material-symbols-outlined" aria-hidden="true">&#xe8b6;</span><span class="name">Search Book</span></button></div>
+<div id="searchresultsplaceholder" class="searchresultsplaceholder" style="display: none">
+<div class="search-results-controls">
+<input aria-label="Search term" id="ptxsearch" class="ptxsearch" type="text" name="terms" placeholder="Search term"><button title="Close search" id="closesearchresults" class="closesearchresults"><span class="material-symbols-outlined">close</span></button>
+</div>
+<h2 class="search-results-heading">Search Results: </h2>
+<div id="searchempty" class="searchempty"><span>No results.</span></div>
+<ol id="searchresults" class="searchresults"></ol>
+</div>
+</div>
+<span class="nav-other-controls"></span><span class="treebuttons"><a class="previous-button button" href="introduction_getting-started.html" title="Previous"><span class="icon material-symbols-outlined" aria-hidden="true">&#xe5cb;</span><span class="name">Prev</span></a><a class="up-button button" href="cppds-3.html" title="Up"><span class="icon material-symbols-outlined" aria-hidden="true">&#xe5ce;</span><span class="name">Up</span></a><a class="next-button button" href="introduction_what-is-programming.html" title="Next"><span class="name">Next</span><span class="icon material-symbols-outlined" aria-hidden="true">&#xe5cc;</span></a></span></nav><div id="latex-macros" class="hidden-content process-math" style="display:none"><span class="process-math">\(
+\newcommand{\lt}{&lt;}
+\newcommand{\gt}{&gt;}
+\newcommand{\amp}{&amp;}
+\definecolor{fillinmathshade}{gray}{0.9}
+\newcommand{\fillinmath}[1]{\mathchoice{\colorbox{fillinmathshade}{$\displaystyle     \phantom{\,#1\,}$}}{\colorbox{fillinmathshade}{$\textstyle        \phantom{\,#1\,}$}}{\colorbox{fillinmathshade}{$\scriptstyle      \phantom{\,#1\,}$}}{\colorbox{fillinmathshade}{$\scriptscriptstyle\phantom{\,#1\,}$}}}
+\)</span></div>
+<div class="ptx-page">
+<div id="ptx-sidebar" class="ptx-sidebar"><nav id="ptx-toc" class="ptx-toc depth2"><ul class="structural contains-active toc-item-list">
+<li class="toc-item toc-chapter contains-active">
+<div class="toc-title-box"><a href="cppds-3.html" class="internal"><span class="codenumber">1</span> <span class="title">Introduction</span></a></div>
+<ul class="structural toc-item-list contains-active">
+<li class="toc-item toc-section"><div class="toc-title-box"><a href="introduction_objectives.html" class="internal"><span class="codenumber">1.1</span> <span class="title">Objectives</span></a></div></li>
+<li class="toc-item toc-section"><div class="toc-title-box"><a href="introduction_getting-started.html" class="internal"><span class="codenumber">1.2</span> <span class="title">Getting Started</span></a></div></li>
+<li class="toc-item toc-section active"><div class="toc-title-box"><a href="introduction_what-is-computer-science.html" class="internal"><span class="codenumber">1.3</span> <span class="title">What Is Computer Science?</span></a></div></li>
+<li class="toc-item toc-section"><div class="toc-title-box"><a href="introduction_what-is-programming.html" class="internal"><span class="codenumber">1.4</span> <span class="title">What Is Programming?</span></a></div></li>
+<li class="toc-item toc-section"><div class="toc-title-box"><a href="introduction_why-study-data-structures-and-abstract-data-types.html" class="internal"><span class="codenumber">1.5</span> <span class="title">Why Study Data Structures and Abstract Data Types?</span></a></div></li>
+<li class="toc-item toc-section"><div class="toc-title-box"><a href="introduction_why-study-algorithms.html" class="internal"><span class="codenumber">1.6</span> <span class="title">Why Study Algorithms?</span></a></div></li>
+<li class="toc-item toc-section"><div class="toc-title-box"><a href="introduction_reviewing-basic-c.html" class="internal"><span class="codenumber">1.7</span> <span class="title">Reviewing Basic C++</span></a></div></li>
+<li class="toc-item toc-section"><div class="toc-title-box"><a href="introduction_getting-started-with-data.html" class="internal"><span class="codenumber">1.8</span> <span class="title">Getting Started with Data</span></a></div></li>
+<li class="toc-item toc-section">
+<div class="toc-title-box"><a href="introduction_collections.html" class="internal"><span class="codenumber">1.9</span> <span class="title">Collections</span></a></div>
+<ul class="structural toc-item-list">
+<li class="toc-item toc-subsection"><div class="toc-title-box"><a href="introduction_collections.html#introduction_arrays" class="internal"><span class="codenumber">1.9.1</span> <span class="title">Arrays</span></a></div></li>
+<li class="toc-item toc-subsection">
+<div class="toc-title-box"><a href="introduction_collections.html#introduction_vectors" class="internal"><span class="codenumber">1.9.2</span> <span class="title">Vectors</span></a></div>
+<ul class="structural toc-item-list"><li class="toc-item toc-subsubsection"><div class="toc-title-box"><a href="introduction_collections.html#introduction_matching" class="internal"><span class="codenumber">1.9.2.1</span> <span class="title">Matching</span></a></div></li></ul>
+</li>
+<li class="toc-item toc-subsection">
+<div class="toc-title-box"><a href="introduction_collections.html#introduction_strings" class="internal"><span class="codenumber">1.9.3</span> <span class="title">Strings</span></a></div>
+<ul class="structural toc-item-list"><li class="toc-item toc-subsubsection"><div class="toc-title-box"><a href="introduction_collections.html#introduction_id1" class="internal"><span class="codenumber">1.9.3.1</span> <span class="title">Matching</span></a></div></li></ul>
+</li>
+<li class="toc-item toc-subsection">
+<div class="toc-title-box"><a href="introduction_collections.html#introduction_hash-tables" class="internal"><span class="codenumber">1.9.4</span> <span class="title">Hash Tables</span></a></div>
+<ul class="structural toc-item-list"><li class="toc-item toc-subsubsection"><div class="toc-title-box"><a href="introduction_collections.html#introduction_id2" class="internal"><span class="codenumber">1.9.4.1</span> <span class="title">Matching</span></a></div></li></ul>
+</li>
+<li class="toc-item toc-subsection">
+<div class="toc-title-box"><a href="introduction_collections.html#introduction_unordered-sets" class="internal"><span class="codenumber">1.9.5</span> <span class="title">Unordered Sets</span></a></div>
+<ul class="structural toc-item-list"><li class="toc-item toc-subsubsection"><div class="toc-title-box"><a href="introduction_collections.html#introduction_id3" class="internal"><span class="codenumber">1.9.5.1</span> <span class="title">Matching</span></a></div></li></ul>
+</li>
+</ul>
+</li>
+<li class="toc-item toc-section">
+<div class="toc-title-box"><a href="introduction_defining-c-functions.html" class="internal"><span class="codenumber">1.10</span> <span class="title">Defining C++ Functions</span></a></div>
+<ul class="structural toc-item-list">
+<li class="toc-item toc-subsection"><div class="toc-title-box"><a href="introduction_defining-c-functions.html#introduction_parameter-passing-by-value-versus-by-reference" class="internal"><span class="codenumber">1.10.1</span> <span class="title">Parameter Passing: by Value versus by Reference</span></a></div></li>
+<li class="toc-item toc-subsection"><div class="toc-title-box"><a href="introduction_defining-c-functions.html#introduction_arrays-as-parameters-in-functions" class="internal"><span class="codenumber">1.10.2</span> <span class="title">Arrays as Parameters in Functions</span></a></div></li>
+<li class="toc-item toc-subsection"><div class="toc-title-box"><a href="introduction_defining-c-functions.html#introduction_function-overloading" class="internal"><span class="codenumber">1.10.3</span> <span class="title">Function Overloading</span></a></div></li>
+</ul>
+</li>
+<li class="toc-item toc-section">
+<div class="toc-title-box"><a href="introduction_object-oriented-programming-in-c-defining-classes.html" class="internal"><span class="codenumber">1.11</span> <span class="title">Object-Oriented Programming in C++: Defining Classes</span></a></div>
+<ul class="structural toc-item-list">
+<li class="toc-item toc-subsection"><div class="toc-title-box"><a href="introduction_object-oriented-programming-in-c-defining-classes.html#introduction_a-fraction-class" class="internal"><span class="codenumber">1.11.1</span> <span class="title">A <code class="code-inline tex2jax_ignore">Fraction</code> Class</span></a></div></li>
+<li class="toc-item toc-subsection"><div class="toc-title-box"><a href="introduction_object-oriented-programming-in-c-defining-classes.html#introduction_abstraction-and-encapsulation" class="internal"><span class="codenumber">1.11.2</span> <span class="title">Abstraction and Encapsulation</span></a></div></li>
+<li class="toc-item toc-subsection"><div class="toc-title-box"><a href="introduction_object-oriented-programming-in-c-defining-classes.html#introduction_polymorphism" class="internal"><span class="codenumber">1.11.3</span> <span class="title">Polymorphism</span></a></div></li>
+<li class="toc-item toc-subsection"><div class="toc-title-box"><a href="introduction_object-oriented-programming-in-c-defining-classes.html#introduction_self-check" class="internal"><span class="codenumber">1.11.4</span> <span class="title">Self Check</span></a></div></li>
+</ul>
+</li>
+<li class="toc-item toc-section">
+<div class="toc-title-box"><a href="introduction_inheritance-in-c.html" class="internal"><span class="codenumber">1.12</span> <span class="title">Inheritance in C++</span></a></div>
+<ul class="structural toc-item-list">
+<li class="toc-item toc-subsection"><div class="toc-title-box"><a href="introduction_inheritance-in-c.html#introduction_logic-gates-and-circuits" class="internal"><span class="codenumber">1.12.1</span> <span class="title">Logic Gates and Circuits</span></a></div></li>
+<li class="toc-item toc-subsection"><div class="toc-title-box"><a href="introduction_inheritance-in-c.html#introduction_building-circuits" class="internal"><span class="codenumber">1.12.2</span> <span class="title">Building Circuits</span></a></div></li>
+</ul>
+</li>
+<li class="toc-item toc-section">
+<div class="toc-title-box"><a href="introduction_optional-graphics-in-c.html" class="internal"><span class="codenumber">1.13</span> <span class="title"><dfn class="terminology">Optional</dfn>: Graphics in C++</span></a></div>
+<ul class="structural toc-item-list">
+<li class="toc-item toc-subsection"><div class="toc-title-box"><a href="introduction_optional-graphics-in-c.html#introduction_introduction-to-turtles" class="internal"><span class="codenumber">1.13.1</span> <span class="title">Introduction to Turtles</span></a></div></li>
+<li class="toc-item toc-subsection"><div class="toc-title-box"><a href="introduction_optional-graphics-in-c.html#introduction_turtle-turtlescreen" class="internal"><span class="codenumber">1.13.2</span> <span class="title">Turtle &amp; TurtleScreen</span></a></div></li>
+<li class="toc-item toc-subsection"><div class="toc-title-box"><a href="introduction_optional-graphics-in-c.html#introduction_geometry-shapes-and-stamps" class="internal"><span class="codenumber">1.13.3</span> <span class="title">Geometry, Shapes, and Stamps</span></a></div></li>
+<li class="toc-item toc-subsection"><div class="toc-title-box"><a href="introduction_optional-graphics-in-c.html#introduction_advanced-features" class="internal"><span class="codenumber">1.13.4</span> <span class="title">Advanced Features</span></a></div></li>
+</ul>
+</li>
+<li class="toc-item toc-section"><div class="toc-title-box"><a href="introduction_summary.html" class="internal"><span class="codenumber">1.14</span> <span class="title">Summary</span></a></div></li>
+<li class="toc-item toc-section"><div class="toc-title-box"><a href="introduction_discussion-questions.html" class="internal"><span class="codenumber">1.15</span> <span class="title">Discussion Questions</span></a></div></li>
+<li class="toc-item toc-section"><div class="toc-title-box"><a href="introduction_programming-exercises.html" class="internal"><span class="codenumber">1.16</span> <span class="title">Programming Exercises</span></a></div></li>
+<li class="toc-item toc-section">
+<div class="toc-title-box"><a href="introduction_glossary.html" class="internal"><span class="codenumber">1.17</span> <span class="title">Glossary</span></a></div>
+<ul class="structural toc-item-list"><li class="toc-item toc-glossary"><div class="toc-title-box"><a href="introduction_glossary.html#introduction_glossary-2" class="internal"><span class="codenumber">1.17</span> <span class="title">Glossary</span></a></div></li></ul>
+</li>
+</ul>
+</li>
+<li class="toc-item toc-chapter">
+<div class="toc-title-box"><a href="cppds-4.html" class="internal"><span class="codenumber">2</span> <span class="title">Analysis</span></a></div>
+<ul class="structural toc-item-list">
+<li class="toc-item toc-section"><div class="toc-title-box"><a href="algorithm-analysis_objectives.html" class="internal"><span class="codenumber">2.1</span> <span class="title">Objectives</span></a></div></li>
+<li class="toc-item toc-section">
+<div class="toc-title-box"><a href="algorithm-analysis_what-is-algorithm-analysis.html" class="internal"><span class="codenumber">2.2</span> <span class="title">What Is Algorithm Analysis?</span></a></div>
+<ul class="structural toc-item-list">
+<li class="toc-item toc-subsection"><div class="toc-title-box"><a href="algorithm-analysis_what-is-algorithm-analysis.html#algorithm-analysis_some-needed-math-notation" class="internal"><span class="codenumber">2.2.1</span> <span class="title">Some Needed Math Notation</span></a></div></li>
+<li class="toc-item toc-subsection"><div class="toc-title-box"><a href="algorithm-analysis_what-is-algorithm-analysis.html#algorithm-analysis_applying-the-math-notation" class="internal"><span class="codenumber">2.2.2</span> <span class="title">Applying the Math Notation</span></a></div></li>
+</ul>
+</li>
+<li class="toc-item toc-section"><div class="toc-title-box"><a href="algorithm-analysis_big-o-notation.html" class="internal"><span class="codenumber">2.3</span> <span class="title">Big-O Notation</span></a></div></li>
+<li class="toc-item toc-section">
+<div class="toc-title-box"><a href="algorithm-analysis_an-anagram-detection-example.html" class="internal"><span class="codenumber">2.4</span> <span class="title">An Anagram Detection Example</span></a></div>
+<ul class="structural toc-item-list">
+<li class="toc-item toc-subsection"><div class="toc-title-box"><a href="algorithm-analysis_an-anagram-detection-example.html#algorithm-analysis_solution-1-checking-off" class="internal"><span class="codenumber">2.4.1</span> <span class="title">Solution 1: Checking Off</span></a></div></li>
+<li class="toc-item toc-subsection"><div class="toc-title-box"><a href="algorithm-analysis_an-anagram-detection-example.html#algorithm-analysis_solution-2-sort-and-compare" class="internal"><span class="codenumber">2.4.2</span> <span class="title">Solution 2: Sort and Compare</span></a></div></li>
+<li class="toc-item toc-subsection"><div class="toc-title-box"><a href="algorithm-analysis_an-anagram-detection-example.html#algorithm-analysis_solution-3-brute-force" class="internal"><span class="codenumber">2.4.3</span> <span class="title">Solution 3: Brute Force</span></a></div></li>
+<li class="toc-item toc-subsection"><div class="toc-title-box"><a href="algorithm-analysis_an-anagram-detection-example.html#algorithm-analysis_solution-4-count-and-compare" class="internal"><span class="codenumber">2.4.4</span> <span class="title">Solution 4: Count and Compare</span></a></div></li>
+</ul>
+</li>
+<li class="toc-item toc-section"><div class="toc-title-box"><a href="algorithm-analysis_performance-of-c-data-collections.html" class="internal"><span class="codenumber">2.5</span> <span class="title">Performance of C++ Data Collections</span></a></div></li>
+<li class="toc-item toc-section"><div class="toc-title-box"><a href="algorithm-analysis_analysis-of-array-and-vector-operators.html" class="internal"><span class="codenumber">2.6</span> <span class="title">Analysis of Array and Vector Operators</span></a></div></li>
+<li class="toc-item toc-section"><div class="toc-title-box"><a href="algorithm-analysis_analysis-of-string-operators.html" class="internal"><span class="codenumber">2.7</span> <span class="title">Analysis of String Operators</span></a></div></li>
+<li class="toc-item toc-section"><div class="toc-title-box"><a href="algorithm-analysis_analysis-of-hash-tables.html" class="internal"><span class="codenumber">2.8</span> <span class="title">Analysis of Hash Tables</span></a></div></li>
+<li class="toc-item toc-section"><div class="toc-title-box"><a href="algorithm-analysis_discussion-questions.html" class="internal"><span class="codenumber">2.9</span> <span class="title">Discussion Questions</span></a></div></li>
+<li class="toc-item toc-section"><div class="toc-title-box"><a href="algorithm-analysis_programming-exercises.html" class="internal"><span class="codenumber">2.10</span> <span class="title">Programming Exercises</span></a></div></li>
+<li class="toc-item toc-section">
+<div class="toc-title-box"><a href="algorithm-analysis_glossary.html" class="internal"><span class="codenumber">2.11</span> <span class="title">Glossary</span></a></div>
+<ul class="structural toc-item-list"><li class="toc-item toc-glossary"><div class="toc-title-box"><a href="algorithm-analysis_glossary.html#algorithm-analysis_glossary-2" class="internal"><span class="codenumber">2.11</span> <span class="title">Glossary</span></a></div></li></ul>
+</li>
+</ul>
+</li>
+<li class="toc-item toc-chapter">
+<div class="toc-title-box"><a href="cppds-5.html" class="internal"><span class="codenumber">3</span> <span class="title">Linear Structures</span></a></div>
+<ul class="structural toc-item-list">
+<li class="toc-item toc-section"><div class="toc-title-box"><a href="linear-basic_objectives.html" class="internal"><span class="codenumber">3.1</span> <span class="title">Objectives</span></a></div></li>
+<li class="toc-item toc-section"><div class="toc-title-box"><a href="linear-basic_what-are-linear-structures.html" class="internal"><span class="codenumber">3.2</span> <span class="title">What Are Linear Structures?</span></a></div></li>
+<li class="toc-item toc-section"><div class="toc-title-box"><a href="linear-basic_what-is-a-stack.html" class="internal"><span class="codenumber">3.3</span> <span class="title">What is a Stack?</span></a></div></li>
+<li class="toc-item toc-section"><div class="toc-title-box"><a href="linear-basic_the-stack-abstract-data-type.html" class="internal"><span class="codenumber">3.4</span> <span class="title">The Stack Abstract Data Type</span></a></div></li>
+<li class="toc-item toc-section"><div class="toc-title-box"><a href="linear-basic_using-a-stack-in-c.html" class="internal"><span class="codenumber">3.5</span> <span class="title">Using a Stack in C++</span></a></div></li>
+<li class="toc-item toc-section"><div class="toc-title-box"><a href="linear-basic_simple-balanced-parentheses.html" class="internal"><span class="codenumber">3.6</span> <span class="title">Simple Balanced Parentheses</span></a></div></li>
+<li class="toc-item toc-section"><div class="toc-title-box"><a href="linear-basic_balanced-symbols-a-general-case.html" class="internal"><span class="codenumber">3.7</span> <span class="title">Balanced Symbols - A General Case</span></a></div></li>
+<li class="toc-item toc-section"><div class="toc-title-box"><a href="linear-basic_converting-decimal-numbers-to-binary-numbers.html" class="internal"><span class="codenumber">3.8</span> <span class="title">Converting Decimal Numbers to Binary Numbers</span></a></div></li>
+<li class="toc-item toc-section">
+<div class="toc-title-box"><a href="linear-basic_infix-prefix-and-postfix-expressions.html" class="internal"><span class="codenumber">3.9</span> <span class="title">Infix, Prefix and Postfix Expressions</span></a></div>
+<ul class="structural toc-item-list">
+<li class="toc-item toc-subsection"><div class="toc-title-box"><a href="linear-basic_infix-prefix-and-postfix-expressions.html#linear-basic_conversion-of-infix-expressions-to-prefix-and-postfix" class="internal"><span class="codenumber">3.9.1</span> <span class="title">Conversion of Infix Expressions to Prefix and Postfix</span></a></div></li>
+<li class="toc-item toc-subsection"><div class="toc-title-box"><a href="linear-basic_infix-prefix-and-postfix-expressions.html#linear-basic_general-infix-to-postfix-conversion" class="internal"><span class="codenumber">3.9.2</span> <span class="title">General Infix-to-Postfix Conversion</span></a></div></li>
+<li class="toc-item toc-subsection"><div class="toc-title-box"><a href="linear-basic_infix-prefix-and-postfix-expressions.html#linear-basic_postfix-evaluation" class="internal"><span class="codenumber">3.9.3</span> <span class="title">Postfix Evaluation</span></a></div></li>
+</ul>
+</li>
+<li class="toc-item toc-section"><div class="toc-title-box"><a href="linear-basic_what-is-a-queue.html" class="internal"><span class="codenumber">3.10</span> <span class="title">What Is a Queue?</span></a></div></li>
+<li class="toc-item toc-section"><div class="toc-title-box"><a href="linear-basic_the-queue-abstract-data-type.html" class="internal"><span class="codenumber">3.11</span> <span class="title">The Queue Abstract Data Type</span></a></div></li>
+<li class="toc-item toc-section"><div class="toc-title-box"><a href="linear-basic_using-a-queue-in-c.html" class="internal"><span class="codenumber">3.12</span> <span class="title">Using a Queue in C++</span></a></div></li>
+<li class="toc-item toc-section"><div class="toc-title-box"><a href="linear-basic_simulation-hot-potato.html" class="internal"><span class="codenumber">3.13</span> <span class="title">Simulation: Hot Potato</span></a></div></li>
+<li class="toc-item toc-section">
+<div class="toc-title-box"><a href="linear-basic_simulation-printing-tasks.html" class="internal"><span class="codenumber">3.14</span> <span class="title">Simulation: Printing Tasks</span></a></div>
+<ul class="structural toc-item-list">
+<li class="toc-item toc-subsection"><div class="toc-title-box"><a href="linear-basic_simulation-printing-tasks.html#linear-basic_main-simulation-steps" class="internal"><span class="codenumber">3.14.1</span> <span class="title">Main Simulation Steps</span></a></div></li>
+<li class="toc-item toc-subsection"><div class="toc-title-box"><a href="linear-basic_simulation-printing-tasks.html#linear-basic_c-implementation" class="internal"><span class="codenumber">3.14.2</span> <span class="title">C++ Implementation</span></a></div></li>
+<li class="toc-item toc-subsection"><div class="toc-title-box"><a href="linear-basic_simulation-printing-tasks.html#linear-basic_discussion" class="internal"><span class="codenumber">3.14.3</span> <span class="title">Discussion</span></a></div></li>
+</ul>
+</li>
+<li class="toc-item toc-section"><div class="toc-title-box"><a href="linear-basic_what-is-a-deque.html" class="internal"><span class="codenumber">3.15</span> <span class="title">What Is a Deque?</span></a></div></li>
+<li class="toc-item toc-section"><div class="toc-title-box"><a href="linear-basic_the-deque-abstract-data-type.html" class="internal"><span class="codenumber">3.16</span> <span class="title">The Deque Abstract Data Type</span></a></div></li>
+<li class="toc-item toc-section"><div class="toc-title-box"><a href="linear-basic_using-a-deque-in-c.html" class="internal"><span class="codenumber">3.17</span> <span class="title">Using a Deque in C++</span></a></div></li>
+<li class="toc-item toc-section"><div class="toc-title-box"><a href="linear-basic_palindrome-checker.html" class="internal"><span class="codenumber">3.18</span> <span class="title">Palindrome-Checker</span></a></div></li>
+<li class="toc-item toc-section"><div class="toc-title-box"><a href="linear-basic_summary.html" class="internal"><span class="codenumber">3.19</span> <span class="title">Summary</span></a></div></li>
+<li class="toc-item toc-section"><div class="toc-title-box"><a href="linear-basic_discussion-questions.html" class="internal"><span class="codenumber">3.20</span> <span class="title">Discussion Questions</span></a></div></li>
+<li class="toc-item toc-section"><div class="toc-title-box"><a href="linear-basic_programming-exercises.html" class="internal"><span class="codenumber">3.21</span> <span class="title">Programming Exercises</span></a></div></li>
+<li class="toc-item toc-section">
+<div class="toc-title-box"><a href="linear-basic_glossary.html" class="internal"><span class="codenumber">3.22</span> <span class="title">Glossary</span></a></div>
+<ul class="structural toc-item-list"><li class="toc-item toc-glossary"><div class="toc-title-box"><a href="linear-basic_glossary.html#linear-basic_glossary-2" class="internal"><span class="codenumber">3.22</span> <span class="title">Glossary</span></a></div></li></ul>
+</li>
+</ul>
+</li>
+<li class="toc-item toc-chapter">
+<div class="toc-title-box"><a href="cppds-6.html" class="internal"><span class="codenumber">4</span> <span class="title">Linear Linked Structures</span></a></div>
+<ul class="structural toc-item-list">
+<li class="toc-item toc-section"><div class="toc-title-box"><a href="linear-linked_objectives.html" class="internal"><span class="codenumber">4.1</span> <span class="title">Objectives</span></a></div></li>
+<li class="toc-item toc-section"><div class="toc-title-box"><a href="linear-linked_what-are-linked-structures.html" class="internal"><span class="codenumber">4.2</span> <span class="title">What Are Linked Structures?</span></a></div></li>
+<li class="toc-item toc-section"><div class="toc-title-box"><a href="linear-linked_implementing-an-unordered-linked-list.html" class="internal"><span class="codenumber">4.3</span> <span class="title">Implementing an Unordered Linked List</span></a></div></li>
+<li class="toc-item toc-section">
+<div class="toc-title-box"><a href="linear-linked_implementing-an-ordered-linked-list.html" class="internal"><span class="codenumber">4.4</span> <span class="title">Implementing an Ordered Linked List</span></a></div>
+<ul class="structural toc-item-list"><li class="toc-item toc-subsection"><div class="toc-title-box"><a href="linear-linked_implementing-an-ordered-linked-list.html#linear-linked_analysis-of-linked-lists" class="internal"><span class="codenumber">4.4.1</span> <span class="title">Analysis of Linked Lists</span></a></div></li></ul>
+</li>
+<li class="toc-item toc-section">
+<div class="toc-title-box"><a href="linear-linked_the-ordered-list-abstract-data-type.html" class="internal"><span class="codenumber">4.5</span> <span class="title">The Ordered List Abstract Data Type</span></a></div>
+<ul class="structural toc-item-list">
+<li class="toc-item toc-subsection"><div class="toc-title-box"><a href="linear-linked_the-ordered-list-abstract-data-type.html#linear-linked_forward-lists" class="internal"><span class="codenumber">4.5.1</span> <span class="title">Forward lists</span></a></div></li>
+<li class="toc-item toc-subsection"><div class="toc-title-box"><a href="linear-linked_the-ordered-list-abstract-data-type.html#linear-linked_lists" class="internal"><span class="codenumber">4.5.2</span> <span class="title">Lists</span></a></div></li>
+</ul>
+</li>
+<li class="toc-item toc-section"><div class="toc-title-box"><a href="linear-linked_summary.html" class="internal"><span class="codenumber">4.6</span> <span class="title">Summary</span></a></div></li>
+<li class="toc-item toc-section"><div class="toc-title-box"><a href="linear-linked_discussion-questions.html" class="internal"><span class="codenumber">4.7</span> <span class="title">Discussion Questions</span></a></div></li>
+<li class="toc-item toc-section"><div class="toc-title-box"><a href="linear-linked_programming-exercises.html" class="internal"><span class="codenumber">4.8</span> <span class="title">Programming Exercises</span></a></div></li>
+<li class="toc-item toc-section">
+<div class="toc-title-box"><a href="linear-linked_glossary.html" class="internal"><span class="codenumber">4.9</span> <span class="title">Glossary</span></a></div>
+<ul class="structural toc-item-list"><li class="toc-item toc-glossary"><div class="toc-title-box"><a href="linear-linked_glossary.html#linear-linked_glossary-2" class="internal"><span class="codenumber">4.9</span> <span class="title">Glossary</span></a></div></li></ul>
+</li>
+</ul>
+</li>
+<li class="toc-item toc-chapter">
+<div class="toc-title-box"><a href="cppds-7.html" class="internal"><span class="codenumber">5</span> <span class="title">Recursion</span></a></div>
+<ul class="structural toc-item-list">
+<li class="toc-item toc-section"><div class="toc-title-box"><a href="recursion_objectives.html" class="internal"><span class="codenumber">5.1</span> <span class="title">Objectives</span></a></div></li>
+<li class="toc-item toc-section"><div class="toc-title-box"><a href="recursion_what-is-recursion.html" class="internal"><span class="codenumber">5.2</span> <span class="title">What Is Recursion?</span></a></div></li>
+<li class="toc-item toc-section"><div class="toc-title-box"><a href="recursion_calculating-the-sum-of-a-vector-of-numbers.html" class="internal"><span class="codenumber">5.3</span> <span class="title">Calculating the Sum of a Vector of Numbers</span></a></div></li>
+<li class="toc-item toc-section"><div class="toc-title-box"><a href="recursion_the-three-laws-of-recursion.html" class="internal"><span class="codenumber">5.4</span> <span class="title">The Three Laws of Recursion</span></a></div></li>
+<li class="toc-item toc-section"><div class="toc-title-box"><a href="recursion_converting-an-integer-to-a-string-in-any-base.html" class="internal"><span class="codenumber">5.5</span> <span class="title">Converting an Integer to a String in Any Base</span></a></div></li>
+<li class="toc-item toc-section"><div class="toc-title-box"><a href="recursion_stack-frames-implementing-recursion.html" class="internal"><span class="codenumber">5.6</span> <span class="title">Stack Frames: Implementing Recursion</span></a></div></li>
+<li class="toc-item toc-section"><div class="toc-title-box"><a href="recursion_introduction-visualizing-recursion.html" class="internal"><span class="codenumber">5.7</span> <span class="title">Introduction: Visualizing Recursion</span></a></div></li>
+<li class="toc-item toc-section"><div class="toc-title-box"><a href="recursion_sierpinski-triangle.html" class="internal"><span class="codenumber">5.8</span> <span class="title">Sierpinski Triangle</span></a></div></li>
+<li class="toc-item toc-section"><div class="toc-title-box"><a href="recursion_complex-recursive-problems.html" class="internal"><span class="codenumber">5.9</span> <span class="title">Complex Recursive Problems</span></a></div></li>
+<li class="toc-item toc-section"><div class="toc-title-box"><a href="recursion_tower-of-hanoi.html" class="internal"><span class="codenumber">5.10</span> <span class="title">Tower of Hanoi</span></a></div></li>
+<li class="toc-item toc-section"><div class="toc-title-box"><a href="recursion_exploring-a-maze.html" class="internal"><span class="codenumber">5.11</span> <span class="title">Exploring a Maze</span></a></div></li>
+<li class="toc-item toc-section"><div class="toc-title-box"><a href="recursion_dynamic-programming.html" class="internal"><span class="codenumber">5.12</span> <span class="title">Dynamic Programming</span></a></div></li>
+<li class="toc-item toc-section"><div class="toc-title-box"><a href="recursion_discussion-questions.html" class="internal"><span class="codenumber">5.13</span> <span class="title">Discussion Questions</span></a></div></li>
+<li class="toc-item toc-section"><div class="toc-title-box"><a href="recursion_programming-exercises.html" class="internal"><span class="codenumber">5.14</span> <span class="title">Programming Exercises</span></a></div></li>
+<li class="toc-item toc-section">
+<div class="toc-title-box"><a href="recursion_glossary.html" class="internal"><span class="codenumber">5.15</span> <span class="title">Glossary</span></a></div>
+<ul class="structural toc-item-list"><li class="toc-item toc-glossary"><div class="toc-title-box"><a href="recursion_glossary.html#recursion_glossary-2" class="internal"><span class="codenumber">5.15</span> <span class="title">Glossary</span></a></div></li></ul>
+</li>
+</ul>
+</li>
+<li class="toc-item toc-chapter">
+<div class="toc-title-box"><a href="cppds-8.html" class="internal"><span class="codenumber">6</span> <span class="title">Searching and Hashing</span></a></div>
+<ul class="structural toc-item-list">
+<li class="toc-item toc-section"><div class="toc-title-box"><a href="search-hash_objectives.html" class="internal"><span class="codenumber">6.1</span> <span class="title">Objectives</span></a></div></li>
+<li class="toc-item toc-section"><div class="toc-title-box"><a href="search-hash_searching.html" class="internal"><span class="codenumber">6.2</span> <span class="title">Searching</span></a></div></li>
+<li class="toc-item toc-section">
+<div class="toc-title-box"><a href="search-hash_the-sequential-search.html" class="internal"><span class="codenumber">6.3</span> <span class="title">The Sequential Search</span></a></div>
+<ul class="structural toc-item-list"><li class="toc-item toc-subsection"><div class="toc-title-box"><a href="search-hash_the-sequential-search.html#search-hash_analysis-of-sequential-search" class="internal"><span class="codenumber">6.3.1</span> <span class="title">Analysis of Sequential Search</span></a></div></li></ul>
+</li>
+<li class="toc-item toc-section">
+<div class="toc-title-box"><a href="search-hash_the-binary-search.html" class="internal"><span class="codenumber">6.4</span> <span class="title">The Binary Search</span></a></div>
+<ul class="structural toc-item-list"><li class="toc-item toc-subsection"><div class="toc-title-box"><a href="search-hash_the-binary-search.html#search-hash_analysis-of-binary-search" class="internal"><span class="codenumber">6.4.1</span> <span class="title">Analysis of Binary Search</span></a></div></li></ul>
+</li>
+<li class="toc-item toc-section">
+<div class="toc-title-box"><a href="search-hash_hashing.html" class="internal"><span class="codenumber">6.5</span> <span class="title">Hashing</span></a></div>
+<ul class="structural toc-item-list">
+<li class="toc-item toc-subsection"><div class="toc-title-box"><a href="search-hash_hashing.html#search-hash_hash-functions" class="internal"><span class="codenumber">6.5.1</span> <span class="title">Hash Functions</span></a></div></li>
+<li class="toc-item toc-subsection"><div class="toc-title-box"><a href="search-hash_hashing.html#search-hash_collision-resolution" class="internal"><span class="codenumber">6.5.2</span> <span class="title">Collision Resolution</span></a></div></li>
+<li class="toc-item toc-subsection"><div class="toc-title-box"><a href="search-hash_hashing.html#search-hash_implementing-the-map-abstract-data-type" class="internal"><span class="codenumber">6.5.3</span> <span class="title">Implementing the <code class="code-inline tex2jax_ignore">Map</code> Abstract Data Type</span></a></div></li>
+<li class="toc-item toc-subsection"><div class="toc-title-box"><a href="search-hash_hashing.html#search-hash_analysis-of-hashing" class="internal"><span class="codenumber">6.5.4</span> <span class="title">Analysis of Hashing</span></a></div></li>
+</ul>
+</li>
+<li class="toc-item toc-section"><div class="toc-title-box"><a href="search-hash_summary.html" class="internal"><span class="codenumber">6.6</span> <span class="title">Summary</span></a></div></li>
+<li class="toc-item toc-section"><div class="toc-title-box"><a href="search-hash_discussion-questions.html" class="internal"><span class="codenumber">6.7</span> <span class="title">Discussion Questions</span></a></div></li>
+<li class="toc-item toc-section"><div class="toc-title-box"><a href="search-hash_programming-exercises.html" class="internal"><span class="codenumber">6.8</span> <span class="title">Programming Exercises</span></a></div></li>
+<li class="toc-item toc-section">
+<div class="toc-title-box"><a href="search-hash_glossary.html" class="internal"><span class="codenumber">6.9</span> <span class="title">Glossary</span></a></div>
+<ul class="structural toc-item-list"><li class="toc-item toc-glossary"><div class="toc-title-box"><a href="search-hash_glossary.html#search-hash_glossary-2" class="internal"><span class="codenumber">6.9</span> <span class="title">Glossary</span></a></div></li></ul>
+</li>
+</ul>
+</li>
+<li class="toc-item toc-chapter">
+<div class="toc-title-box"><a href="cppds-9.html" class="internal"><span class="codenumber">7</span> <span class="title">Sorting</span></a></div>
+<ul class="structural toc-item-list">
+<li class="toc-item toc-section"><div class="toc-title-box"><a href="sort_objectives.html" class="internal"><span class="codenumber">7.1</span> <span class="title">Objectives</span></a></div></li>
+<li class="toc-item toc-section"><div class="toc-title-box"><a href="sort_sorting.html" class="internal"><span class="codenumber">7.2</span> <span class="title">Sorting</span></a></div></li>
+<li class="toc-item toc-section"><div class="toc-title-box"><a href="sort_the-bubble-sort.html" class="internal"><span class="codenumber">7.3</span> <span class="title">The Bubble Sort</span></a></div></li>
+<li class="toc-item toc-section"><div class="toc-title-box"><a href="sort_the-selection-sort.html" class="internal"><span class="codenumber">7.4</span> <span class="title">The Selection Sort</span></a></div></li>
+<li class="toc-item toc-section"><div class="toc-title-box"><a href="sort_the-insertion-sort.html" class="internal"><span class="codenumber">7.5</span> <span class="title">The Insertion Sort</span></a></div></li>
+<li class="toc-item toc-section"><div class="toc-title-box"><a href="sort_the-shell-sort.html" class="internal"><span class="codenumber">7.6</span> <span class="title">The Shell Sort</span></a></div></li>
+<li class="toc-item toc-section"><div class="toc-title-box"><a href="sort_the-merge-sort.html" class="internal"><span class="codenumber">7.7</span> <span class="title">The Merge Sort</span></a></div></li>
+<li class="toc-item toc-section"><div class="toc-title-box"><a href="sort_the-quick-sort.html" class="internal"><span class="codenumber">7.8</span> <span class="title">The Quick Sort</span></a></div></li>
+<li class="toc-item toc-section"><div class="toc-title-box"><a href="sort_summary.html" class="internal"><span class="codenumber">7.9</span> <span class="title">Summary</span></a></div></li>
+<li class="toc-item toc-section"><div class="toc-title-box"><a href="sort_discussion-questions.html" class="internal"><span class="codenumber">7.10</span> <span class="title">Discussion Questions</span></a></div></li>
+<li class="toc-item toc-section"><div class="toc-title-box"><a href="sort_programming-exercises.html" class="internal"><span class="codenumber">7.11</span> <span class="title">Programming Exercises</span></a></div></li>
+<li class="toc-item toc-section">
+<div class="toc-title-box"><a href="sort_glossary.html" class="internal"><span class="codenumber">7.12</span> <span class="title">Glossary</span></a></div>
+<ul class="structural toc-item-list"><li class="toc-item toc-glossary"><div class="toc-title-box"><a href="sort_glossary.html#sort_glossary-2" class="internal"><span class="codenumber">7.12</span> <span class="title">Glossary</span></a></div></li></ul>
+</li>
+</ul>
+</li>
+<li class="toc-item toc-chapter">
+<div class="toc-title-box"><a href="cppds-10.html" class="internal"><span class="codenumber">8</span> <span class="title">Trees and Tree Algorithms</span></a></div>
+<ul class="structural toc-item-list">
+<li class="toc-item toc-section"><div class="toc-title-box"><a href="trees_objectives.html" class="internal"><span class="codenumber">8.1</span> <span class="title">Objectives</span></a></div></li>
+<li class="toc-item toc-section"><div class="toc-title-box"><a href="trees_examples-of-trees.html" class="internal"><span class="codenumber">8.2</span> <span class="title">Examples of Trees</span></a></div></li>
+<li class="toc-item toc-section"><div class="toc-title-box"><a href="trees_vocabulary-and-definitions.html" class="internal"><span class="codenumber">8.3</span> <span class="title">Vocabulary and Definitions</span></a></div></li>
+<li class="toc-item toc-section"><div class="toc-title-box"><a href="trees_nodes-and-references.html" class="internal"><span class="codenumber">8.4</span> <span class="title">Nodes and References</span></a></div></li>
+<li class="toc-item toc-section"><div class="toc-title-box"><a href="trees_parse-tree.html" class="internal"><span class="codenumber">8.5</span> <span class="title">Parse Tree</span></a></div></li>
+<li class="toc-item toc-section"><div class="toc-title-box"><a href="trees_tree-traversals.html" class="internal"><span class="codenumber">8.6</span> <span class="title">Tree Traversals</span></a></div></li>
+<li class="toc-item toc-section"><div class="toc-title-box"><a href="trees_priority-queues-with-binary-heaps.html" class="internal"><span class="codenumber">8.7</span> <span class="title">Priority Queues with Binary Heaps</span></a></div></li>
+<li class="toc-item toc-section"><div class="toc-title-box"><a href="trees_priority-queues-with-binary-heaps-example.html" class="internal"><span class="codenumber">8.8</span> <span class="title">Priority Queues with Binary Heaps Example</span></a></div></li>
+<li class="toc-item toc-section"><div class="toc-title-box"><a href="trees_binary-heap-operations.html" class="internal"><span class="codenumber">8.9</span> <span class="title">Binary Heap Operations</span></a></div></li>
+<li class="toc-item toc-section">
+<div class="toc-title-box"><a href="trees_binary-heap-implementation.html" class="internal"><span class="codenumber">8.10</span> <span class="title">Binary Heap Implementation</span></a></div>
+<ul class="structural toc-item-list">
+<li class="toc-item toc-subsection"><div class="toc-title-box"><a href="trees_binary-heap-implementation.html#trees_the-structure-property" class="internal"><span class="codenumber">8.10.1</span> <span class="title">The Structure Property</span></a></div></li>
+<li class="toc-item toc-subsection"><div class="toc-title-box"><a href="trees_binary-heap-implementation.html#trees_the-heap-order-property" class="internal"><span class="codenumber">8.10.2</span> <span class="title">The Heap Order Property</span></a></div></li>
+<li class="toc-item toc-subsection"><div class="toc-title-box"><a href="trees_binary-heap-implementation.html#trees_heap-operations" class="internal"><span class="codenumber">8.10.3</span> <span class="title">Heap Operations</span></a></div></li>
+</ul>
+</li>
+<li class="toc-item toc-section"><div class="toc-title-box"><a href="trees_binary-search-trees.html" class="internal"><span class="codenumber">8.11</span> <span class="title">Binary Search Trees</span></a></div></li>
+<li class="toc-item toc-section"><div class="toc-title-box"><a href="trees_search-tree-operations.html" class="internal"><span class="codenumber">8.12</span> <span class="title">Search Tree Operations</span></a></div></li>
+<li class="toc-item toc-section"><div class="toc-title-box"><a href="trees_search-tree-implementation.html" class="internal"><span class="codenumber">8.13</span> <span class="title">Search Tree Implementation</span></a></div></li>
+<li class="toc-item toc-section"><div class="toc-title-box"><a href="trees_search-tree-analysis.html" class="internal"><span class="codenumber">8.14</span> <span class="title">Search Tree Analysis</span></a></div></li>
+<li class="toc-item toc-section"><div class="toc-title-box"><a href="trees_balanced-binary-search-trees.html" class="internal"><span class="codenumber">8.15</span> <span class="title">Balanced Binary Search Trees</span></a></div></li>
+<li class="toc-item toc-section"><div class="toc-title-box"><a href="trees_avl-tree-performance.html" class="internal"><span class="codenumber">8.16</span> <span class="title">AVL Tree Performance</span></a></div></li>
+<li class="toc-item toc-section"><div class="toc-title-box"><a href="trees_avl-tree-implementation.html" class="internal"><span class="codenumber">8.17</span> <span class="title">AVL Tree Implementation</span></a></div></li>
+<li class="toc-item toc-section"><div class="toc-title-box"><a href="trees_summary-of-map-adt-implementations.html" class="internal"><span class="codenumber">8.18</span> <span class="title">Summary of Map ADT Implementations</span></a></div></li>
+<li class="toc-item toc-section"><div class="toc-title-box"><a href="trees_summary.html" class="internal"><span class="codenumber">8.19</span> <span class="title">Summary</span></a></div></li>
+<li class="toc-item toc-section"><div class="toc-title-box"><a href="trees_discussion-questions.html" class="internal"><span class="codenumber">8.20</span> <span class="title">Discussion Questions</span></a></div></li>
+<li class="toc-item toc-section"><div class="toc-title-box"><a href="trees_programming-exercises.html" class="internal"><span class="codenumber">8.21</span> <span class="title">Programming Exercises</span></a></div></li>
+<li class="toc-item toc-section">
+<div class="toc-title-box"><a href="trees_glossary.html" class="internal"><span class="codenumber">8.22</span> <span class="title">Glossary</span></a></div>
+<ul class="structural toc-item-list"><li class="toc-item toc-glossary"><div class="toc-title-box"><a href="trees_glossary.html#trees_glossary-2" class="internal"><span class="codenumber">8.22</span> <span class="title">Glossary</span></a></div></li></ul>
+</li>
+</ul>
+</li>
+<li class="toc-item toc-chapter">
+<div class="toc-title-box"><a href="cppds-11.html" class="internal"><span class="codenumber">9</span> <span class="title">Graphs and Graph Algorithms</span></a></div>
+<ul class="structural toc-item-list">
+<li class="toc-item toc-section"><div class="toc-title-box"><a href="graphs_objectives.html" class="internal"><span class="codenumber">9.1</span> <span class="title">Objectives</span></a></div></li>
+<li class="toc-item toc-section"><div class="toc-title-box"><a href="graphs_vocabulary-and-definitions.html" class="internal"><span class="codenumber">9.2</span> <span class="title">Vocabulary and Definitions</span></a></div></li>
+<li class="toc-item toc-section"><div class="toc-title-box"><a href="graphs_the-graph-abstract-data-type.html" class="internal"><span class="codenumber">9.3</span> <span class="title">The Graph Abstract Data Type</span></a></div></li>
+<li class="toc-item toc-section"><div class="toc-title-box"><a href="graphs_an-adjacency-matrix.html" class="internal"><span class="codenumber">9.4</span> <span class="title">An Adjacency Matrix</span></a></div></li>
+<li class="toc-item toc-section"><div class="toc-title-box"><a href="graphs_an-adjacency-list.html" class="internal"><span class="codenumber">9.5</span> <span class="title">An Adjacency List</span></a></div></li>
+<li class="toc-item toc-section"><div class="toc-title-box"><a href="graphs_implementation.html" class="internal"><span class="codenumber">9.6</span> <span class="title">Implementation</span></a></div></li>
+<li class="toc-item toc-section"><div class="toc-title-box"><a href="graphs_the-word-ladder-problem.html" class="internal"><span class="codenumber">9.7</span> <span class="title">The Word Ladder Problem</span></a></div></li>
+<li class="toc-item toc-section"><div class="toc-title-box"><a href="graphs_building-the-word-ladder-graph.html" class="internal"><span class="codenumber">9.8</span> <span class="title">Building the Word Ladder Graph</span></a></div></li>
+<li class="toc-item toc-section"><div class="toc-title-box"><a href="graphs_implementing-breadth-first-search.html" class="internal"><span class="codenumber">9.9</span> <span class="title">Implementing Breadth First Search</span></a></div></li>
+<li class="toc-item toc-section"><div class="toc-title-box"><a href="graphs_breadth-first-search-analysis.html" class="internal"><span class="codenumber">9.10</span> <span class="title">Breadth First Search Analysis</span></a></div></li>
+<li class="toc-item toc-section"><div class="toc-title-box"><a href="graphs_the-knights-tour-problem.html" class="internal"><span class="codenumber">9.11</span> <span class="title">The Knight’s Tour Problem</span></a></div></li>
+<li class="toc-item toc-section"><div class="toc-title-box"><a href="graphs_building-the-knights-tour-graph.html" class="internal"><span class="codenumber">9.12</span> <span class="title">Building the Knight’s Tour Graph</span></a></div></li>
+<li class="toc-item toc-section"><div class="toc-title-box"><a href="graphs_implementing-knights-tour.html" class="internal"><span class="codenumber">9.13</span> <span class="title">Implementing Knight’s Tour</span></a></div></li>
+<li class="toc-item toc-section"><div class="toc-title-box"><a href="graphs_knights-tour-analysis.html" class="internal"><span class="codenumber">9.14</span> <span class="title">Knight’s Tour Analysis</span></a></div></li>
+<li class="toc-item toc-section"><div class="toc-title-box"><a href="graphs_general-depth-first-search.html" class="internal"><span class="codenumber">9.15</span> <span class="title">General Depth First Search</span></a></div></li>
+<li class="toc-item toc-section"><div class="toc-title-box"><a href="graphs_depth-first-search-analysis.html" class="internal"><span class="codenumber">9.16</span> <span class="title">Depth First Search Analysis</span></a></div></li>
+<li class="toc-item toc-section"><div class="toc-title-box"><a href="graphs_topological-sorting.html" class="internal"><span class="codenumber">9.17</span> <span class="title">Topological Sorting</span></a></div></li>
+<li class="toc-item toc-section"><div class="toc-title-box"><a href="graphs_strongly-connected-components.html" class="internal"><span class="codenumber">9.18</span> <span class="title">Strongly Connected Components</span></a></div></li>
+<li class="toc-item toc-section"><div class="toc-title-box"><a href="graphs_shortest-path-problems.html" class="internal"><span class="codenumber">9.19</span> <span class="title">Shortest Path Problems</span></a></div></li>
+<li class="toc-item toc-section"><div class="toc-title-box"><a href="graphs_dijkstras-algorithm.html" class="internal"><span class="codenumber">9.20</span> <span class="title">Dijkstra’s Algorithm</span></a></div></li>
+<li class="toc-item toc-section"><div class="toc-title-box"><a href="graphs_analysis-of-dijkstras-algorithm.html" class="internal"><span class="codenumber">9.21</span> <span class="title">Analysis of Dijkstra’s Algorithm</span></a></div></li>
+<li class="toc-item toc-section"><div class="toc-title-box"><a href="graphs_prims-spanning-tree-algorithm.html" class="internal"><span class="codenumber">9.22</span> <span class="title">Prim’s Spanning Tree Algorithm</span></a></div></li>
+<li class="toc-item toc-section"><div class="toc-title-box"><a href="graphs_summary.html" class="internal"><span class="codenumber">9.23</span> <span class="title">Summary</span></a></div></li>
+<li class="toc-item toc-section"><div class="toc-title-box"><a href="graphs_discussion-questions.html" class="internal"><span class="codenumber">9.24</span> <span class="title">Discussion Questions</span></a></div></li>
+<li class="toc-item toc-section"><div class="toc-title-box"><a href="graphs_programming-exercises.html" class="internal"><span class="codenumber">9.25</span> <span class="title">Programming Exercises</span></a></div></li>
+<li class="toc-item toc-section">
+<div class="toc-title-box"><a href="graphs_glossary.html" class="internal"><span class="codenumber">9.26</span> <span class="title">Glossary</span></a></div>
+<ul class="structural toc-item-list"><li class="toc-item toc-glossary"><div class="toc-title-box"><a href="graphs_glossary.html#graphs_glossary-2" class="internal"><span class="codenumber">9.26</span> <span class="title">Glossary</span></a></div></li></ul>
+</li>
+</ul>
+</li>
+<li class="toc-item toc-backmatter">
+<div class="toc-title-box"><a href="cppds-12.html" class="internal"><span class="title">Back Matter</span></a></div>
+<ul class="structural toc-item-list"><li class="toc-item toc-index"><div class="toc-title-box"><a href="cppds-12-1.html" class="internal"><span class="title">Index</span></a></div></li></ul>
+</li>
+</ul></nav></div>
+<main class="ptx-main"><div id="ptx-content" class="ptx-content"><section class="section" id="introduction_what-is-computer-science"><h2 class="heading hide-type">
+<span class="type">Section</span><span class="space"> </span><span class="codenumber">1.3</span><span class="space"> </span><span class="title">What Is Computer Science?</span>
+</h2>
+<div class="para" id="introduction_what-is-computer-science-3">Computer science can be considered difficult to define. This is probably due to the unfortunate use of the word “computer” in the name. As you are perhaps aware, computer science is not simply the study of computers. Although computers play an important supporting role as a tool in the discipline, they are just that–tools.</div>
+<div class="para" id="introduction_what-is-computer-science-4"> Computer science is the study of problems, problem-solving, and the solutions that come out of the problem-solving process. Given a problem, a computer scientist’s goal is to develop an <dfn class="terminology">algorithm</dfn>, a step-by-step list of instructions for solving any instance of the problem that might arise. Algorithms are finite processes that if followed will solve the problem. Algorithms are solutions.</div>
+<div class="para" id="introduction_what-is-computer-science-5">Computer science can be thought of as the study of algorithms. Some problems do not have solutions at all. Other problems do have solutions, but these solutions cannot be executed in a reasonable amount of time. Although proving these statements is beyond the scope of this text, the fact that some problems cannot be solved and/or cannot be solved in the amount of time available is important for those who study computer science. We can fully define computer science, then, by including these types of problems and stating that computer science is the study of solutions to problems as well as the study of problems without fast solutions and including the study of problems without any solutions at all.</div>
+<div class="para" id="introduction_what-is-computer-science-6"> Hence, it is very common to include the word <dfn class="terminology">computable</dfn> when describing problems and solutions. We say that a problem is computable if an algorithm exists for solving it. An alternative definition for computer science, then, is to say that computer science is the study of problems that are and that are not computable, the study of the existence and the nonexistence of algorithms as well as the analysis of the relative speed of those algorithms. Here, you will note that the word “computer” did not come up at all. Solutions are and should be considered independent from the machine.</div>
+<div class="para" id="introduction_what-is-computer-science-7"> Computer science, as it pertains to the problem-solving process itself, is also the study of <dfn class="terminology">abstraction</dfn>. Abstraction allows us to view the problem and solution in such a way as to separate the so-called logical and physical perspectives. The basic idea is familiar to us in a common example.</div>
+<div class="para" id="introduction_what-is-computer-science-8">Consider the automobile that you may have driven to school or work today. As a driver, a user of the car, you have certain interactions that take place in order to utilize the car for its intended purpose. You get in, insert the key, start the car, shift, brake, accelerate, and steer in order to drive. From an abstraction point of view, we can say that you are seeing the logical perspective of the automobile. You are using the functions provided by the car designers for the purpose of transporting you from one location to another. These functions are sometimes also referred to as the <dfn class="terminology">interface</dfn>.</div>
+<div class="para" id="introduction_what-is-computer-science-9">On the other hand, the mechanic who must repair your automobile takes a very different point of view. She not only knows how to drive but must know all of the details necessary to carry out all the functions that we take for granted. She needs to understand how the engine works, how the transmission shifts gears, how temperature is controlled, and so on. This is known as the physical perspective, the details that take place “under the hood.”</div>
+<div class="para" id="introduction_what-is-computer-science-10">The same thing happens when we use computers. Most people use computers to write documents, send and receive email, surf the web, play music, store images, and play games without any knowledge of the details that take place to allow those types of applications to work. They view computers from a logical or user perspective. Computer scientists, programmers, technology support staff, and system administrators take a very different view of the computer. They must know the details of how operating systems work, how network protocols are configured, and how to code various scripts that control function. They must be able to control the low-level details that a user simply assumes.</div>
+<div class="para" id="introduction_what-is-computer-science-11">The common point for both of these examples is that the user of the abstraction, sometimes also called the client, does not need to know the details as long as the user is aware of the way the interface works. This interface is the way we as users communicate with the underlying complexities of the implementation. As another example of abstraction, consider the C++ <code class="code-inline tex2jax_ignore">cmath</code> module. Once we import the module, we can perform computations such as</div>
+<details id="introduction_what-is-computer-science-12" class="exercise exercise-like born-hidden-knowl"><summary><h3 class="heading">
+<span class="type">Checkpoint</span><span class="space"> </span><span class="codenumber">1.3.1</span><span class="period">.</span>
+</h3></summary><article class="exercise exercise-like"><pre class="program"><code class="language-cpp">//Outputs the square root of a given number.
+#include &lt;iostream&gt;
+#include &lt;cmath&gt;
+using namespace std;
+
+int main() {
+    cout &lt;&lt; sqrt(16);
+}
+</code></pre>
+<div class="ptx-runestone-container"><div class="runestone explainer ac_section "><div data-component="activecode" id="Python"><textarea data-lang="python" data-timelimit="25000" data-audio="" data-coach="true" style="visibility: hidden;" id="Python_editor" data-question_label="" data-codelens="true">#Outputs the square root of a given number.
+import math
+
+print(math.sqrt(16))
+</textarea></div></div></div></article></details><div class="para" id="introduction_what-is-computer-science-13"> This is an example of <dfn class="terminology">procedural abstraction</dfn>. We do not necessarily know how the square root is being calculated, but we know what the function is called and how to use it. If we perform the import correctly, we can assume that the library is correct and any function using it will provide us with the correct results. We know that someone implemented a solution to the square root problem and we only need to know how to use it. This is sometimes referred to as a “black box” view of a process. We simply describe the interface: the name of the function, what is needed (the parameters), and what will be returned. The details are hidden inside (see <a href="" class="xref" data-knowl="./knowl/xref/fig-procabstraction.html" title="Figure 1.3.2">Figure 1.3.2</a>).</div>
+<figure class="figure figure-like" id="fig-procabstraction"><div class="image-box" style="width: 50%; margin-left: 25%; margin-right: 25%;"><img src="external/Introduction/blackbox.png" class="contained" alt="Diagram illustrating the concept of procedural abstraction with a central box labeled ’sqrt()’ representing a function. An arrow labeled ’n’ points to the box, indicating the input, and another arrow points away from the box, labeled ’square root of n’, indicating the output."></div>
+<figcaption><span class="type">Figure</span><span class="space"> </span><span class="codenumber">1.3.2<span class="period">.</span></span><span class="space"> </span>Procedural Abstraction</figcaption></figure></section></div>
+<div class="ptx-content-footer">
+<a class="previous-button button" href="introduction_getting-started.html" title="Previous"><span class="icon material-symbols-outlined" aria-hidden="true">&#xe5cb;</span><span class="name">Prev</span></a><a class="top-button button" href="#" title="Top"><span class="icon material-symbols-outlined" aria-hidden="true">&#xe5ce;</span><span class="name">Top</span></a><a class="next-button button" href="introduction_what-is-programming.html" title="Next"><span class="name">Next</span><span class="icon material-symbols-outlined" aria-hidden="true">&#xe5cc;</span></a>
+</div></main>
+</div>
+<div id="ptx-page-footer" class="ptx-page-footer">
+<a class="pretext-link" href="https://pretextbook.org" title="PreTeXt"><div class="logo"><svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="338 3000 8772 6866"><g style="stroke-width:.025in; stroke:black; fill:none"><polyline points="472,3590 472,9732 " style="stroke:#000000;stroke-width:174; stroke-linejoin:miter; stroke-linecap:round; "></polyline><path style="stroke:#000000;stroke-width:126;stroke-linecap:butt;" d="M 4724,9448 A 4660 4660  0  0  1  8598  9259"></path><path style="stroke:#000000;stroke-width:174;stroke-linecap:butt;" d="M 4488,9685 A 4228 4228  0  0  0   472  9732"></path><path style="stroke:#000000;stroke-width:126;stroke-linecap:butt;" d="M 4724,3590 A 4241 4241  0  0  1  8598  3496"></path><path style="stroke:#000000;stroke-width:126;stroke-linecap:round;" d="M 850,3496  A 4241 4241  0  0  1  4724  3590"></path><path style="stroke:#000000;stroke-width:126;stroke-linecap:round;" d="M 850,9259  A 4507 4507  0  0  1  4724  9448"></path><polyline points="5385,4299 4062,8125" style="stroke:#000000;stroke-width:300; stroke-linejoin:miter; stroke-linecap:round;"></polyline><polyline points="8598,3496 8598,9259" style="stroke:#000000;stroke-width:126; stroke-linejoin:miter; stroke-linecap:round;"></polyline><polyline points="850,3496 850,9259" style="stroke:#000000;stroke-width:126; stroke-linejoin:miter; stroke-linecap:round;"></polyline><polyline points="4960,9685 4488,9685" style="stroke:#000000;stroke-width:174; stroke-linejoin:miter; stroke-linecap:round;"></polyline><polyline points="3070,4582 1889,6141 3070,7700" style="stroke:#000000;stroke-width:300; stroke-linejoin:miter; stroke-linecap:round;"></polyline><polyline points="6418,4582 7600,6141 6418,7700" style="stroke:#000000;stroke-width:300; stroke-linejoin:miter; stroke-linecap:round;"></polyline><polyline points="8976,3590 8976,9732" style="stroke:#000000;stroke-width:174; stroke-linejoin:miter; stroke-linecap:round;"></polyline><path style="stroke:#000000;stroke-width:174;stroke-linecap:butt;" d="M 4960,9685 A 4228 4228  0  0  1  8976  9732"></path></g></svg></div></a><a class="runestone-link" href="https://runestone.academy" title="Runestone Academy"><img class="logo" src="https://runestone.academy/runestone/static/images/RAIcon_cropped.png"></a><a class="mathjax-link" href="https://www.mathjax.org" title="MathJax"><img class="logo" src="https://www.mathjax.org/badge/badge-square-2.png"></a>
+</div>
+</body>
+</html>

--- a/pretext/LinearBasic/ConvertingDecimalNumberstoBinaryNumbers.ptx
+++ b/pretext/LinearBasic/ConvertingDecimalNumberstoBinaryNumbers.ptx
@@ -31,7 +31,13 @@
             reversal property that signals that a stack is likely to be the
             appropriate data structure for solving the problem.</p>
         
-        <figure align="center" xml:id="fig-decbin"><caption xmlns:c="https://www.sphinx-doc.org/" xmlns:changeset="https://www.sphinx-doc.org/" xmlns:citation="https://www.sphinx-doc.org/" xmlns:cpp="https://www.sphinx-doc.org/" xmlns:index="https://www.sphinx-doc.org/" xmlns:js="https://www.sphinx-doc.org/" xmlns:math="https://www.sphinx-doc.org/" xmlns:py="https://www.sphinx-doc.org/" xmlns:rst="https://www.sphinx-doc.org/" xmlns:std="https://www.sphinx-doc.org/">Figure 5: Decimal-to-Binary Conversion</caption><image source="LinearBasic/Figures/dectobin.png" width="50%"/></figure>
+        <figure align="center" xml:id="fig-decbin">
+            <caption>Decimal-to-Binary Conversion</caption>
+                <image source="LinearBasic/dectobin.png" width="50%">
+                    <description>Figure 5 shows us the reversal property that signals that a stack is likely to be the appropriate data structure for solving the problem.</description>
+                </image>
+        </figure>
+
         <p>The code in <xref ref="lst-binconverter"/>
             implements the Divide by 2
             algorithm. The function <c>divideBy2</c> takes an argument that is a

--- a/pretext/LinearBasic/ConvertingDecimalNumberstoBinaryNumbers.ptx
+++ b/pretext/LinearBasic/ConvertingDecimalNumberstoBinaryNumbers.ptx
@@ -34,7 +34,9 @@
         <figure align="center" xml:id="fig-decbin">
             <caption>Decimal-to-Binary Conversion</caption>
                 <image source="LinearBasic/dectobin.png" width="50%">
-                    <description>Figure 5 shows us the reversal property that signals that a stack is likely to be the appropriate data structure for solving the problem.</description>
+                    <description> 
+                        The image shows a diagram illustrating the process of converting a fraction to a decimal. It features a visual representation that resembles a ladder with numbers arranged in a stepwise fashion. The diagram guides the viewer through a series of calculations involving repeated division and remainder operations.
+                    </description>
                 </image>
         </figure>
 

--- a/pretext/LinearBasic/InfixPrefixandPostfixExpressions.ptx
+++ b/pretext/LinearBasic/InfixPrefixandPostfixExpressions.ptx
@@ -272,14 +272,26 @@
                 operator were also moved to its corresponding right parenthesis position
                 and the matching left parenthesis were removed, the complete postfix
                 expression would result (see <xref ref="fig-moveright"/>).</p>
-            
-            <figure align="center" xml:id="id4"><caption xmlns:c="https://www.sphinx-doc.org/" xmlns:changeset="https://www.sphinx-doc.org/" xmlns:citation="https://www.sphinx-doc.org/" xmlns:cpp="https://www.sphinx-doc.org/" xmlns:index="https://www.sphinx-doc.org/" xmlns:js="https://www.sphinx-doc.org/" xmlns:math="https://www.sphinx-doc.org/" xmlns:py="https://www.sphinx-doc.org/" xmlns:rst="https://www.sphinx-doc.org/" xmlns:std="https://www.sphinx-doc.org/">Figure 6: Moving Operators to the Right for Postfix Notation</caption><image source="LinearBasic/Figures/moveright.png" width="50%"/></figure>
+
+            <figure align="center" xml:id="id4">
+                <caption>Moving Operators to the Right for Postfix Notation</caption>
+                    <image source="LinearBasic/moveright.png" width="50%">
+                        <description>Figure 6 shows us the process of moving operators to the right for postfix notation.</description>
+                    </image>
+            </figure>
+
             <p>If we do the same thing but instead of moving the symbol to the position
                 of the right parenthesis, we move it to the left, we get prefix notation
                 (see <xref ref="fig-moveleft"/>). The position of the parenthesis pair is
                 actually a clue to the final position of the enclosed operator.</p>
             
-            <figure align="center" xml:id="id5"><caption xmlns:c="https://www.sphinx-doc.org/" xmlns:changeset="https://www.sphinx-doc.org/" xmlns:citation="https://www.sphinx-doc.org/" xmlns:cpp="https://www.sphinx-doc.org/" xmlns:index="https://www.sphinx-doc.org/" xmlns:js="https://www.sphinx-doc.org/" xmlns:math="https://www.sphinx-doc.org/" xmlns:py="https://www.sphinx-doc.org/" xmlns:rst="https://www.sphinx-doc.org/" xmlns:std="https://www.sphinx-doc.org/">Figure 7: Moving Operators to the Left for Prefix Notation</caption><image source="LinearBasic/Figures/moveleft.png" width="50%"/></figure>
+            <figure align="center" xml:id="id5">
+                <caption>Moving Operators to the Left for Prefix Notation</caption>
+                    <image source="LinearBasic/moveleft.png" width="50%">
+                        <description>Figure 7 shows us the process of moving operators to the left for prefix notation.</description>
+                    </image>
+            </figure>
+
             <p>So in order to convert an expression, no matter how complex, to either
                 prefix or postfix notation, fully parenthesize the expression using the
                 order of operations. Then move the enclosed operator to the position of
@@ -289,7 +301,13 @@
                 <xref ref="fig-complexmove"/> shows the conversion to postfix and prefix
                 notations.</p>
             
-            <figure align="center" xml:id="id6"><caption xmlns:c="https://www.sphinx-doc.org/" xmlns:changeset="https://www.sphinx-doc.org/" xmlns:citation="https://www.sphinx-doc.org/" xmlns:cpp="https://www.sphinx-doc.org/" xmlns:index="https://www.sphinx-doc.org/" xmlns:js="https://www.sphinx-doc.org/" xmlns:math="https://www.sphinx-doc.org/" xmlns:py="https://www.sphinx-doc.org/" xmlns:rst="https://www.sphinx-doc.org/" xmlns:std="https://www.sphinx-doc.org/">Figure 8: Converting a Complex Expression to Prefix and Postfix Notations</caption><image source="LinearBasic/Figures/complexmove.png" width="50%"/></figure>
+            <figure align="center" xml:id="id6">
+                <caption>Converting a Complex Expression to Prefix and Postfix Notations</caption>
+                    <image source="LinearBasic/complexmove.png" width="50%">
+                        <description>Figure 8 shows us the process of converting a complex expression like (A + B) * C - (D - E) * (F + G) to prefix and postfix notation.</description>
+                    </image>
+            </figure>
+
 <exercise label="question1_100_4" indent="show" language="python"><statement>
             <p>What does the prefix expression of this infix expression look like: ((A+B)*(C-D)) if this were modeled using a stack with the top being the end of the expression and the bottom being the beginning of the expression?</p>
 </statement>
@@ -400,8 +418,14 @@
                 * occurs, since multiplication has precedence over addition. At the end
                 of the infix expression the stack is popped twice, removing both
                 operators and placing + as the last operator in the postfix expression.</p>
+                        
+            <figure align="center" xml:id="id7">
+                <caption>Converting A * B + C * D to Postfix Notation</caption>
+                    <image source="LinearBasic/intopost.png" width="50%">
+                        <description>Figure 9 shows us the process of converting A * B + C * D to Postfix Notation.</description>
+                    </image>
+            </figure>
             
-            <figure align="center" xml:id="id7"><caption xmlns:c="https://www.sphinx-doc.org/" xmlns:changeset="https://www.sphinx-doc.org/" xmlns:citation="https://www.sphinx-doc.org/" xmlns:cpp="https://www.sphinx-doc.org/" xmlns:index="https://www.sphinx-doc.org/" xmlns:js="https://www.sphinx-doc.org/" xmlns:math="https://www.sphinx-doc.org/" xmlns:py="https://www.sphinx-doc.org/" xmlns:rst="https://www.sphinx-doc.org/" xmlns:std="https://www.sphinx-doc.org/">Figure 9: Converting A * B + C * D to Postfix Notation</caption><image source="LinearBasic/Figures/intopost.png" width="50%"/></figure>
             <p>In order to code the algorithm in C++, we will use a hash map
                 called <c>prec</c> to hold the precedence values for the operators
                 which will be implemented with an unordered map.
@@ -574,8 +598,14 @@ main()
                 on the stack. Pop and return it as the result of the expression.
                 <xref ref="fig-evalpost1"/> shows the stack contents as this entire example
                 expression is being processed.</p>
+                        
+            <figure align="center" xml:id="id8">
+                <caption>Stack Contents During Evaluation</caption>
+                    <image source="LinearBasic/evalpostfix1.png" width="50%">
+                        <description>Figure 10 shows the stack contents as this entire example expression is being processed.</description>
+                    </image>
+            </figure>
             
-            <figure align="center" xml:id="id8"><caption xmlns:c="https://www.sphinx-doc.org/" xmlns:changeset="https://www.sphinx-doc.org/" xmlns:citation="https://www.sphinx-doc.org/" xmlns:cpp="https://www.sphinx-doc.org/" xmlns:index="https://www.sphinx-doc.org/" xmlns:js="https://www.sphinx-doc.org/" xmlns:math="https://www.sphinx-doc.org/" xmlns:py="https://www.sphinx-doc.org/" xmlns:rst="https://www.sphinx-doc.org/" xmlns:std="https://www.sphinx-doc.org/">Figure 10: Stack Contents During Evaluation</caption><image source="LinearBasic/Figures/evalpostfix1.png" width="50%"/></figure>
             <p><xref ref="fig-evalpost2"/> shows a slightly more complex example, 7 8 + 3 2
                 + /. There are two things to note in this example. First, the stack size
                 grows, shrinks, and then grows again as the subexpressions are
@@ -587,7 +617,13 @@ main()
                 <math>15/5</math> is not the same as <math>5/15</math>, we must be sure that
                 the order of the operands is not switched.</p>
             
-            <figure align="center" xml:id="id9"><caption xmlns:c="https://www.sphinx-doc.org/" xmlns:changeset="https://www.sphinx-doc.org/" xmlns:citation="https://www.sphinx-doc.org/" xmlns:cpp="https://www.sphinx-doc.org/" xmlns:index="https://www.sphinx-doc.org/" xmlns:js="https://www.sphinx-doc.org/" xmlns:math="https://www.sphinx-doc.org/" xmlns:py="https://www.sphinx-doc.org/" xmlns:rst="https://www.sphinx-doc.org/" xmlns:std="https://www.sphinx-doc.org/">Figure 11: A More Complex Example of Evaluation</caption><image source="LinearBasic/Figures/evalpostfix2.png" width="50%"/></figure>
+            <figure align="center" xml:id="id9">
+                <caption>A More Complex Example of Evaluation</caption>
+                    <image source="LinearBasic/evalpostfix2.png" width="50%">
+                        <description>Figure 11 shows a slightly more complex example, 7 8 + 3 2 + /. There are two things to note in this example. First, the stack size grows, shrinks, and then grows again as the subexpressions are evaluated. Second, the division operation needs to be handled carefully. </description>
+                    </image>
+            </figure>
+
             <p>Assume the postfix expression is a string of tokens delimited by spaces.
                 The operators are *, /, +, and - and the operands are assumed to be
                 single-digit integer values. The output will be an integer result.</p>

--- a/pretext/LinearBasic/InfixPrefixandPostfixExpressions.ptx
+++ b/pretext/LinearBasic/InfixPrefixandPostfixExpressions.ptx
@@ -273,10 +273,12 @@
                 and the matching left parenthesis were removed, the complete postfix
                 expression would result (see <xref ref="fig-moveright"/>).</p>
 
-            <figure align="center" xml:id="id4">
+            <figure align="center" xml:id="fig-moveright">
                 <caption>Moving Operators to the Right for Postfix Notation</caption>
                     <image source="LinearBasic/moveright.png" width="50%">
-                        <description>Figure 6 shows us the process of moving operators to the right for postfix notation.</description>
+                        <description>
+                            The image depicts a step in parsing the equation (A+ (B C)). It features a circle with arrows pointing up and down, representing the order of operations. The upward arrow highlights the most recent operation to be performed, which is the addition of A and the result of (B C).
+                        </description>
                     </image>
             </figure>
 
@@ -285,10 +287,12 @@
                 (see <xref ref="fig-moveleft"/>). The position of the parenthesis pair is
                 actually a clue to the final position of the enclosed operator.</p>
             
-            <figure align="center" xml:id="id5">
+            <figure align="center" xml:id="fig-moveleft">
                 <caption>Moving Operators to the Left for Prefix Notation</caption>
                     <image source="LinearBasic/moveleft.png" width="50%">
-                        <description>Figure 7 shows us the process of moving operators to the left for prefix notation.</description>
+                        <description>
+                            The image shows three arrows, each pointing in a different direction. The arrows are arranged in a triangular pattern on a white background.
+                        </description>
                     </image>
             </figure>
 
@@ -301,10 +305,12 @@
                 <xref ref="fig-complexmove"/> shows the conversion to postfix and prefix
                 notations.</p>
             
-            <figure align="center" xml:id="id6">
+            <figure align="center" xml:id="fig-complexmove">
                 <caption>Converting a Complex Expression to Prefix and Postfix Notations</caption>
                     <image source="LinearBasic/complexmove.png" width="50%">
-                        <description>Figure 8 shows us the process of converting a complex expression like (A + B) * C - (D - E) * (F + G) to prefix and postfix notation.</description>
+                        <description>
+                            The image depicts a black and white diagram of a chemical reaction. It includes various symbols and notations that represent the reactants, products, and the process of the reaction. 
+                        </description>
                     </image>
             </figure>
 
@@ -419,10 +425,12 @@
                 of the infix expression the stack is popped twice, removing both
                 operators and placing + as the last operator in the postfix expression.</p>
                         
-            <figure align="center" xml:id="id7">
+            <figure align="center" xml:id="fig-intopost">
                 <caption>Converting A * B + C * D to Postfix Notation</caption>
                     <image source="LinearBasic/intopost.png" width="50%">
-                        <description>Figure 9 shows us the process of converting A * B + C * D to Postfix Notation.</description>
+                        <description>
+                            The image visually demonstrates the steps involved in converting the infix expression A * B + C * D to its equivalent postfix notation. It outlines a multi-step process that involves using a stack to manage operators and operands.
+                        </description>
                     </image>
             </figure>
             
@@ -599,10 +607,12 @@ main()
                 <xref ref="fig-evalpost1"/> shows the stack contents as this entire example
                 expression is being processed.</p>
                         
-            <figure align="center" xml:id="id8">
+            <figure align="center" xml:id="fig-evalpost1">
                 <caption>Stack Contents During Evaluation</caption>
                     <image source="LinearBasic/evalpostfix1.png" width="50%">
-                        <description>Figure 10 shows the stack contents as this entire example expression is being processed.</description>
+                        <description>
+                            The image depicts a diagram illustrating the left-to-right evaluation of a postfix expression. It visually demonstrates the step-by-step process of how values are pushed onto a stack, popped off, and combined using arithmetic operations.
+                        </description>
                     </image>
             </figure>
             
@@ -617,10 +627,12 @@ main()
                 <math>15/5</math> is not the same as <math>5/15</math>, we must be sure that
                 the order of the operands is not switched.</p>
             
-            <figure align="center" xml:id="id9">
+            <figure align="center" xml:id="fig-evalpost2">
                 <caption>A More Complex Example of Evaluation</caption>
                     <image source="LinearBasic/evalpostfix2.png" width="50%">
-                        <description>Figure 11 shows a slightly more complex example, 7 8 + 3 2 + /. There are two things to note in this example. First, the stack size grows, shrinks, and then grows again as the subexpressions are evaluated. Second, the division operation needs to be handled carefully. </description>
+                        <description>
+                            This image depicts a more complex example of evaluation, likely involving numerical calculations or decision-making steps. The numbers arranged in a grid-like pattern and the arrows pointing towards them suggest a structured evaluation process where values are being compared, assessed, or manipulated in a specific sequence.
+                        </description>
                     </image>
             </figure>
 

--- a/pretext/LinearBasic/PalindromeChecker.ptx
+++ b/pretext/LinearBasic/PalindromeChecker.ptx
@@ -15,8 +15,10 @@
                 
         <figure align="center" xml:id="fig-palindrome">
             <caption>A Deque</caption>
-                <image source="LinearBasic/basicdeque.png" width="50%">
-                    <description>Figure 3.18.1 shows a deque implementation of the Palindrome problem.</description>
+                <image source="LinearBasic/palindromesetup.png" width="50%">
+                    <description>
+                        A diagram showing a deque representation of Python data objects. The deque contains the items 'dog', '4', 'cat', and 'True', arranged in a horizontal row. Arrows point to both ends of the deque, labeled 'add to rear', 'rear', 'front', and 'add to front'. Below the deque are labels for 'remove from rear' and 'remove from front'.                    
+                    </description>
                 </image>
         </figure>
         

--- a/pretext/LinearBasic/PalindromeChecker.ptx
+++ b/pretext/LinearBasic/PalindromeChecker.ptx
@@ -12,8 +12,14 @@
             the dual functionality of the deque. The front of the deque will hold
             the first character of the string and the rear of the deque will hold
             the last character (see <xref ref="fig-palindrome"/>).</p>
+                
+        <figure align="center" xml:id="fig-palindrome">
+            <caption>A Deque</caption>
+                <image source="LinearBasic/basicdeque.png" width="50%">
+                    <description>Figure 3.18.1 shows a deque implementation of the Palindrome problem.</description>
+                </image>
+        </figure>
         
-        <figure align="center" xml:id="fig-palindrome"><caption xmlns:c="https://www.sphinx-doc.org/" xmlns:changeset="https://www.sphinx-doc.org/" xmlns:citation="https://www.sphinx-doc.org/" xmlns:cpp="https://www.sphinx-doc.org/" xmlns:index="https://www.sphinx-doc.org/" xmlns:js="https://www.sphinx-doc.org/" xmlns:math="https://www.sphinx-doc.org/" xmlns:py="https://www.sphinx-doc.org/" xmlns:rst="https://www.sphinx-doc.org/" xmlns:std="https://www.sphinx-doc.org/">Figure 2: A Deque</caption><image source="LinearBasic/Figures/palindromesetup.png" width="50%"/></figure>
         <p>Since we can remove both of them directly, we can compare them and
             continue only if they match. If we can keep matching first and the last
             items, we will eventually either run out of characters or be left with a

--- a/pretext/LinearBasic/SimpleBalancedParentheses.ptx
+++ b/pretext/LinearBasic/SimpleBalancedParentheses.ptx
@@ -42,7 +42,13 @@
             from the inside out. This is a clue that stacks can be used to solve the
             problem.</p>
         
-        <figure align="center" xml:id="fig-parmatch"><caption xmlns:c="https://www.sphinx-doc.org/" xmlns:changeset="https://www.sphinx-doc.org/" xmlns:citation="https://www.sphinx-doc.org/" xmlns:cpp="https://www.sphinx-doc.org/" xmlns:index="https://www.sphinx-doc.org/" xmlns:js="https://www.sphinx-doc.org/" xmlns:math="https://www.sphinx-doc.org/" xmlns:py="https://www.sphinx-doc.org/" xmlns:rst="https://www.sphinx-doc.org/" xmlns:std="https://www.sphinx-doc.org/">Figure 4: Matching Parentheses</caption><image source="LinearBasic/Figures/simpleparcheck.png" width="50%"/></figure>
+        <figure align="center" xml:id="fig-parmatch">
+            <caption>Matching Parentheses</caption>
+                <image source="LinearBasic/simpleparcheck.png" width="50%">
+                    <description>Figure 4 shows us that as you process symbols from left to right, the most recent opening parenthesis must match the next closing symbol.</description>
+                </image>
+        </figure>
+
         <p>Once you agree that a stack is the appropriate data structure for
             keeping the parentheses, the statement of the algorithm is
             straightforward. Starting with an empty stack, process the parenthesis

--- a/pretext/LinearBasic/SimpleBalancedParentheses.ptx
+++ b/pretext/LinearBasic/SimpleBalancedParentheses.ptx
@@ -45,7 +45,9 @@
         <figure align="center" xml:id="fig-parmatch">
             <caption>Matching Parentheses</caption>
                 <image source="LinearBasic/simpleparcheck.png" width="50%">
-                    <description>Figure 4 shows us that as you process symbols from left to right, the most recent opening parenthesis must match the next closing symbol.</description>
+                    <description>
+                        The image demonstrates the concept of matching parentheses in a string. It highlights that the most recent opening parenthesis is matched with the first closing parenthesis. Additionally, it shows that the first opening parenthesis may need to wait until the very last closing parenthesis to find its match.
+                    </description>
                 </image>
         </figure>
 

--- a/pretext/LinearBasic/SimulationHotPotato.ptx
+++ b/pretext/LinearBasic/SimulationHotPotato.ptx
@@ -12,7 +12,9 @@
         <figure align="center" xml:id="fig-quhotpotato">
             <caption>A Six Person Game of Hot Potato</caption>
                 <image source="LinearBasic/hotpotato.png" width="50%">
-                    <description>Figure 3.13.1 shows a six persons game of hot potato.</description>
+                    <description>
+                        The image depicts a diagram of a popular game called "Hot Potato" played by six people. It visually represents the game's mechanics using a queue data structure to simulate the passing and elimination process.
+                    </description>
                 </image>
         </figure>
         
@@ -46,7 +48,9 @@
         <figure align="center" xml:id="fig-qupotatoqueue">
             <caption>A Queue Implementation of Hot Potato</caption>
                 <image source="LinearBasic/namequeue.png" width="50%">
-                    <description>Figure 3.13.2 shows us how to Queue implement a game of hot potato.</description>
+                    <description>
+                        Diagram of a six-person game of Hot Potato using a squeue data structure. The diagram shows two states of the squeue: before and after passing the potato. In the first state, the front of the squeue is Bill, followed by Brad, Kent, Jane, Susan, and David at the rear. In the second state, after passing the potato, the front is David, followed by Susan, Jane, Kent, Brad, and Bill at the rear. Arrows indicate the actions of enqueueing (going to the rear) and dequeueing (passing the potato).                    
+                    </description>
                 </image>
         </figure>
         

--- a/pretext/LinearBasic/SimulationHotPotato.ptx
+++ b/pretext/LinearBasic/SimulationHotPotato.ptx
@@ -8,8 +8,14 @@
             point in the game, the action is stopped and the child who has the item
             (the potato) is removed from the circle. Play continues until only one
             child is left.</p>
+                
+        <figure align="center" xml:id="fig-quhotpotato">
+            <caption>A Six Person Game of Hot Potato</caption>
+                <image source="LinearBasic/hotpotato.png" width="50%">
+                    <description>Figure 3.13.1 shows a six persons game of hot potato.</description>
+                </image>
+        </figure>
         
-        <figure align="center" xml:id="fig-quhotpotato"><caption xmlns:c="https://www.sphinx-doc.org/" xmlns:changeset="https://www.sphinx-doc.org/" xmlns:citation="https://www.sphinx-doc.org/" xmlns:cpp="https://www.sphinx-doc.org/" xmlns:index="https://www.sphinx-doc.org/" xmlns:js="https://www.sphinx-doc.org/" xmlns:math="https://www.sphinx-doc.org/" xmlns:py="https://www.sphinx-doc.org/" xmlns:rst="https://www.sphinx-doc.org/" xmlns:std="https://www.sphinx-doc.org/">Figure 2: A Six Person Game of Hot Potato</caption><image source="LinearBasic/Figures/hotpotato.png" width="50%"/></figure>
         <p>This game is a modern-day equivalent of the famous Josephus problem.
             Based on a legend about the famous first-century historian Flavius
             Josephus, the story is told that in the Jewish revolt against Rome,
@@ -36,8 +42,14 @@
             dequeue/enqueue operations, the child at the front will be removed
             permanently and another cycle will begin. This process will continue
             until only one name remains (the size of the queue is 1).</p>
+                
+        <figure align="center" xml:id="fig-qupotatoqueue">
+            <caption>A Queue Implementation of Hot Potato</caption>
+                <image source="LinearBasic/namequeue.png" width="50%">
+                    <description>Figure 3.13.2 shows us how to Queue implement a game of hot potato.</description>
+                </image>
+        </figure>
         
-        <figure align="center" xml:id="fig-qupotatoqueue"><caption xmlns:c="https://www.sphinx-doc.org/" xmlns:changeset="https://www.sphinx-doc.org/" xmlns:citation="https://www.sphinx-doc.org/" xmlns:cpp="https://www.sphinx-doc.org/" xmlns:index="https://www.sphinx-doc.org/" xmlns:js="https://www.sphinx-doc.org/" xmlns:math="https://www.sphinx-doc.org/" xmlns:py="https://www.sphinx-doc.org/" xmlns:rst="https://www.sphinx-doc.org/" xmlns:std="https://www.sphinx-doc.org/">Figure 3: A Queue Implementation of Hot Potato</caption><image source="LinearBasic/Figures/namequeue.png" width="50%"/></figure>
         <p>The program is shown in <xref ref="lst-josephussim"/>. A call to the
             <c>hotPotato</c> function using 7 as the counting constant returns <c>Susan</c>.</p>
         

--- a/pretext/LinearBasic/SimulationPrintingTasks.ptx
+++ b/pretext/LinearBasic/SimulationPrintingTasks.ptx
@@ -29,7 +29,9 @@
         <figure align="center" xml:id="fig-qulabsim">
             <caption>A Computer Science Laboratory Printing Queue</caption>
                 <image source="LinearBasic/simulationsetup.png" width="50%">
-                    <description>Figure 3.14.1 shows us a queue simulation of a Computer Science laboratory.</description>
+                    <description>
+                        A diagram of a printing task in a print queue. The diagram shows a row of computers connected to a printer by a cable. A queue of print tasks is shown above the printer, with the task at the front of the queue currently being printed. The text above the queue reads "Lab Computers" and the text below the queue reads "printing tasks in print queue                    
+                    </description>
                 </image>
         </figure>
         

--- a/pretext/LinearBasic/SimulationPrintingTasks.ptx
+++ b/pretext/LinearBasic/SimulationPrintingTasks.ptx
@@ -25,8 +25,14 @@
             for us is the average amount of time students will wait for their papers
             to be printed. This is equal to the average amount of time a task waits
             in the queue.</p>
+                
+        <figure align="center" xml:id="fig-qulabsim">
+            <caption>A Computer Science Laboratory Printing Queue</caption>
+                <image source="LinearBasic/simulationsetup.png" width="50%">
+                    <description>Figure 3.14.1 shows us a queue simulation of a Computer Science laboratory.</description>
+                </image>
+        </figure>
         
-        <figure align="center" xml:id="fig-qulabsim"><caption xmlns:c="https://www.sphinx-doc.org/" xmlns:changeset="https://www.sphinx-doc.org/" xmlns:citation="https://www.sphinx-doc.org/" xmlns:cpp="https://www.sphinx-doc.org/" xmlns:index="https://www.sphinx-doc.org/" xmlns:js="https://www.sphinx-doc.org/" xmlns:math="https://www.sphinx-doc.org/" xmlns:py="https://www.sphinx-doc.org/" xmlns:rst="https://www.sphinx-doc.org/" xmlns:std="https://www.sphinx-doc.org/">Figure 4: Computer Science Laboratory Printing Queue</caption><image source="LinearBasic/Figures/simulationsetup.png" width="50%"/></figure>
         <p>To model this situation we need to use some probabilities. For example,
             students may print a paper from 1 to 20 pages in length. If each length
             from 1 to 20 is equally likely, the actual length for a print task can

--- a/pretext/LinearBasic/WhatIsaDeque.ptx
+++ b/pretext/LinearBasic/WhatIsaDeque.ptx
@@ -17,7 +17,9 @@
         <figure align="center" xml:id="fig-basicdeque">
             <caption>A Deque of Python Data Objects</caption>
                 <image source="LinearBasic/basicdeque.png" width="50%">
-                    <description>Figure 3.15.1 shows a deque representation of Python data objects.</description>
+                    <description>
+                        A diagram showing a deque representation of Python data objects. The deque contains the items 'dog', '4', 'cat', and 'True', arranged in a horizontal row. Arrows point to both ends of the deque, labeled 'add to rear', 'rear', 'front', and 'add to front'. Below the deque are labels for 'remove from rear' and 'remove from front'.                    
+                    </description>
                 </image>
         </figure>
 

--- a/pretext/LinearBasic/WhatIsaDeque.ptx
+++ b/pretext/LinearBasic/WhatIsaDeque.ptx
@@ -14,6 +14,12 @@
             and FIFO orderings that are enforced by those data structures. It is up
             to you to make consistent use of the addition and removal operations.</p>
         
-        <figure align="center" xml:id="fig-basicdeque"><caption xmlns:c="https://www.sphinx-doc.org/" xmlns:changeset="https://www.sphinx-doc.org/" xmlns:citation="https://www.sphinx-doc.org/" xmlns:cpp="https://www.sphinx-doc.org/" xmlns:index="https://www.sphinx-doc.org/" xmlns:js="https://www.sphinx-doc.org/" xmlns:math="https://www.sphinx-doc.org/" xmlns:py="https://www.sphinx-doc.org/" xmlns:rst="https://www.sphinx-doc.org/" xmlns:std="https://www.sphinx-doc.org/">Figure 1: A Deque of Python Data Objects</caption><image source="LinearBasic/Figures/basicdeque.png" width="50%"/></figure>
+        <figure align="center" xml:id="fig-basicdeque">
+            <caption>A Deque of Python Data Objects</caption>
+                <image source="LinearBasic/basicdeque.png" width="50%">
+                    <description>Figure 3.15.1 shows a deque representation of Python data objects.</description>
+                </image>
+        </figure>
+
     </section>
 

--- a/pretext/LinearBasic/WhatIsaQueue.ptx
+++ b/pretext/LinearBasic/WhatIsaQueue.ptx
@@ -24,7 +24,9 @@
         <figure align="center" xml:id="fig-qubasicqueue1">
             <caption>A queue of strings</caption>
                 <image source="LinearBasic/basicqueue1.png" width="50%">
-                    <description>Figure 3.10.1 shows a simple queue of Python data objects.</description>
+                    <description>
+                        The image depicts a queue, a data structure that operates on the "first-in, first-out" (FIFO) principle. In this visual representation, elements are added to the rear of the queue and removed from the front. The image specifically shows a queue containing the strings "true", "dog", "8.4", and "4", arranged in the order they would be processed.
+                    </description>
                 </image>
         </figure>
         

--- a/pretext/LinearBasic/WhatIsaQueue.ptx
+++ b/pretext/LinearBasic/WhatIsaQueue.ptx
@@ -20,8 +20,14 @@
             out. There is no jumping in the middle and no leaving before you have
             waited the necessary amount of time to get to the front.
             <xref ref="fig-qubasicqueue1"/> shows a simple queue of Python data objects.</p>
+                
+        <figure align="center" xml:id="fig-qubasicqueue1">
+            <caption>A queue of strings</caption>
+                <image source="LinearBasic/basicqueue1.png" width="50%">
+                    <description>Figure 3.10.1 shows a simple queue of Python data objects.</description>
+                </image>
+        </figure>
         
-        <figure align="center" xml:id="fig-qubasicqueue1"><caption xmlns:c="https://www.sphinx-doc.org/" xmlns:changeset="https://www.sphinx-doc.org/" xmlns:citation="https://www.sphinx-doc.org/" xmlns:cpp="https://www.sphinx-doc.org/" xmlns:index="https://www.sphinx-doc.org/" xmlns:js="https://www.sphinx-doc.org/" xmlns:math="https://www.sphinx-doc.org/" xmlns:py="https://www.sphinx-doc.org/" xmlns:rst="https://www.sphinx-doc.org/" xmlns:std="https://www.sphinx-doc.org/">Figure 1: A queue of strings</caption><image source="LinearBasic/Figures/basicqueue1.png" width="50%"/></figure>
         <p>Computer science also has common examples of queues. Our computer
             laboratory has 30 computers networked with a single printer. When
             students want to print, their print tasks <q>get in line</q> with all the

--- a/pretext/LinearBasic/WhatisaStack.ptx
+++ b/pretext/LinearBasic/WhatisaStack.ptx
@@ -22,10 +22,21 @@
             book whose cover is visible is the one on top. To access others in the
             stack, we need to remove the ones that are sitting on top of them.
             <xref ref="fig-objectstack"/> shows another stack.</p>
-        
-        <figure align="center" xml:id="fig-bookstack"><caption xmlns:c="https://www.sphinx-doc.org/" xmlns:changeset="https://www.sphinx-doc.org/" xmlns:citation="https://www.sphinx-doc.org/" xmlns:cpp="https://www.sphinx-doc.org/" xmlns:index="https://www.sphinx-doc.org/" xmlns:js="https://www.sphinx-doc.org/" xmlns:math="https://www.sphinx-doc.org/" xmlns:py="https://www.sphinx-doc.org/" xmlns:rst="https://www.sphinx-doc.org/" xmlns:std="https://www.sphinx-doc.org/">Figure 1: A Stack of Books</caption><image source="LinearBasic/Figures/bookstack2.png" width="50%"/></figure>
-        
-        <figure align="center" xml:id="fig-objectstack"><caption xmlns:c="https://www.sphinx-doc.org/" xmlns:changeset="https://www.sphinx-doc.org/" xmlns:citation="https://www.sphinx-doc.org/" xmlns:cpp="https://www.sphinx-doc.org/" xmlns:index="https://www.sphinx-doc.org/" xmlns:js="https://www.sphinx-doc.org/" xmlns:math="https://www.sphinx-doc.org/" xmlns:py="https://www.sphinx-doc.org/" xmlns:rst="https://www.sphinx-doc.org/" xmlns:std="https://www.sphinx-doc.org/">Figure 2: A Stack of Primitive Python Objects</caption><image source="LinearBasic/Figures/primitive.png" width="50%"/></figure>
+
+        <figure align="center" xml:id="fig-bookstack">
+            <caption>A Stack of Books</caption>
+                <image source="LinearBasic/bookstack2.png" width="50%">
+                    <description>Figure 1 shows a stack of book on a desk.</description>
+                </image>
+        </figure>
+
+        <figure align="center" xml:id="fig-objectstack">
+            <caption>A Stack of Primitive Python Objects</caption>
+                <image source="LinearBasic/primitive.png" width="50%">
+                    <description>Figure 2 shows a stack of primitive python objects.</description>
+                </image>
+        </figure>
+
         <p>One of the most useful ideas related to stacks comes from the simple
             observation of items as they are added and then removed. Assume you
             start out with a clean desktop. Now place books one at a time on top of
@@ -37,8 +48,14 @@
             <xref ref="fig-reversal"/> shows the stack object as it was
             created and then again as items are removed. Note the order of the
             objects.</p>
-        
-        <figure align="center" xml:id="id3"><caption xmlns:c="https://www.sphinx-doc.org/" xmlns:changeset="https://www.sphinx-doc.org/" xmlns:citation="https://www.sphinx-doc.org/" xmlns:cpp="https://www.sphinx-doc.org/" xmlns:index="https://www.sphinx-doc.org/" xmlns:js="https://www.sphinx-doc.org/" xmlns:math="https://www.sphinx-doc.org/" xmlns:py="https://www.sphinx-doc.org/" xmlns:rst="https://www.sphinx-doc.org/" xmlns:std="https://www.sphinx-doc.org/">Figure 3: The Reversal Property of Stacks</caption><image source="LinearBasic/Figures/simplereversal.png" width="50%"/></figure>
+
+        <figure align="center" xml:id="id3">
+            <caption>The Reversal Property of Stacks</caption>
+                <image source="LinearBasic/simplereversal.png" width="50%">
+                    <description> Figure 3 shows the stack object as it was created and then again as items are removed.</description>
+                </image>
+        </figure>
+
 <exercise label="stack_prob" indent="show" language="python"><statement>
         <p>Say we create a stack by pushing numbers 1 to 4 from lowest to highest. What would the stack look like afterwards?</p>
 </statement>

--- a/pretext/LinearBasic/WhatisaStack.ptx
+++ b/pretext/LinearBasic/WhatisaStack.ptx
@@ -26,14 +26,18 @@
         <figure align="center" xml:id="fig-bookstack">
             <caption>A Stack of Books</caption>
                 <image source="LinearBasic/bookstack2.png" width="50%">
-                    <description>Figure 1 shows a stack of book on a desk.</description>
+                    <description>
+                        The image shows a stack of books stacked on top of each other on a table. The books have different colors and thicknesses, and their titles are visible: Python, Calculus, Physics, Music, and History.
+                    </description>
                 </image>
         </figure>
 
         <figure align="center" xml:id="fig-objectstack">
             <caption>A Stack of Primitive Python Objects</caption>
                 <image source="LinearBasic/primitive.png" width="50%">
-                    <description>Figure 2 shows a stack of primitive python objects.</description>
+                    <description>
+                        The image shows a diagram of a stack, with the top element labeled "true" and the bottom element labeled "dog". The stack is visually represented as a vertical column of boxes, with arrows indicating the direction of addition and removal of elements.
+                    </description>
                 </image>
         </figure>
 
@@ -49,10 +53,12 @@
             created and then again as items are removed. Note the order of the
             objects.</p>
 
-        <figure align="center" xml:id="id3">
+        <figure align="center" xml:id="fig-reversalstacks">
             <caption>The Reversal Property of Stacks</caption>
                 <image source="LinearBasic/simplereversal.png" width="50%">
-                    <description> Figure 3 shows the stack object as it was created and then again as items are removed.</description>
+                    <description>
+                        The image depicts a diagram of a stack, visually demonstrating the original order of elements and the reversed order after they are popped out. It highlights the last-in, first-out (LIFO) principle of stacks, where elements are removed in the opposite order they were added.
+                    </description>
                 </image>
         </figure>
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description
<!--- Describe your changes in detail -->
I fixed all the broken images in Chapter 3 by reformatting their image tags to keep them simple and straightforward and by changing their src path.
## Related Issue
<!--- This project prefers pull requests related to open issues -->
<!--- If suggesting a change, please discuss it in an issue first -->
<!--- Please link to the issue here: -->
fix #484 
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
I tested them by building and viewing them and then comparing them the old runestone book to make sure everything looks goo. Bellow are some snippet from the new edits:
![image](https://github.com/pearcej/cppds/assets/89263196/a27d6122-020e-4332-bacc-29d12e8fa24a)
![image](https://github.com/pearcej/cppds/assets/89263196/55bb9aef-c62d-41cf-b2c2-071bfd9618c7)
