### PR TITLE
Fix broken self-check questions across Chapter 2 in cppds-v2

### DIFF
--- a/pretext/AlgorithmAnalysis/AnAnagramDetectionExample.ptx
+++ b/pretext/AlgorithmAnalysis/AnAnagramDetectionExample.ptx
@@ -344,187 +344,188 @@ main()
                 scientist, when given a choice of algorithms, it will be up to you to
                 determine the best use of computing resources given a particular
                 problem.</p>
-            <note>
-                <title>Self Check</title>
-            </note>
-    <exercise label="analysis_1">
-        <statement>
 
-                <p>Q-7: Given the following code fragment, what is its Big-O running time?</p>
-                <program language="cpp"><input>
-int main(){
-    int test = 0;
-    for (int i = 0; i &lt; n; i++){
-        for (int j = 0; j &lt; n; j++){
-            test = test + i * j;
+    <reading-questions xml:id="rq-alnagram-detection">
+        <title>
+            Reading Questions
+        </title>
+        <exercise label="analysis_1">
+            <statement>
+    
+                    <p>Given the following code fragment, what is its Big-O running time?</p>
+                    <program language="cpp"><input>
+    int main(){
+        int test = 0;
+        for (int i = 0; i &lt; n; i++){
+            for (int j = 0; j &lt; n; j++){
+                test = test + i * j;
+            }
         }
+        return 0;
     }
-    return 0;
-}
-</input></program>
-
-        </statement>
-<choices>
-
-            <choice>
-                <statement>
-                    <p>O(n)</p>
-                </statement>
-                <feedback>
-                    <p>No. In an example like this you want to count the nested loops, especially the loops that are dependent on the same variable, in this case, n.</p>
-                </feedback>
-            </choice>
-
-            <choice correct="yes">
-                <statement>
-                    <p>O(n<sup>2</sup>)</p>
-                </statement>
-                <feedback>
-                    <p>Right! A nested loop like this is O(n<sup>2</sup>).</p>
-                </feedback>
-            </choice>
-
-            <choice>
-                <statement>
-                    <p>O(log n)</p>
-                </statement>
-                <feedback>
-                    <p>No. log n typically is indicated when the problem is iteratively made smaller</p>
-                </feedback>
-            </choice>
-
-            <choice>
-                <statement>
-                    <p>O(n<sup>3</sup>)</p>
-                </statement>
-                <feedback>
-                    <p>No. In an example like this you want to count the nested loops. especially the loops that are dependent on the same variable, in this case, n.</p>
-                </feedback>
-            </choice>
-</choices>
-
-    </exercise>
-
-    <exercise label="analysis_2">
-        <statement>
-
-                <p>Q-8: Given the following code fragment what is its Big-O running time?</p>
-                <program language="cpp"><input>
-int main(){
-    int test = 0;
-    for (int i = 0; i &lt; n; i++){
-        test = test + 1;
+    </input></program>
+    
+            </statement>
+    <choices>
+    
+                <choice>
+                    <statement>
+                        <p>O(n)</p>
+                    </statement>
+                    <feedback>
+                        <p>No. In an example like this you want to count the nested loops, especially the loops that are dependent on the same variable, in this case, n.</p>
+                    </feedback>
+                </choice>
+    
+                <choice correct="yes">
+                    <statement>
+                        <p>O(n<sup>2</sup>)</p>
+                    </statement>
+                    <feedback>
+                        <p>Right! A nested loop like this is O(n<sup>2</sup>).</p>
+                    </feedback>
+                </choice>
+    
+                <choice>
+                    <statement>
+                        <p>O(log n)</p>
+                    </statement>
+                    <feedback>
+                        <p>No. log n typically is indicated when the problem is iteratively made smaller</p>
+                    </feedback>
+                </choice>
+    
+                <choice>
+                    <statement>
+                        <p>O(n<sup>3</sup>)</p>
+                    </statement>
+                    <feedback>
+                        <p>No. In an example like this you want to count the nested loops. especially the loops that are dependent on the same variable, in this case, n.</p>
+                    </feedback>
+                </choice>
+    </choices>
+    
+        </exercise>
+        <exercise label="analysis_2">
+            <statement>
+    
+                    <p>Given the following code fragment what is its Big-O running time?</p>
+                    <program language="cpp"><input>
+    int main(){
+        int test = 0;
+        for (int i = 0; i &lt; n; i++){
+            test = test + 1;
+        }
+        for (int j = 0; j &lt; n; j++){
+            test = test - 1;
+        }
+        return 0;
     }
-    for (int j = 0; j &lt; n; j++){
-        test = test - 1;
+    </input></program>
+    
+            </statement>
+    <choices>
+    
+                <choice correct="yes">
+                    <statement>
+                        <p>O(n)</p>
+                    </statement>
+                    <feedback>
+                        <p>Right! Even though there are two loops they are not nested.  You might think of this as O(2n) but we can ignore the constant 2.</p>
+                    </feedback>
+                </choice>
+    
+                <choice>
+                    <statement>
+                        <p>O(n<sup>2</sup>)</p>
+                    </statement>
+                    <feedback>
+                        <p>No. Be careful, in counting loops you want to look carefully at whether or not the loops are nested.</p>
+                    </feedback>
+                </choice>
+    
+                <choice>
+                    <statement>
+                        <p>O(log n)</p>
+                    </statement>
+                    <feedback>
+                        <p>No. log n typically is indicated when the problem is iteratively made smaller.</p>
+                    </feedback>
+                </choice>
+    
+                <choice>
+                    <statement>
+                        <p>O(n<sup>3</sup>)</p>
+                    </statement>
+                    <feedback>
+                        <p>No. Be careful, in counting loops you want to look carefully at whether or not the loops are nested.</p>
+                    </feedback>
+                </choice>
+    </choices>
+    
+        </exercise>
+        <exercise label="analysis_3">
+            <statement>
+    
+                    <p> Given the following code fragment what is its Big-O running time?</p>
+                    <program language="cpp"><input>
+    int main(){
+        int i = n;
+        int count = 0;
+        while (i &gt; 0){
+            count = count + 1;
+            i = i // 2;
+        }
+        return 0;
     }
-    return 0;
-}
-</input></program>
-
-        </statement>
-<choices>
-
-            <choice correct="yes">
-                <statement>
-                    <p>O(n)</p>
-                </statement>
-                <feedback>
-                    <p>Right! Even though there are two loops they are not nested.  You might think of this as O(2n) but we can ignore the constant 2.</p>
-                </feedback>
-            </choice>
-
-            <choice>
-                <statement>
-                    <p>O(n<sup>2</sup>)</p>
-                </statement>
-                <feedback>
-                    <p>No. Be careful, in counting loops you want to look carefully at whether or not the loops are nested.</p>
-                </feedback>
-            </choice>
-
-            <choice>
-                <statement>
-                    <p>O(log n)</p>
-                </statement>
-                <feedback>
-                    <p>No. log n typically is indicated when the problem is iteratively made smaller.</p>
-                </feedback>
-            </choice>
-
-            <choice>
-                <statement>
-                    <p>O(n<sup>3</sup>)</p>
-                </statement>
-                <feedback>
-                    <p>No. Be careful, in counting loops you want to look carefully at whether or not the loops are nested.</p>
-                </feedback>
-            </choice>
-</choices>
-
-    </exercise>
-
-    <exercise label="analysis_3">
-        <statement>
-
-                <p>Q-9: Given the following code fragment what is its Big-O running time?</p>
-                <program language="cpp"><input>
-int main(){
-    int i = n;
-    int count = 0;
-    while (i &gt; 0){
-        count = count + 1;
-        i = i // 2;
-    }
-    return 0;
-}
-</input></program>
-
-        </statement>
-<choices>
-
-            <choice>
-                <statement>
-                    <p>O(n)</p>
-                </statement>
-                <feedback>
-                    <p>No. Look carefully at the loop variable i.  Notice that the value of i is cut in half each time through the loop.  This is a big hint that the performance is better than O(n)</p>
-                </feedback>
-            </choice>
-
-            <choice>
-                <statement>
-                    <p>O(n<sup>2</sup>)</p>
-                </statement>
-                <feedback>
-                    <p>No. Check again, is this a nested loop?</p>
-                </feedback>
-            </choice>
-
-            <choice correct="yes">
-                <statement>
-                    <p>O(log n)</p>
-                </statement>
-                <feedback>
-                    <p>Right! The value of i is cut in half each time through the loop so it will only take log n iterations.</p>
-                </feedback>
-            </choice>
-
-            <choice>
-                <statement>
-                    <p>O(n<sup>3</sup>)</p>
-                </statement>
-                <feedback>
-                    <p>No. Check again, is this a nested loop?</p>
-                </feedback>
-            </choice>
-</choices>
-
-    </exercise>
-
+    </input></program>
+    
+            </statement>
+    <choices>
+    
+                <choice>
+                    <statement>
+                        <p>O(n)</p>
+                    </statement>
+                    <feedback>
+                        <p>No. Look carefully at the loop variable i.  Notice that the value of i is cut in half each time through the loop.  This is a big hint that the performance is better than O(n)</p>
+                    </feedback>
+                </choice>
+    
+                <choice>
+                    <statement>
+                        <p>O(n<sup>2</sup>)</p>
+                    </statement>
+                    <feedback>
+                        <p>No. Check again, is this a nested loop?</p>
+                    </feedback>
+                </choice>
+    
+                <choice correct="yes">
+                    <statement>
+                        <p>O(log n)</p>
+                    </statement>
+                    <feedback>
+                        <p>Right! The value of i is cut in half each time through the loop so it will only take log n iterations.</p>
+                    </feedback>
+                </choice>
+    
+                <choice>
+                    <statement>
+                        <p>O(n<sup>3</sup>)</p>
+                    </statement>
+                    <feedback>
+                        <p>No. Check again, is this a nested loop?</p>
+                    </feedback>
+                </choice>
+    </choices>
+    
+        </exercise>
+        
         <exercise>
             <statement>
-    <p>Q-10: If an algorithm performing at <math>O(n^{2})</math> has the integer 8 as input, what is the worst case scenario for the algorithm? <var/>  </p></statement><setup><var><condition number="[64, 64]"><feedback><p>Correct!</p></feedback></condition><condition number="[16, 16]"><feedback><p>That would be 2n, which would be simplified as n.</p></feedback></condition><condition number="[8, 8]"><feedback><p>That would be n.</p></feedback></condition><condition string="^\s*.*\s*$"><feedback><p>Wrong, Try again!</p></feedback></condition></var></setup></exercise>            
+    <p>If an algorithm performing at <math>O(n^{2})</math> has the integer 8 as input, what is the worst case scenario for the algorithm? <var/>  </p></statement><setup><var><condition number="[64]"><feedback><p>Correct!</p></feedback></condition><condition number="[16]"><feedback><p>That would be 2n, which would be simplified as n.</p></feedback></condition><condition number="[8]"><feedback><p>That would be n.</p></feedback></condition><condition string="^\s*.*\s*$"><feedback><p>Wrong, Try again!</p></feedback></condition></var></setup></exercise>
+    </reading-questions>            
         </subsection>
     </section>
 

--- a/pretext/AlgorithmAnalysis/AnAnagramDetectionExample.ptx
+++ b/pretext/AlgorithmAnalysis/AnAnagramDetectionExample.ptx
@@ -346,7 +346,7 @@ main()
                 problem.</p>
             <note>
                 <title>Self Check</title>
-
+            </note>
     <exercise label="analysis_1">
         <statement>
 
@@ -524,7 +524,7 @@ int main(){
 
         <exercise>
             <statement>
-    <p>Q-10: If an algorithm performing at <math>O(n^{2})</math> has the integer 8 as input, what is the worst case scenario for the algorithm? <var/>  </p></statement><setup><var><condition number="[64, 64]"><feedback><p>Correct!</p></feedback></condition><condition number="[16, 16]"><feedback><p>That would be 2n, which would be simplified as n.</p></feedback></condition><condition number="[8, 8]"><feedback><p>That would be n.</p></feedback></condition><condition string="^\s*.*\s*$"><feedback><p>Wrong, Try again!</p></feedback></condition></var></setup></exercise>            </note>
+    <p>Q-10: If an algorithm performing at <math>O(n^{2})</math> has the integer 8 as input, what is the worst case scenario for the algorithm? <var/>  </p></statement><setup><var><condition number="[64, 64]"><feedback><p>Correct!</p></feedback></condition><condition number="[16, 16]"><feedback><p>That would be 2n, which would be simplified as n.</p></feedback></condition><condition number="[8, 8]"><feedback><p>That would be n.</p></feedback></condition><condition string="^\s*.*\s*$"><feedback><p>Wrong, Try again!</p></feedback></condition></var></setup></exercise>            
         </subsection>
     </section>
 

--- a/pretext/AlgorithmAnalysis/BigONotation.ptx
+++ b/pretext/AlgorithmAnalysis/BigONotation.ptx
@@ -57,61 +57,7 @@
         would say then that the function <math>T(n)</math> has an order of
         magnitude <math>f(n)=n^{2}</math>, or simply that it is <math>O(n^{2})</math>.</p>
 
-<exercise label="bigo3">
-    <statement>
 
-    <p>Q-1: If the exact number of steps is <math>T(n)=2n+3n^{2}-1</math> what is the Big O?</p>
-
-    </statement>
-<choices>
-
-        <choice>
-            <statement>
-                <p>O(2n)</p>
-            </statement>
-            <feedback>
-                <p>No, 3n<sup>2</sup> dominates 2n. Try again.</p>
-            </feedback>
-        </choice>
-
-        <choice>
-            <statement>
-                <p>O(n)</p>
-            </statement>
-            <feedback>
-                <p>No, n<sup>2</sup> dominates n. Try again.</p>
-            </feedback>
-        </choice>
-
-        <choice>
-            <statement>
-                <p>O(3n<sup>2</sup>)</p>
-            </statement>
-            <feedback>
-                <p>No, the 3 should be omitted because n<sup>2</sup> dominates.</p>
-            </feedback>
-        </choice>
-
-        <choice correct="yes">
-            <statement>
-                <p>O(n<sup>2</sup>)</p>
-            </statement>
-            <feedback>
-                <p>Right!</p>
-            </feedback>
-        </choice>
-
-        <choice>
-            <statement>
-                <p>More than one of the above</p>
-            </statement>
-            <feedback>
-                <p>No, only one of them is correct. Try again.</p>
-            </feedback>
-        </choice>
-</choices>
-
-</exercise>
     <p>Although we do not see this in the summation example, sometimes the
         performance of an algorithm depends on the exact values of the data
         rather than simply the size of the problem. For these kinds of
@@ -218,18 +164,7 @@
             </image>
     </figure>
 
-<exercise label="parsonsBigO" indent="show" language="python"><statement>
-    <p>Without looking at the graph above, from top to bottom order the following from most to least efficient.</p>
-</statement>
-<blocks><block order="1">
-<cline>constant</cline>
-<cline>logarithmic</cline>
-<cline>linear</cline>
-<cline>log linear</cline>
-<cline>quadratic</cline>
-<cline>cubic</cline>
-<cline>exponential</cline>
-</block></blocks></exercise>        <p>As a final example, suppose that we have the fragment of C++ code
+        <p>As a final example, suppose that we have the fragment of C++ code
         shown in <xref ref="lst-dummycode"/>. Although this program does not really do
         anything, it is instructive to see how we can take actual code and
         analyze performance.</p>
@@ -300,288 +235,363 @@ main()</pre>
         to see that <math>T(n)</math> then follows the quadratic function as
         <math>n</math> continues to grow.</p>
 
-<exercise label="crossoverefficiency">
-    <statement>
+<reading-questions xml:id="rq-big-o-notation">
+    <title>
+Reading Questions
+    </title>
+    <exercise>
 
-    <p>Q-3: Which of the following statements is true about the two algorithms?
-        Algorithm 1: 100n + 1
-        Algorithm 2: n^2 + n + 1</p>
+            <p>Write two C++ functions to find the minimum number in an array.  The first function should compare each number to every other number on the array. <math>O(n^2)</math>.  The second function should be linear <math>O(n)</math>.</p>
+        
+    </exercise>
+    <exercise label="bigo3">
+        <statement>
+    
+        <p>If the exact number of steps is <math>T(n)=2n+3n^{2}-1</math> what is the Big O?</p>
+    
+        </statement>
+    <choices>
+    
+            <choice>
+                <statement>
+                    <p>O(2n)</p>
+                </statement>
+                <feedback>
+                    <p>No, 3n<sup>2</sup> dominates 2n. Try again.</p>
+                </feedback>
+            </choice>
+    
+            <choice>
+                <statement>
+                    <p>O(n)</p>
+                </statement>
+                <feedback>
+                    <p>No, n<sup>2</sup> dominates n. Try again.</p>
+                </feedback>
+            </choice>
+    
+            <choice>
+                <statement>
+                    <p>O(3n<sup>2</sup>)</p>
+                </statement>
+                <feedback>
+                    <p>No, the 3 should be omitted because n<sup>2</sup> dominates.</p>
+                </feedback>
+            </choice>
+    
+            <choice correct="yes">
+                <statement>
+                    <p>O(n<sup>2</sup>)</p>
+                </statement>
+                <feedback>
+                    <p>Right!</p>
+                </feedback>
+            </choice>
+    
+            <choice>
+                <statement>
+                    <p>More than one of the above</p>
+                </statement>
+                <feedback>
+                    <p>No, only one of them is correct. Try again.</p>
+                </feedback>
+            </choice>
+    </choices>
+    
+    </exercise>
 
+    <exercise label="parsonsBigO" indent="show" language="python"><statement>
+        <p>Without looking at the graph above, from top to bottom order the following from most to least efficient.</p>
     </statement>
-<choices>
+    <blocks><block order="1">
+    <cline>constant</cline>
+    <cline>logarithmic</cline>
+    <cline>linear</cline>
+    <cline>log linear</cline>
+    <cline>quadratic</cline>
+    <cline>cubic</cline>
+    <cline>exponential</cline>
+    </block></blocks></exercise>
 
-        <choice>
-            <statement>
-                <p>Algorithm 1 will require a greater number of steps to complete than Algorithm 2</p>
-            </statement>
-            <feedback>
-                <p>This could be true depending on the input, but consider the broader picture</p>
-            </feedback>
-        </choice>
+    <exercise label="crossoverefficiency">
+        <statement>
+    
+        <p>Which of the following statements is true about the two algorithms?
+            Algorithm 1: 100n + 1
+            Algorithm 2: n^2 + n + 1</p>
+    
+        </statement>
+    <choices>
+    
+            <choice>
+                <statement>
+                    <p>Algorithm 1 will require a greater number of steps to complete than Algorithm 2</p>
+                </statement>
+                <feedback>
+                    <p>This could be true depending on the input, but consider the broader picture</p>
+                </feedback>
+            </choice>
+    
+            <choice>
+                <statement>
+                    <p>Algorithm 2 will require a greater number of steps to complete than Algorithm 1</p>
+                </statement>
+                <feedback>
+                    <p>This could be true depending on the input, but consider the broader picture</p>
+                </feedback>
+            </choice>
+    
+            <choice correct="yes">
+                <statement>
+                    <p>Algorithm 1 will require a greater number of steps to complete than Algorithm 2 until they reach the crossover point</p>
+                </statement>
+                <feedback>
+                    <p>Correct!</p>
+                </feedback>
+            </choice>
+    
+            <choice>
+                <statement>
+                    <p>Algorithm 1 and 2 will always require the same number of steps to complete</p>
+                </statement>
+                <feedback>
+                    <p>No, the efficiency of both will depend on the input</p>
+                </feedback>
+            </choice>
+    </choices>
+    
+    </exercise>
+    
 
-        <choice>
-            <statement>
-                <p>Algorithm 2 will require a greater number of steps to complete than Algorithm 1</p>
-            </statement>
-            <feedback>
-                <p>This could be true depending on the input, but consider the broader picture</p>
-            </feedback>
-        </choice>
+    <exercise label="BIGO1">
+        <statement>
+    
+            <p>The Big O of a particular algorithm is <math>O(log_{2}n)</math>.
+                Given that it takes 2 seconds to complete the algorithm with 3 million inputs;
+                how long would it take with 4 million inputs?</p>
+    
+        </statement>
+    <choices>
+    
+            <choice>
+                <statement>
+                    <p>3.444</p>
+                </statement>
+                <feedback>
+                    <p>Incorrect. Try again.</p>
+                </feedback>
+            </choice>
+    
+            <choice correct="yes">
+                <statement>
+                    <p>2.53</p>
+                </statement>
+                <feedback>
+                    <p>Correct!</p>
+                </feedback>
+            </choice>
+    
+            <choice>
+                <statement>
+                    <p>2</p>
+                </statement>
+                <feedback>
+                    <p>Incorrect. Try again.</p>
+                </feedback>
+            </choice>
+    
+            <choice>
+                <statement>
+                    <p>4</p>
+                </statement>
+                <feedback>
+                    <p>Incorrect. Try again.</p>
+                </feedback>
+            </choice>
+    
+            <choice>
+                <statement>
+                    <p>More than one of the above</p>
+                </statement>
+                <feedback>
+                    <p>No, only one of them is correct. Try again.</p>
+                </feedback>
+            </choice>
+    </choices>
+    
+    </exercise>
+    <exercise label="BIGO2">
+        <statement>
+    
+            <p>The Big O of a particular algorithm is <math>O(log_{2}n)</math>.
+                Given that it takes 2 seconds to complete the algorithm with 3 million inputs;
+                how long would it take with 10 million inputs?</p>
+    
+        </statement>
+    <choices>
+    
+            <choice>
+                <statement>
+                    <p>3.444</p>
+                </statement>
+                <feedback>
+                    <p>Incorrect. Try again.</p>
+                </feedback>
+            </choice>
+    
+            <choice>
+                <statement>
+                    <p>2.53</p>
+                </statement>
+                <feedback>
+                    <p>Incorrect. Try again.</p>
+                </feedback>
+            </choice>
+    
+            <choice>
+                <statement>
+                    <p>2</p>
+                </statement>
+                <feedback>
+                    <p>Incorrect. Try again.</p>
+                </feedback>
+            </choice>
+    
+            <choice correct="yes">
+                <statement>
+                    <p>4.2</p>
+                </statement>
+                <feedback>
+                    <p>Right!</p>
+                </feedback>
+            </choice>
+    
+            <choice>
+                <statement>
+                    <p>More than one of the above</p>
+                </statement>
+                <feedback>
+                    <p>No, only one of them is correct. Try again.</p>
+                </feedback>
+            </choice>
+    </choices>
+    
+    </exercise>
+    <exercise label="BIGO3">
+        <statement>
+    
+            <p>The Big O of a particular algorithm is <math>O(n^{3})</math>.
+                Given that it takes 2 seconds to complete the algorithm with 1000 inputs;
+                how long would it take with 2000 inputs?</p>
+    
+        </statement>
+    <choices>
+    
+            <choice>
+                <statement>
+                    <p>2000</p>
+                </statement>
+                <feedback>
+                    <p>Incorrect. Try again. Think about what happens to the time as more operations occur.</p>
+                </feedback>
+            </choice>
+    
+            <choice>
+                <statement>
+                    <p>3000</p>
+                </statement>
+                <feedback>
+                    <p>Incorrect. Try again. Think about what happens to the time as more operations occur.</p>
+                </feedback>
+            </choice>
+    
+            <choice correct="yes">
+                <statement>
+                    <p>16</p>
+                </statement>
+                <feedback>
+                    <p>Correct!</p>
+                </feedback>
+            </choice>
+    
+            <choice>
+                <statement>
+                    <p>1500</p>
+                </statement>
+                <feedback>
+                    <p>Incorrect. Try again. Think about what happens to the time as more operations occur.</p>
+                </feedback>
+            </choice>
+    
+            <choice>
+                <statement>
+                    <p>More than one of the above</p>
+                </statement>
+                <feedback>
+                    <p>No, only one of them is correct. Try again.</p>
+                </feedback>
+            </choice>
+    </choices>
+    
+    </exercise>
 
-        <choice correct="yes">
-            <statement>
-                <p>Algorithm 1 will require a greater number of steps to complete than Algorithm 2 until they reach the crossover point</p>
-            </statement>
-            <feedback>
-                <p>Correct!</p>
-            </feedback>
-        </choice>
-
-        <choice>
-            <statement>
-                <p>Algorithm 1 and 2 will always require the same number of steps to complete</p>
-            </statement>
-            <feedback>
-                <p>No, the efficiency of both will depend on the input</p>
-            </feedback>
-        </choice>
-</choices>
-
-</exercise>
-    <note>
-        <title>Self Check</title>
-        <p>Write two C++ functions to find the minimum number in an array.  The first function should compare each number to every other number on the array. <math>O(n^2)</math>.  The second function should be linear <math>O(n)</math>.</p>
-    </note>
-<exercise label="BIGO1">
-    <statement>
-
-        <p>Q-4: The Big O of a particular algorithm is <math>O(log_{2}n)</math>.
-            Given that it takes 2 seconds to complete the algorithm with 3 million inputs;
-            how long would it take with 4 million inputs?</p>
-
-    </statement>
-<choices>
-
-        <choice>
-            <statement>
-                <p>3.444</p>
-            </statement>
-            <feedback>
-                <p>Incorrect. Try again.</p>
-            </feedback>
-        </choice>
-
-        <choice correct="yes">
-            <statement>
-                <p>2.53</p>
-            </statement>
-            <feedback>
-                <p>Correct!</p>
-            </feedback>
-        </choice>
-
-        <choice>
-            <statement>
-                <p>2</p>
-            </statement>
-            <feedback>
-                <p>Incorrect. Try again.</p>
-            </feedback>
-        </choice>
-
-        <choice>
-            <statement>
-                <p>4</p>
-            </statement>
-            <feedback>
-                <p>Incorrect. Try again.</p>
-            </feedback>
-        </choice>
-
-        <choice>
-            <statement>
-                <p>More than one of the above</p>
-            </statement>
-            <feedback>
-                <p>No, only one of them is correct. Try again.</p>
-            </feedback>
-        </choice>
-</choices>
-
-</exercise>
-
-<exercise label="BIGO2">
-    <statement>
-
-        <p>Q-5: The Big O of a particular algorithm is <math>O(log_{2}n)</math>.
-            Given that it takes 2 seconds to complete the algorithm with 3 million inputs;
-            how long would it take with 10 million inputs?</p>
-
-    </statement>
-<choices>
-
-        <choice>
-            <statement>
-                <p>3.444</p>
-            </statement>
-            <feedback>
-                <p>Incorrect. Try again.</p>
-            </feedback>
-        </choice>
-
-        <choice>
-            <statement>
-                <p>2.53</p>
-            </statement>
-            <feedback>
-                <p>Incorrect. Try again.</p>
-            </feedback>
-        </choice>
-
-        <choice>
-            <statement>
-                <p>2</p>
-            </statement>
-            <feedback>
-                <p>Incorrect. Try again.</p>
-            </feedback>
-        </choice>
-
-        <choice correct="yes">
-            <statement>
-                <p>4.2</p>
-            </statement>
-            <feedback>
-                <p>Right!</p>
-            </feedback>
-        </choice>
-
-        <choice>
-            <statement>
-                <p>More than one of the above</p>
-            </statement>
-            <feedback>
-                <p>No, only one of them is correct. Try again.</p>
-            </feedback>
-        </choice>
-</choices>
-
-</exercise>
-
-<exercise label="BIGO3">
-    <statement>
-
-        <p>Q-6: The Big O of a particular algorithm is <math>O(n^{3})</math>.
-            Given that it takes 2 seconds to complete the algorithm with 1000 inputs;
-            how long would it take with 2000 inputs?</p>
-
-    </statement>
-<choices>
-
-        <choice>
-            <statement>
-                <p>2000</p>
-            </statement>
-            <feedback>
-                <p>Incorrect. Try again. Think about what happens to the time as more operations occur.</p>
-            </feedback>
-        </choice>
-
-        <choice>
-            <statement>
-                <p>3000</p>
-            </statement>
-            <feedback>
-                <p>Incorrect. Try again. Think about what happens to the time as more operations occur.</p>
-            </feedback>
-        </choice>
-
-        <choice correct="yes">
-            <statement>
-                <p>16</p>
-            </statement>
-            <feedback>
-                <p>Correct!</p>
-            </feedback>
-        </choice>
-
-        <choice>
-            <statement>
-                <p>1500</p>
-            </statement>
-            <feedback>
-                <p>Incorrect. Try again. Think about what happens to the time as more operations occur.</p>
-            </feedback>
-        </choice>
-
-        <choice>
-            <statement>
-                <p>More than one of the above</p>
-            </statement>
-            <feedback>
-                <p>No, only one of them is correct. Try again.</p>
-            </feedback>
-        </choice>
-</choices>
-
-</exercise>
-
-<exercise label="BIGO4">
-    <statement>
-
-        <p>Q-7: The Big O of a particular algorithm is <math>O(n^{3})</math>.
-            Given that it takes 2 seconds to complete the algorithm with 1000 inputs;
-            how long would it take with 10,000 inputs?</p>
-
-    </statement>
-<choices>
-
-        <choice correct="yes">
-            <statement>
-                <p>2000</p>
-            </statement>
-            <feedback>
-                <p>Right!</p>
-            </feedback>
-        </choice>
-
-        <choice>
-            <statement>
-                <p>3000</p>
-            </statement>
-            <feedback>
-                <p>Incorrect. Try again. Think about what happens to the time as more operations occur.</p>
-            </feedback>
-        </choice>
-
-        <choice>
-            <statement>
-                <p>16</p>
-            </statement>
-            <feedback>
-                <p>Incorrect. Try again. Think about what happens to the time as more operations occur.</p>
-            </feedback>
-        </choice>
-
-        <choice>
-            <statement>
-                <p>1500</p>
-            </statement>
-            <feedback>
-                <p>Incorrect. Try again. Think about what happens to the time as more operations occur.</p>
-            </feedback>
-        </choice>
-
-        <choice>
-            <statement>
-                <p>More than one of the above</p>
-            </statement>
-            <feedback>
-                <p>No, only one of them is correct. Try again.</p>
-            </feedback>
-        </choice>
-</choices>
-
-</exercise>
+    <exercise label="BIGO4">
+        <statement>
+    
+            <p>The Big O of a particular algorithm is <math>O(n^{3})</math>.
+                Given that it takes 2 seconds to complete the algorithm with 1000 inputs;
+                how long would it take with 10,000 inputs?</p>
+    
+        </statement>
+    <choices>
+    
+            <choice correct="yes">
+                <statement>
+                    <p>2000</p>
+                </statement>
+                <feedback>
+                    <p>Right!</p>
+                </feedback>
+            </choice>
+    
+            <choice>
+                <statement>
+                    <p>3000</p>
+                </statement>
+                <feedback>
+                    <p>Incorrect. Try again. Think about what happens to the time as more operations occur.</p>
+                </feedback>
+            </choice>
+    
+            <choice>
+                <statement>
+                    <p>16</p>
+                </statement>
+                <feedback>
+                    <p>Incorrect. Try again. Think about what happens to the time as more operations occur.</p>
+                </feedback>
+            </choice>
+    
+            <choice>
+                <statement>
+                    <p>1500</p>
+                </statement>
+                <feedback>
+                    <p>Incorrect. Try again. Think about what happens to the time as more operations occur.</p>
+                </feedback>
+            </choice>
+    
+            <choice>
+                <statement>
+                    <p>More than one of the above</p>
+                </statement>
+                <feedback>
+                    <p>No, only one of them is correct. Try again.</p>
+                </feedback>
+            </choice>
+    </choices>
+    
+    </exercise>
+</reading-questions>
 </section>
 

--- a/pretext/AlgorithmAnalysis/BigONotation.ptx
+++ b/pretext/AlgorithmAnalysis/BigONotation.ptx
@@ -351,7 +351,7 @@ main()</pre>
     <note>
         <title>Self Check</title>
         <p>Write two C++ functions to find the minimum number in an array.  The first function should compare each number to every other number on the array. <math>O(n^2)</math>.  The second function should be linear <math>O(n)</math>.</p>
-
+    </note>
 <exercise label="BIGO1">
     <statement>
 
@@ -583,6 +583,5 @@ main()</pre>
 </choices>
 
 </exercise>
-    </note>
 </section>
 

--- a/pretext/AlgorithmAnalysis/HashTableAnalysis.ptx
+++ b/pretext/AlgorithmAnalysis/HashTableAnalysis.ptx
@@ -181,7 +181,7 @@ print("%d,%10.3f,%10.3f" % (i, lst_time, d_time))
         data structures can be found on the C++ website.</p>
     <note>
         <title>Self Check</title>
-
+    </note>
 <exercise label="mccppmapperfcpp3">
     <statement>
 
@@ -349,7 +349,7 @@ print("%d,%10.3f,%10.3f" % (i, lst_time, d_time))
 </choices>
 
 </exercise>
-    </note>
+    
     <!--Copyright (C)  Brad Miller, David Ranum, and Jan Pearce
 This work is licensed under the Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International License. To view a copy of this license, visit http://creativecommons.org/licenses/by-nc-sa/4.0/.-->
 </section>

--- a/pretext/AlgorithmAnalysis/HashTableAnalysis.ptx
+++ b/pretext/AlgorithmAnalysis/HashTableAnalysis.ptx
@@ -179,13 +179,19 @@ print("%d,%10.3f,%10.3f" % (i, lst_time, d_time))
     <p>Since C++ is an evolving language, there are always changes going on
         behind the scenes. The latest information on the performance of C++
         data structures can be found on the C++ website.</p>
-    <note>
-        <title>Self Check</title>
-    </note>
+
+        <reading-questions xml:id="rq-hashtable-analysis">
+            <title>
+                Reading Questions
+            </title>
+            
+            
+            
+        
 <exercise label="mccppmapperfcpp3">
     <statement>
 
-        <p>Q-1: Which of the vector operations shown below is not O(1)?</p>
+        <p>Which of the vector operations shown below is not O(1)?</p>
 
     </statement>
 <choices>
@@ -241,7 +247,7 @@ print("%d,%10.3f,%10.3f" % (i, lst_time, d_time))
 <exercise label="mccppmapperfcpp4">
     <statement>
 
-        <p>Q-2: Which of the hash table operations shown below is O(1)?</p>
+        <p>Which of the hash table operations shown below is O(1)?</p>
 
     </statement>
 <choices>
@@ -297,7 +303,7 @@ print("%d,%10.3f,%10.3f" % (i, lst_time, d_time))
 <exercise label="manswer_shtBO">
     <statement>
 
-        <p>Q-3: What is an operator for hash tables with an efficiency other than O(1)?</p>
+        <p>What is an operator for hash tables with an efficiency other than O(1)?</p>
 
     </statement>
 <choices>
@@ -349,6 +355,7 @@ print("%d,%10.3f,%10.3f" % (i, lst_time, d_time))
 </choices>
 
 </exercise>
+</reading-questions>
     
     <!--Copyright (C)  Brad Miller, David Ranum, and Jan Pearce
 This work is licensed under the Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International License. To view a copy of this license, visit http://creativecommons.org/licenses/by-nc-sa/4.0/.-->

--- a/pretext/AlgorithmAnalysis/VectorAnalysis.ptx
+++ b/pretext/AlgorithmAnalysis/VectorAnalysis.ptx
@@ -346,9 +346,16 @@ int main(){
 }
         </input>
     </program>
-
+<reading-questions xml:id="rq-vector-analysis">
+    <title>
+        Reading Question
+    </title>
+    
+    
 <exercise label="matching_VectorBO">
     <statement><p>Drag the operation(s) on the left to their corresponding Big(O)</p></statement>
     <feedback><p>Review operations and thier Big(O)</p></feedback>
-<matches><match order="1"><premise>begin(), end(), size(), index [], index assignment = ,push_back(), pop_back()</premise><response> O(1)</response></match><match order="2"><premise>reserve(), erase(i), insert(i, item),find(srt, stp, item)</premise><response>O(n)</response></match><match order="3"><premise>find(srt, stp, item)</premise><response>O(log n)</response></match></matches></exercise>    </section>
+<matches><match order="1"><premise>begin(), end(), size(), index [], index assignment = ,push_back(), pop_back()</premise><response> O(1)</response></match><match order="2"><premise>reserve(), erase(i), insert(i, item),find(srt, stp, item)</premise><response>O(n)</response></match><match order="3"><premise>find(srt, stp, item)</premise><response>O(log n)</response></match></matches></exercise>    
+</reading-questions>
+</section>
 

--- a/pretext/AlgorithmAnalysis/WhatIsAlgorithmAnalysis.ptx
+++ b/pretext/AlgorithmAnalysis/WhatIsAlgorithmAnalysis.ptx
@@ -231,9 +231,7 @@ for (int i=0; i&lt;n+1; i++){
 theSum = theSum + 1; //how many times?
 }</pre>
 
-    <exercise>
-        <statement>
-<p>Q-7: How many times is the <title_reference>theSum = theSum + 1</title_reference> line executed? <var/>  </p></statement><setup><var><condition number="[1001, 1001]"><feedback><p>Right! Good job!</p></feedback></condition><condition number="[1000, 1000]"><feedback><p>No. Look carefully at the loop condition i&lt;n+1.</p></feedback></condition><condition string="^\s*default\s*$"><feedback><p>Incorrect. Please try again.</p></feedback></condition></var></setup></exercise>        <subsection xml:id="algorithm-analysis_some-needed-math-notation">
+           <subsection xml:id="algorithm-analysis_some-needed-math-notation">
         <title>Some Needed Math Notation</title>
         <p>This is the sigma symbol: <math>\sum_{}</math>.
             It tells us that we are summing up something
@@ -249,61 +247,7 @@ theSum = theSum + 1; //how many times?
             because just like in a <title_reference>for</title_reference> loop, we plug a value for each <title_reference>i</title_reference> value.
             Similarly, <math>\sum_{i=2}^{4} i^2</math> means <math>2^2+3^2+4^2</math>.</p>
 
-<exercise label="somemath1">
-    <statement>
 
-        <p>Q-8: Compute the result of <math>\sum_{i=1}^{3} i^3</math></p>
-
-    </statement>
-<choices>
-
-        <choice>
-            <statement>
-                <p>6</p>
-            </statement>
-            <feedback>
-                <p>No. Use i = 1, i = 2, and i = 3, plugging into i^3.</p>
-            </feedback>
-        </choice>
-
-        <choice>
-            <statement>
-                <p>14</p>
-            </statement>
-            <feedback>
-                <p>No. Use i = 1, i = 2, and i = 3, plugging into i^3.</p>
-            </feedback>
-        </choice>
-
-        <choice>
-            <statement>
-                <p>25</p>
-            </statement>
-            <feedback>
-                <p>No. Use i = 1, i = 2, and i = 3, plugging into i^3.</p>
-            </feedback>
-        </choice>
-
-        <choice correct="yes">
-            <statement>
-                <p>36</p>
-            </statement>
-            <feedback>
-                <p>Right! It is 1^3 + 2^3 + 3^3 = 1 + 8 + 27.</p>
-            </feedback>
-        </choice>
-
-        <choice>
-            <statement>
-                <p>None of the above.</p>
-            </statement>
-            <feedback>
-                <p>One of the above is correct!</p>
-            </feedback>
-        </choice>
-</choices>
-
-</exercise>
     </subsection>
     <subsection xml:id="algorithm-analysis_applying-the-math-notation">
         <title>Applying the Math Notation</title>
@@ -335,9 +279,7 @@ int sum_n = (n*(n+1))/2; // how many times?
 return sum_n;
 }</pre>
 
-    <exercise>
-        <statement>
-<p>Q-9: If <title_reference>SumOfN3</title_reference> is called once with a parameter of <title_reference>n=10</title_reference>, how many times is the <title_reference>int sum_n = (n*(n+1))/2;</title_reference> line executed? <var/>  </p></statement><setup><var><condition number="[1, 1]"><feedback><p>Right! Good job!</p></feedback></condition><condition number="[10, 10]"><feedback><p>No, consider that the function is called only once, and n is the parameter.</p></feedback></condition><condition string="^\s*default\s*$"><feedback><p>Incorrect. Please try again.</p></feedback></condition></var></setup></exercise>            <p>We see this in <xref ref="algorithm-analysis_active3cpp"/>,
+             <p>We see this in <xref ref="algorithm-analysis_active3cpp"/>,
             which shows <c>sumOfN3</c>
             taking advantage of the formula we just developed.</p>
         
@@ -419,6 +361,74 @@ Sum is 50005000 required 0.000000 seconds</pre>
             characterization that is independent of the program or computer being
             used. This measure would then be useful for judging the algorithm alone
             and could be used to compare algorithms across implementations.</p>
+            <reading-questions xml:id="rqs-what-algo-analysis">
+                <title>
+                    Reading Questions
+                </title>
+                
+                
+                <exercise>
+                    <statement>
+            <p>How many times is the <title_reference>theSum = theSum + 1</title_reference> line executed? <var/>  </p></statement><setup><var><condition number="[1001]"><feedback><p>Right! Good job!</p></feedback></condition><condition number="[1000, 1000]"><feedback><p>No. Look carefully at the loop condition i&lt;n+1.</p></feedback></condition><condition string="^\s*default\s*$"><feedback><p>Incorrect. Please try again.</p></feedback></condition></var></setup></exercise> 
+            <exercise label="somemath1">
+                <statement>
+            
+                    <p>Compute the result of <math>\sum_{i=1}^{3} i^3</math></p>
+            
+                </statement>
+            <choices>
+            
+                    <choice>
+                        <statement>
+                            <p>6</p>
+                        </statement>
+                        <feedback>
+                            <p>No. Use i = 1, i = 2, and i = 3, plugging into i^3.</p>
+                        </feedback>
+                    </choice>
+            
+                    <choice>
+                        <statement>
+                            <p>14</p>
+                        </statement>
+                        <feedback>
+                            <p>No. Use i = 1, i = 2, and i = 3, plugging into i^3.</p>
+                        </feedback>
+                    </choice>
+            
+                    <choice>
+                        <statement>
+                            <p>25</p>
+                        </statement>
+                        <feedback>
+                            <p>No. Use i = 1, i = 2, and i = 3, plugging into i^3.</p>
+                        </feedback>
+                    </choice>
+            
+                    <choice correct="yes">
+                        <statement>
+                            <p>36</p>
+                        </statement>
+                        <feedback>
+                            <p>Right! It is 1^3 + 2^3 + 3^3 = 1 + 8 + 27.</p>
+                        </feedback>
+                    </choice>
+            
+                    <choice>
+                        <statement>
+                            <p>None of the above.</p>
+                        </statement>
+                        <feedback>
+                            <p>One of the above is correct!</p>
+                        </feedback>
+                    </choice>
+            </choices>
+            
+            </exercise>
+            <exercise>
+                <statement>
+        <p>If <title_reference>SumOfN3</title_reference> is called once with a parameter of <title_reference>n=10</title_reference>, how many times is the <title_reference>int sum_n = (n*(n+1))/2;</title_reference> line executed? <var/>  </p></statement><setup><var><condition number="[1]"><feedback><p>Right! Good job!</p></feedback></condition><condition number="[10]"><feedback><p>No, consider that the function is called only once, and n is the parameter.</p></feedback></condition><condition string="^\s*default\s*$"><feedback><p>Incorrect. Please try again.</p></feedback></condition></var></setup></exercise>   
+            </reading-questions>
     </subsection>
 </section>
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description
<!--- Describe your changes in detail -->
(Update) I fixed all the broken self-check questions across chapter 2. As in the issue described, all of the questions became broken because they were in the Note tag, but what I did is I remove the Note tag. Instead, I put them in the tag so they will no longer break, and also, they will no longer be in the checkpoint section.
## Related Issue
fix #521 
<!--- This project prefers pull requests related to open issues -->
<!--- If suggesting a change, please discuss it in an issue first -->
<!--- Please link to the issue here: -->

## How Has This Been Tested?
1. Make changes locally.
2. Veryfiy the changes locally.
![image](https://github.com/pearcej/cppds/assets/117699634/fb825c5d-c48a-436c-8b54-034ac9cec47f)
![image](https://github.com/pearcej/cppds/assets/117699634/9972b62e-a8aa-49d8-b160-339c56694a05)
![image](https://github.com/pearcej/cppds/assets/117699634/54a27537-b95b-42b9-b6e7-7f1fbf94832a)


<!--- Please describe in detail how you tested your changes. -->
