### PR TITLE
Fix broken self-check questions across Chapter 3 in cppds-v2

### DIFF
--- a/pretext/LinearBasic/BalancedSymbolsGeneralCase.ptx
+++ b/pretext/LinearBasic/BalancedSymbolsGeneralCase.ptx
@@ -150,47 +150,56 @@ main()
         </input>
     </program>
             </TabNode></exercise>
-
-<exercise label="stackclick">
-    <statement><p>Using the program below, click on the line of code that adds an open parenthesis to the stack.</p></statement>
-<feedback><p>Remember that the function to do this would be the push function.</p></feedback>
-<areas>
-<cline><area>bool parChecker(string symbolString){</area>:</cline>
-<cline>      <area>stack&lt;string&gt; s;</area>:</cline>
-<cline>      <area>bool balanced = true;</area>:</cline>
-<cline>      <area>int index = 0;</area>:</cline>
-<cline>      <area>int symbolLength = symbolString.length();</area>:</cline>
-<cline/>
-<cline>      while(index &lt; symbolLength &amp;&amp; balanced){</cline>
-<cline>          <area>string symbol;</area>:</cline>
-<cline>          <area>symbol = symbolString[index];</area>:</cline>
-<cline>          <area>string opens = "({[";</area>:</cline>
-<cline>          <area>if (inString(symbol, opens)){</area>:</cline>
-<cline>              <area correct="yes">s.push(symbol);</area>:</cline>
-<cline>          } else {</cline>
-<cline>              if (s.empty()){</cline>
-<cline>                  <area>balanced = false;</area>:</cline>
-<cline>              } else {</cline>
-<cline>                  <area>string top = s.top();</area>:</cline>
-<cline>                  <area>s.pop();</area>:</cline>
-<cline>                  <area>if (!matches(top, symbol)){</area>:</cline>
-<cline>                      <area>balanced = false;</area>:</cline>
-<cline>                  }</cline>
-<cline>              }</cline>
-<cline>          }</cline>
-<cline>          <area>index = index + 1;</area>:</cline>
-<cline>      }</cline>
-<cline>      <area>if(balanced &amp;&amp; s.empty()){</area>:</cline>
-<cline>          <area>return true;</area>:</cline>
-<cline>      } else {</cline>
-<cline>          <area>return false;</area>:</cline>
-<cline>      }</cline>
-<cline>}</cline>
-</areas></exercise>        <p>These two examples show that stacks are very important data structures
+        <p>These two examples show that stacks are very important data structures
             for the processing of language constructs in computer science. Almost
             any notation you can think of has some type of nested symbols that must
             be matched in a balanced order. A number of other important
             uses for stacks exist in computer science. We will continue to explore them
             in the next sections.</p>
+<reading-questions xml:id="rq-balanced-sybols">
+    <title>
+        <p>
+            Reading Question
+        </p>
+    </title>
+    
+    
+                <exercise label="stackclick">
+                    <statement><p>Using the program below, click on the line of code that adds an open parenthesis to the stack.</p></statement>
+                <feedback><p>Remember that the function to do this would be the push function.</p></feedback>
+                <areas>
+                <cline><area>bool parChecker(string symbolString){</area>:</cline>
+                <cline>      <area>stack&lt;string&gt; s;</area>:</cline>
+                <cline>      <area>bool balanced = true;</area>:</cline>
+                <cline>      <area>int index = 0;</area>:</cline>
+                <cline>      <area>int symbolLength = symbolString.length();</area>:</cline>
+                <cline/>
+                <cline>      while(index &lt; symbolLength &amp;&amp; balanced){</cline>
+                <cline>          <area>string symbol;</area>:</cline>
+                <cline>          <area>symbol = symbolString[index];</area>:</cline>
+                <cline>          <area>string opens = "({[";</area>:</cline>
+                <cline>          <area>if (inString(symbol, opens)){</area>:</cline>
+                <cline>              <area correct="yes">s.push(symbol);</area>:</cline>
+                <cline>          } else {</cline>
+                <cline>              if (s.empty()){</cline>
+                <cline>                  <area>balanced = false;</area>:</cline>
+                <cline>              } else {</cline>
+                <cline>                  <area>string top = s.top();</area>:</cline>
+                <cline>                  <area>s.pop();</area>:</cline>
+                <cline>                  <area>if (!matches(top, symbol)){</area>:</cline>
+                <cline>                      <area>balanced = false;</area>:</cline>
+                <cline>                  }</cline>
+                <cline>              }</cline>
+                <cline>          }</cline>
+                <cline>          <area>index = index + 1;</area>:</cline>
+                <cline>      }</cline>
+                <cline>      <area>if(balanced &amp;&amp; s.empty()){</area>:</cline>
+                <cline>          <area>return true;</area>:</cline>
+                <cline>      } else {</cline>
+                <cline>          <area>return false;</area>:</cline>
+                <cline>      }</cline>
+                <cline>}</cline>
+                </areas></exercise>
+            </reading-questions>
     </section>
 

--- a/pretext/LinearBasic/BalancedSymbolsGeneralCase.ptx
+++ b/pretext/LinearBasic/BalancedSymbolsGeneralCase.ptx
@@ -40,7 +40,7 @@
             must be checked to see that it matches the current closing symbol. If a
             mismatch occurs, the Boolean variable <c>balanced</c> is set to <c>false</c>.</p>
         
-        <exercise ><TabNode tabname="C++" tabnode_options="{'subchapter': 'BalancedSymbolsGeneralCase', 'chapter': 'LinearBasic', 'basecourse': 'cppds', 'optional': '', 'optclass': '', 'tabname': 'C++'}">
+        <TabNode tabname="C++" tabnode_options="{'subchapter': 'BalancedSymbolsGeneralCase', 'chapter': 'LinearBasic', 'basecourse': 'cppds', 'optional': '', 'optclass': '', 'tabname': 'C++'}">
 
     <program xml:id="parcheck2_cpp" interactive="activecode" language="cpp">
         <input>
@@ -149,7 +149,7 @@ def main():
 main()
         </input>
     </program>
-            </TabNode></exercise>
+            </TabNode>
         <p>These two examples show that stacks are very important data structures
             for the processing of language constructs in computer science. Almost
             any notation you can think of has some type of nested symbols that must

--- a/pretext/LinearBasic/ConvertingDecimalNumberstoBinaryNumbers.ptx
+++ b/pretext/LinearBasic/ConvertingDecimalNumberstoBinaryNumbers.ptx
@@ -232,17 +232,20 @@ main()
             resulting digit can be appended to the answer. For example, if the
             remainder 13 is removed from the stack, the digit D is appended to the
             resulting string.</p>
-        <note>
-            <title>Self Check</title>
-        </note>
+       
+        <reading-questions xml:id="rq-converting-decimal-num-binary-num">
+            <title>
+                Reading Questions
+            </title>
         <exercise>
             <statement>
-    <p>Q-5: What is value of 25 expressed as an octal (base 8) number? <var/>  </p></statement><setup><var><p><BlankNode/></p><condition number="[31, 31]"><feedback><p>Correct because 25 = 3x8 + 1.</p></feedback></condition></var></setup></exercise>
+    <p>What is value of 25 expressed as an octal (base 8) number? <var/>  </p></statement><setup><var><p><BlankNode/></p><condition number="[31, 31]"><feedback><p>Correct because 25 = 3x8 + 1.</p></feedback></condition></var></setup></exercise>
         <exercise>
             <statement>
-    <p>Q-6: What is value of 256 expressed as a hexadecimal (base 16) number? <var/>  </p></statement><setup><var><p><BlankNode/></p><condition number="[100, 100]"><feedback><p>Correct because 256 = 1x16^2.</p></feedback></condition></var></setup></exercise>
+    <p>What is value of 256 expressed as a hexadecimal (base 16) number? <var/>  </p></statement><setup><var><p><BlankNode/></p><condition number="[100, 100]"><feedback><p>Correct because 256 = 1x16^2.</p></feedback></condition></var></setup></exercise>
         <exercise>
             <statement>
-    <p>Q-7: What is value of 26 expressed in base 26? <var/>  </p></statement><setup><var><p><BlankNode/></p><condition number="[10, 10]"><feedback><p>Correct because 26 = 1x26^1.</p></feedback></condition></var></setup></exercise>        
+    <p>What is value of 26 expressed in base 26? <var/>  </p></statement><setup><var><p><BlankNode/></p><condition number="[10, 10]"><feedback><p>Correct because 26 = 1x26^1.</p></feedback></condition></var></setup></exercise>  
+</reading-questions>      
     </section>
 

--- a/pretext/LinearBasic/ConvertingDecimalNumberstoBinaryNumbers.ptx
+++ b/pretext/LinearBasic/ConvertingDecimalNumberstoBinaryNumbers.ptx
@@ -234,7 +234,7 @@ main()
             resulting string.</p>
         <note>
             <title>Self Check</title>
-
+        </note>
         <exercise>
             <statement>
     <p>Q-5: What is value of 25 expressed as an octal (base 8) number? <var/>  </p></statement><setup><var><p><BlankNode/></p><condition number="[31, 31]"><feedback><p>Correct because 25 = 3x8 + 1.</p></feedback></condition></var></setup></exercise>
@@ -243,6 +243,6 @@ main()
     <p>Q-6: What is value of 256 expressed as a hexadecimal (base 16) number? <var/>  </p></statement><setup><var><p><BlankNode/></p><condition number="[100, 100]"><feedback><p>Correct because 256 = 1x16^2.</p></feedback></condition></var></setup></exercise>
         <exercise>
             <statement>
-    <p>Q-7: What is value of 26 expressed in base 26? <var/>  </p></statement><setup><var><p><BlankNode/></p><condition number="[10, 10]"><feedback><p>Correct because 26 = 1x26^1.</p></feedback></condition></var></setup></exercise>        </note>
+    <p>Q-7: What is value of 26 expressed in base 26? <var/>  </p></statement><setup><var><p><BlankNode/></p><condition number="[10, 10]"><feedback><p>Correct because 26 = 1x26^1.</p></feedback></condition></var></setup></exercise>        
     </section>
 

--- a/pretext/LinearBasic/ImplementingaQueueCpp.ptx
+++ b/pretext/LinearBasic/ImplementingaQueueCpp.ptx
@@ -89,7 +89,7 @@ main()
             </TabNode></exercise>
         <note>
             <title>Self Check</title>
-
+        </note>
     <exercise label="queue_1">
         <statement>
 
@@ -142,6 +142,6 @@ q.pop();</pre>
 </choices>
 
     </exercise>
-        </note>
+        
     </section>
 

--- a/pretext/LinearBasic/ImplementingaQueueCpp.ptx
+++ b/pretext/LinearBasic/ImplementingaQueueCpp.ptx
@@ -87,9 +87,11 @@ main()
         </input>
     </program>
             </TabNode></exercise>
-        <note>
-            <title>Self Check</title>
-        </note>
+        <reading-questions xml:id="rqs-implementing-queue">
+            <title>
+   Reading Question
+            </title>
+       
     <exercise label="queue_1">
         <statement>
 
@@ -142,6 +144,6 @@ q.pop();</pre>
 </choices>
 
     </exercise>
-        
+</reading-questions>   
     </section>
 

--- a/pretext/LinearBasic/ImplementingaQueueCpp.ptx
+++ b/pretext/LinearBasic/ImplementingaQueueCpp.ptx
@@ -14,7 +14,7 @@
             of the queue and <c>pop</c> operations will
             manipulate the opposite side, the <term>front</term> end.</p>
         
-        <exercise ><TabNode tabname="C++" tabnode_options="{'subchapter': 'ImplementingaQueueCpp', 'chapter': 'LinearBasic', 'basecourse': 'cppds', 'optional': '', 'optclass': '', 'tabname': 'C++'}">
+        <TabNode tabname="C++" tabnode_options="{'subchapter': 'ImplementingaQueueCpp', 'chapter': 'LinearBasic', 'basecourse': 'cppds', 'optional': '', 'optclass': '', 'tabname': 'C++'}">
 
     <program xml:id="queue1accpp" interactive="activecode" language="cpp">
         <input>
@@ -86,7 +86,7 @@ def main():
 main()
         </input>
     </program>
-            </TabNode></exercise>
+            </TabNode>
         <reading-questions xml:id="rqs-implementing-queue">
             <title>
    Reading Question

--- a/pretext/LinearBasic/ImplementingaQueueCpp.ptx
+++ b/pretext/LinearBasic/ImplementingaQueueCpp.ptx
@@ -95,7 +95,7 @@ main()
     <exercise label="queue_1">
         <statement>
 
-            <p>Q-3: Suppose you have the following series of queue operations.</p>
+            <p>Suppose you have the following series of queue operations.</p>
             <pre>queue&lt;int&gt; q;
 q.push(10);
 q.push(20);

--- a/pretext/LinearBasic/ImplementingaStackCpp.ptx
+++ b/pretext/LinearBasic/ImplementingaStackCpp.ptx
@@ -98,7 +98,7 @@ main()
             </TabNode></exercise>
         <note>
             <title>Self Check</title>
-
+        </note>
     <exercise label="stack_1">
         <statement>
 
@@ -210,6 +210,6 @@ while (!m.empty()){
 </choices>
 
     </exercise>
-        </note>
+        
     </section>
 

--- a/pretext/LinearBasic/ImplementingaStackCpp.ptx
+++ b/pretext/LinearBasic/ImplementingaStackCpp.ptx
@@ -96,13 +96,13 @@ main()
         </input>
     </program>
             </TabNode></exercise>
-        <note>
-            <title>Self Check</title>
-        </note>
+
+<reading-questions xml:id="rq-stack-implementation">
+                <title>Reading Questions</title>
     <exercise label="stack_1">
         <statement>
 
-            <p>Q-3: Given the following sequence of stack operations, what is the top item on the stack when the sequence is complete?</p>
+            <p>Given the following sequence of stack operations, what is the top item on the stack when the sequence is complete?</p>
             <program language="cpp"><input>
 stack&lt;int&gt; m;
 m.push(5);
@@ -157,7 +157,7 @@ cout &lt;&lt; m.top();
     <exercise label="stack_2">
         <statement>
 
-            <p>Q-4: Given the following sequence of stack operations, what is the top item on the stack when the sequence is complete?</p>
+            <p>Given the following sequence of stack operations, what is the top item on the stack when the sequence is complete?</p>
             <program language="cpp"><input>
 stack&lt;int&gt; m;
 m.push(37);
@@ -210,6 +210,6 @@ while (!m.empty()){
 </choices>
 
     </exercise>
-        
+</reading-questions>  
     </section>
 

--- a/pretext/LinearBasic/ImplementingaStackCpp.ptx
+++ b/pretext/LinearBasic/ImplementingaStackCpp.ptx
@@ -14,7 +14,7 @@
             grows (as <c>push</c> operations occur), new items will be added on the end
             of the array. <c>pop</c> operations will manipulate that same end.</p>
         
-        <exercise ><TabNode tabname="C++" tabnode_options="{'subchapter': 'ImplementingaStackCpp', 'chapter': 'LinearBasic', 'basecourse': 'cppds', 'optional': '', 'optclass': '', 'tabname': 'C++'}">
+        <TabNode tabname="C++" tabnode_options="{'subchapter': 'ImplementingaStackCpp', 'chapter': 'LinearBasic', 'basecourse': 'cppds', 'optional': '', 'optclass': '', 'tabname': 'C++'}">
 
     <program xml:id="stack_1ac_cpp" interactive="activecode" language="cpp">
         <input>
@@ -95,7 +95,7 @@ def main():
 main()
         </input>
     </program>
-            </TabNode></exercise>
+            </TabNode>
 
 <reading-questions xml:id="rq-stack-implementation">
                 <title>Reading Questions</title>

--- a/pretext/LinearBasic/InfixPrefixandPostfixExpressions.ptx
+++ b/pretext/LinearBasic/InfixPrefixandPostfixExpressions.ptx
@@ -723,7 +723,7 @@ main()
                 this as an exercise at the end of the chapter.</p>
             <note>
                 <title>Self Check</title>
-
+            </note>
         <exercise>
             <statement>
     <p>Q-6: Without using the activecode infixToPostfix function, convert the following expression to postfix  <c>10 + 3 * 5 / (16 - 4)</c> . <var/>  </p></statement><setup><var><p><BlankNode/></p><condition string="^\s*10\s+3\s+5\s*\*\s*16\s+4\s*-\s*/\s*\+\s*$"><feedback><p>Correct.</p></feedback></condition><condition string="^\s*10.*3.*5.*16.*4\s+[\s+/+*-]*\s*$"><feedback><p>The numbers appear to be in the correct order check your operators</p></feedback></condition></var></setup></exercise>
@@ -732,7 +732,7 @@ main()
     <p>Q-7: What is the result of evaluating the following: <c>17 10 + 3 * 9 / =</c> <var/>  </p></statement><setup><var><p><BlankNode/></p><condition number="[9, 9]"><feedback><p>Correct.</p></feedback></condition></var></setup></exercise>
         <exercise>
             <statement>
-    <p>Q-8: Modify the infixToPostfix function above so that it can convert the following expression. Once you have the answer from the code put it in the blank below:  <c>5 * 3 /(4 - 2)</c>. <var/>  </p></statement><setup><var><p><BlankNode/></p><condition string="^\s*5\s+3\s*\*\s*4\s+2\s*\-\s*\/\s*$"><feedback><p>Correct.</p></feedback></condition><condition string="^\s*5.*3.*5.*4.*2\s+[-/*]*\s*$"><feedback><p>The numbers appear to be in the correct order check your operators</p></feedback></condition></var></setup></exercise>            </note>
+    <p>Q-8: Modify the infixToPostfix function above so that it can convert the following expression. Once you have the answer from the code put it in the blank below:  <c>5 * 3 /(4 - 2)</c>. <var/>  </p></statement><setup><var><p><BlankNode/></p><condition string="^\s*5\s+3\s*\*\s*4\s+2\s*\-\s*\/\s*$"><feedback><p>Correct.</p></feedback></condition><condition string="^\s*5.*3.*5.*4.*2\s+[-/*]*\s*$"><feedback><p>The numbers appear to be in the correct order check your operators</p></feedback></condition></var></setup></exercise>            
         </subsection>
     </section>
 

--- a/pretext/LinearBasic/InfixPrefixandPostfixExpressions.ptx
+++ b/pretext/LinearBasic/InfixPrefixandPostfixExpressions.ptx
@@ -290,18 +290,7 @@
                 notations.</p>
             
             <figure align="center" xml:id="id6"><caption xmlns:c="https://www.sphinx-doc.org/" xmlns:changeset="https://www.sphinx-doc.org/" xmlns:citation="https://www.sphinx-doc.org/" xmlns:cpp="https://www.sphinx-doc.org/" xmlns:index="https://www.sphinx-doc.org/" xmlns:js="https://www.sphinx-doc.org/" xmlns:math="https://www.sphinx-doc.org/" xmlns:py="https://www.sphinx-doc.org/" xmlns:rst="https://www.sphinx-doc.org/" xmlns:std="https://www.sphinx-doc.org/">Figure 8: Converting a Complex Expression to Prefix and Postfix Notations</caption><image source="LinearBasic/Figures/complexmove.png" width="50%"/></figure>
-<exercise label="question1_100_4" indent="show" language="python"><statement>
-            <p>What does the prefix expression of this infix expression look like: ((A+B)*(C-D)) if this were modeled using a stack with the top being the end of the expression and the bottom being the beginning of the expression?</p>
-</statement>
-<blocks><block order="1">
-<cline>D</cline>
-<cline>C</cline>
-<cline>-</cline>
-<cline>B</cline>
-<cline>A</cline>
-<cline>+</cline>
-<cline>*</cline>
-</block></blocks></exercise>        </subsection>
+   </subsection>
         <subsection xml:id="linear-basic_general-infix-to-postfix-conversion">
             <title>General Infix-to-Postfix Conversion</title>
 
@@ -721,18 +710,35 @@ main()
                 input expression. Using these programs as a starting point, you can
                 easily see how error detection and reporting can be included. We leave
                 this as an exercise at the end of the chapter.</p>
-            <note>
-                <title>Self Check</title>
-            </note>
+          
+
+<reading-questions xml:id="rq-decimal-to-binary">
+    <title>
+        Reading Questions
+    </title>
+
+                <exercise label="question1_100_4" indent="show" language="python"><statement>
+                    <p>What does the prefix expression of this infix expression look like: ((A+B)*(C-D)) if this were modeled using a stack with the top being the end of the expression and the bottom being the beginning of the expression?</p>
+        </statement>
+        <blocks><block order="1">
+        <cline>D</cline>
+        <cline>C</cline>
+        <cline>-</cline>
+        <cline>B</cline>
+        <cline>A</cline>
+        <cline>+</cline>
+        <cline>*</cline>
+        </block></blocks></exercise>     
         <exercise>
             <statement>
-    <p>Q-6: Without using the activecode infixToPostfix function, convert the following expression to postfix  <c>10 + 3 * 5 / (16 - 4)</c> . <var/>  </p></statement><setup><var><p><BlankNode/></p><condition string="^\s*10\s+3\s+5\s*\*\s*16\s+4\s*-\s*/\s*\+\s*$"><feedback><p>Correct.</p></feedback></condition><condition string="^\s*10.*3.*5.*16.*4\s+[\s+/+*-]*\s*$"><feedback><p>The numbers appear to be in the correct order check your operators</p></feedback></condition></var></setup></exercise>
+    <p>Without using the activecode infixToPostfix function, convert the following expression to postfix  <c>10 + 3 * 5 / (16 - 4)</c> . <var/>  </p></statement><setup><var><p><BlankNode/></p><condition string="^\s*10\s+3\s+5\s*\*\s*16\s+4\s*-\s*/\s*\+\s*$"><feedback><p>Correct.</p></feedback></condition><condition string="^\s*10.*3.*5.*16.*4\s+[\s+/+*-]*\s*$"><feedback><p>The numbers appear to be in the correct order check your operators</p></feedback></condition></var></setup></exercise>
         <exercise>
             <statement>
-    <p>Q-7: What is the result of evaluating the following: <c>17 10 + 3 * 9 / =</c> <var/>  </p></statement><setup><var><p><BlankNode/></p><condition number="[9, 9]"><feedback><p>Correct.</p></feedback></condition></var></setup></exercise>
+    <p>What is the result of evaluating the following: <c>17 10 + 3 * 9 / =</c> <var/>  </p></statement><setup><var><p><BlankNode/></p><condition number="[9, 9]"><feedback><p>Correct.</p></feedback></condition></var></setup></exercise>
         <exercise>
             <statement>
-    <p>Q-8: Modify the infixToPostfix function above so that it can convert the following expression. Once you have the answer from the code put it in the blank below:  <c>5 * 3 /(4 - 2)</c>. <var/>  </p></statement><setup><var><p><BlankNode/></p><condition string="^\s*5\s+3\s*\*\s*4\s+2\s*\-\s*\/\s*$"><feedback><p>Correct.</p></feedback></condition><condition string="^\s*5.*3.*5.*4.*2\s+[-/*]*\s*$"><feedback><p>The numbers appear to be in the correct order check your operators</p></feedback></condition></var></setup></exercise>            
+    <p>Modify the infixToPostfix function above so that it can convert the following expression. Once you have the answer from the code put it in the blank below:  <c>5 * 3 /(4 - 2)</c>. <var/>  </p></statement><setup><var><p><BlankNode/></p><condition string="^\s*5\s+3\s*\*\s*4\s+2\s*\-\s*\/\s*$"><feedback><p>Correct.</p></feedback></condition><condition string="^\s*5.*3.*5.*4.*2\s+[-/*]*\s*$"><feedback><p>The numbers appear to be in the correct order check your operators</p></feedback></condition></var></setup></exercise> 
+</reading-questions>           
         </subsection>
     </section>
 

--- a/pretext/LinearBasic/PalindromeChecker.ptx
+++ b/pretext/LinearBasic/PalindromeChecker.ptx
@@ -187,7 +187,12 @@ int main() {
     </program>
                 </TabNode></exercise>
         </blockquote>
-
+<reading-questions xml:id="rqs-">
+    <title>
+        Reading Questions
+    </title>
+    
+    
 <exercise label="orderingPrinciples">
     <statement><p>Drag each data structure to its corresponding ordering principle</p></statement>
     <feedback><p>This is feedback.</p></feedback>
@@ -203,10 +208,11 @@ int main() {
 <cline><area>d.push_back("Catfish");</area>:</cline>
 <cline><area>d.push_back("Giraffe");</area>:</cline>
 </areas></exercise>
+
     <exercise label="structureefficiency">
         <statement>
 
-        <p>Q-6: If you add five items to your code in this order <q>potato</q>, <q>rutabaga</q>, <q>avocado</q>, <q>squash</q>, <q>eggplant</q> which structure would take the least steps to retrieve <q>rutabaga</q>?</p>
+        <p>If you add five items to your code in this order <q>potato</q>, <q>rutabaga</q>, <q>avocado</q>, <q>squash</q>, <q>eggplant</q> which structure would take the least steps to retrieve <q>rutabaga</q>?</p>
 
         </statement>
 <choices>
@@ -258,5 +264,7 @@ int main() {
 </choices>
 
     </exercise>
+</reading-questions>
+
     </section>
 

--- a/pretext/LinearBasic/TheStackAbstractDataType.ptx
+++ b/pretext/LinearBasic/TheStackAbstractDataType.ptx
@@ -169,11 +169,14 @@
                 
             
         </tabular></table>
+<reading-questions xml:id="rq-what-is-stack">
+    <title>Reading Question</title>
+
 
     <exercise label="stack_datatypes">
         <statement>
 
-        <p>Q-1: Which group of data would not make a valid Stack?</p>
+        <p>Which group of data would not make a valid Stack?</p>
 
         </statement>
 <choices>
@@ -216,5 +219,6 @@
 </choices>
 
     </exercise>
+</reading-questions>
     </section>
 

--- a/pretext/LinearBasic/WhatisaStack.ptx
+++ b/pretext/LinearBasic/WhatisaStack.ptx
@@ -39,20 +39,23 @@
             objects.</p>
         
         <figure align="center" xml:id="id3"><caption xmlns:c="https://www.sphinx-doc.org/" xmlns:changeset="https://www.sphinx-doc.org/" xmlns:citation="https://www.sphinx-doc.org/" xmlns:cpp="https://www.sphinx-doc.org/" xmlns:index="https://www.sphinx-doc.org/" xmlns:js="https://www.sphinx-doc.org/" xmlns:math="https://www.sphinx-doc.org/" xmlns:py="https://www.sphinx-doc.org/" xmlns:rst="https://www.sphinx-doc.org/" xmlns:std="https://www.sphinx-doc.org/">Figure 3: The Reversal Property of Stacks</caption><image source="LinearBasic/Figures/simplereversal.png" width="50%"/></figure>
-<exercise label="stack_prob" indent="show" language="python"><statement>
-        <p>Say we create a stack by pushing numbers 1 to 4 from lowest to highest. What would the stack look like afterwards?</p>
-</statement>
-<blocks><block order="1">
-<cline>4</cline>
-<cline>3</cline>
-<cline>2</cline>
-<cline>1</cline>
-</block></blocks></exercise>        <p>Considering this reversal property, you can perhaps think of examples of
+    <p>Considering this reversal property, you can perhaps think of examples of
             stacks that occur as you use your computer. For example, every web
             browser has a Back button. As you navigate from web page to web page,
             those pages are placed on a stack (actually it is the URLs that are
             going on the stack). The current page that you are viewing is on the top
             and the first page you looked at is at the base. If you click on the
             Back button, you begin to move in reverse order through the pages.</p>
+            <reading-questions xml:id="rq-what-is-stack">
+                <title>Reading Question</title>
+                <exercise label="stack_prob" indent="show" language="python"><statement>
+                        <p>Say we create a stack by pushing numbers 1 to 4 from lowest to highest. What would the stack look like afterwards?</p>
+                </statement>
+                <blocks><block order="1">
+                <cline>4</cline>
+                <cline>3</cline>
+                <cline>2</cline>
+                <cline>1</cline>
+                </block></blocks></exercise>   </reading-questions> 
     </section>
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description
<!--- Describe your changes in detail -->
(Update) I fixed all the broken self-check questions across chapter 3. As in the issue described, all of the questions became broken because they were in the Note tag, but what I did is I remove the Note tag. Instead, I put them in the tag so they will no longer break, and also, they will no longer be in the checkpoint section.
## Related Issue
fix #522 
<!--- This project prefers pull requests related to open issues -->
<!--- If suggesting a change, please discuss it in an issue first -->
<!--- Please link to the issue here: -->

## How Has This Been Tested?
1. Make changes locally.
2. Veryfiy the changes locally.
![image](https://github.com/pearcej/cppds/assets/117699634/519ceac3-42f4-44fb-8d60-3629e601458b)
![image](https://github.com/pearcej/cppds/assets/117699634/9d3c1186-fa71-4f51-b85a-225ec16dd47b)

