### PR TITLE
Fix broken self-check questions across Chapter 5 in cppds-v2

### DIFF
--- a/pretext/Recursion/TheThreeLawsofRecursion.ptx
+++ b/pretext/Recursion/TheThreeLawsofRecursion.ptx
@@ -83,7 +83,7 @@ int main(){
             problem by using the three laws of recursion.</p>
         <note>
             <title>Self Check</title>
-
+        </note>
     <exercise label="question_recsimp_1">
         <statement>
 
@@ -224,6 +224,6 @@ int main(){
 </choices>
 
     </exercise>
-        </note>
+        
     </section>
 

--- a/pretext/Recursion/TheThreeLawsofRecursion.ptx
+++ b/pretext/Recursion/TheThreeLawsofRecursion.ptx
@@ -81,13 +81,11 @@ int main(){
         <p>In the remainder of this chapter we will look at more examples of
             recursion. In each case we will focus on designing a solution to a
             problem by using the three laws of recursion.</p>
-        <note>
-            <title>Self Check</title>
-        </note>
+<reading-questions xml:id="rq-three-laws-recursion">
     <exercise label="question_recsimp_1">
         <statement>
 
-            <p>Q-2: Why is a base case needed in a recursive function?</p>
+            <p>Why is a base case needed in a recursive function?</p>
 
         </statement>
 <choices>
@@ -134,7 +132,7 @@ int main(){
     <exercise label="question_recsimp_2">
         <statement>
 
-            <p>Q-3: How many recursive calls are made when computing the sum of the vector {2,4,6,8,10}?</p>
+            <p>How many recursive calls are made when computing the sum of the vector {2,4,6,8,10}?</p>
 
         </statement>
 <choices>
@@ -181,7 +179,7 @@ int main(){
     <exercise label="question_recsimp_3">
         <statement>
 
-            <p>Q-4: Suppose you are going to write a recursive function to calculate the factorial of a number.  fact(n) returns n * n-1 * n-2 * &#8230; Where the factorial of zero is defined to be 1.  What would be the most appropriate base case?</p>
+            <p>Suppose you are going to write a recursive function to calculate the factorial of a number.  fact(n) returns n * n-1 * n-2 * &#8230; Where the factorial of zero is defined to be 1.  What would be the most appropriate base case?</p>
 
         </statement>
 <choices>
@@ -224,6 +222,6 @@ int main(){
 </choices>
 
     </exercise>
-        
+</reading-questions>   
     </section>
 

--- a/pretext/Recursion/TowerofHanoi.ptx
+++ b/pretext/Recursion/TowerofHanoi.ptx
@@ -106,7 +106,7 @@ int moveDisk(char fp, char tp){
 }
 </input></program>
         <p>The program in ActiveCode 1 provides the entire solution for three disks.</p>
-        <exercise ><TabNode tabname="C++" tabnode_options="{'subchapter': 'TowerofHanoi', 'chapter': 'Recursion', 'basecourse': 'cppds', 'optional': '', 'optclass': '', 'tabname': 'C++'}">
+        <TabNode tabname="C++" tabnode_options="{'subchapter': 'TowerofHanoi', 'chapter': 'Recursion', 'basecourse': 'cppds', 'optional': '', 'optclass': '', 'tabname': 'C++'}">
 
     <program xml:id="hanoicpp" interactive="activecode" language="cpp">
         <input>
@@ -153,7 +153,7 @@ def main():
 main()
         </input>
     </program>
-            </TabNode></exercise>
+            </TabNode>
  <p>Now that you have seen the code for both <c>moveTower</c> and <c>moveDisk</c>,
             you may be wondering why we do not have a data structure that explicitly
             keeps track of what disks are on what poles. Here is a hint: if you were

--- a/pretext/Recursion/TowerofHanoi.ptx
+++ b/pretext/Recursion/TowerofHanoi.ptx
@@ -154,14 +154,17 @@ main()
         </input>
     </program>
             </TabNode></exercise>
-
-        <exercise>
-            <statement>
-    <p>Q-3: If you change the tower height in Line 17 from 3 to 6, how many moves must you make to complete the Hanoi tower? (hint, try implementing a counter to return the correct number) <var/>  </p></statement><setup><var><condition number="[63, 63]"><feedback><p>Correct, you can make a global counter at line 3, and then cout the increasing total under line 11.</p></feedback></condition><condition number="[62, 62]"><feedback><p>Technically you are correct but, you are off by one.</p></feedback></condition><condition string="^\s*.*\s*$"><feedback><p>Please try again you need to add a statement at line 3, and under line 11.</p></feedback></condition></var></setup></exercise>        <p>Now that you have seen the code for both <c>moveTower</c> and <c>moveDisk</c>,
+ <p>Now that you have seen the code for both <c>moveTower</c> and <c>moveDisk</c>,
             you may be wondering why we do not have a data structure that explicitly
             keeps track of what disks are on what poles. Here is a hint: if you were
             going to explicitly keep track of the disks, you would probably use
             three <c>Stack</c> objects, one for each pole. The answer is that C++
             provides the stacks that we need implicitly through the call stack.</p>
+
+            <reading-questions xml:id="rq-tower-hanoi">
+
+                <exercise>
+                    <statement>
+            <p>If you change the tower height in Line 17 from 3 to 6, how many moves must you make to complete the Hanoi tower? (hint, try implementing a counter to return the correct number) <var/>  </p></statement><setup><var><condition number="[63, 63]"><feedback><p>Correct, you can make a global counter at line 3, and then cout the increasing total under line 11.</p></feedback></condition><condition number="[62, 62]"><feedback><p>Technically you are correct but, you are off by one.</p></feedback></condition><condition string="^\s*.*\s*$"><feedback><p>Please try again you need to add a statement at line 3, and under line 11.</p></feedback></condition></var></setup></exercise>    </reading-questions>   
     </section>
 

--- a/pretext/Recursion/pythondsConvertinganIntegertoaStringinAnyBase.ptx
+++ b/pretext/Recursion/pythondsConvertinganIntegertoaStringinAnyBase.ptx
@@ -132,7 +132,7 @@ main()
             discussion of stacks back in the previous chapter.</p>
         <note>
             <title>Self Check</title>
-
+        </note>
     <exercise label="RecursiveQ1">
         <statement>
 
@@ -262,6 +262,6 @@ int main(){
         </input>
     </program>
             </blockquote>
-        </note>
+        
     </section>
 

--- a/pretext/Recursion/pythondsConvertinganIntegertoaStringinAnyBase.ptx
+++ b/pretext/Recursion/pythondsConvertinganIntegertoaStringinAnyBase.ptx
@@ -130,13 +130,12 @@ main()
             the concatenation operation until after the recursive call has returned,
             we get the result in the proper order. This should remind you of our
             discussion of stacks back in the previous chapter.</p>
-        <note>
-            <title>Self Check</title>
-        </note>
+ <reading-questions xml:id="rq-converting-integer-to-string">
+
     <exercise label="RecursiveQ1">
         <statement>
 
-            <p>Q-3: Is the process of stepping through a recursive function similar to the construct of a stack or a queue?</p>
+            <p>Is the process of stepping through a recursive function similar to the construct of a stack or a queue?</p>
 
         </statement>
 <choices>
@@ -262,6 +261,6 @@ int main(){
         </input>
     </program>
             </blockquote>
-        
+        </reading-questions>   
     </section>
 

--- a/pretext/Recursion/pythondsintro-VisualizingRecursion.ptx
+++ b/pretext/Recursion/pythondsintro-VisualizingRecursion.ptx
@@ -239,9 +239,7 @@ main()
             is just not as symmetric as a computer program. The exercises at the end
             of the chapter will give you some ideas for how to explore some
             interesting options to make your tree look more realistic.</p>
-        <note>
-            <title>Self Check</title>
-        </note>
+  <reading-questions xml:id="rq-visualizing-recursion">
             <p>Modify the recursive tree program using one or all of the following
                 ideas:</p>
             <p><ul>
@@ -272,6 +270,6 @@ main()
 
         </input>
     </program>
-        
+</reading-questions>  
     </section>
 

--- a/pretext/Recursion/pythondsintro-VisualizingRecursion.ptx
+++ b/pretext/Recursion/pythondsintro-VisualizingRecursion.ptx
@@ -241,6 +241,7 @@ main()
             interesting options to make your tree look more realistic.</p>
         <note>
             <title>Self Check</title>
+        </note>
             <p>Modify the recursive tree program using one or all of the following
                 ideas:</p>
             <p><ul>
@@ -271,6 +272,6 @@ main()
 
         </input>
     </program>
-        </note>
+        
     </section>
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description
<!--- Describe your changes in detail -->
(Update) I fixed all the broken self-check questions across chapter 5. As in the issue described, all of the questions became broken because they were in the Note tag, but what I did is I remove the Note tag. Instead, I put them in the tag so they will no longer break, and also, they will no longer be in the checkpoint section.
## Related Issue
fix #523 
<!--- This project prefers pull requests related to open issues -->
<!--- If suggesting a change, please discuss it in an issue first -->
<!--- Please link to the issue here: -->

## How Has This Been Tested?
1. Make changes locally.
2. Veryfiy the changes locally.
![image](https://github.com/pearcej/cppds/assets/117699634/d8808074-c7a3-4a16-888d-abdfdcf6be0e)
![image](https://github.com/pearcej/cppds/assets/117699634/be71eb2d-b00a-465d-9b37-40c761c2b3e9)

