### PR TITLE
Fix broken self-check questions across Chapter 6 in cppds-v2

### DIFF
--- a/pretext/SearchHash/Hashing.ptx
+++ b/pretext/SearchHash/Hashing.ptx
@@ -479,102 +479,7 @@ int main() {
                 advantage is that on the average there are likely to be many fewer items
                 in each slot, so the search is perhaps more efficient. We will look at
                 the analysis for hashing at the end of this section.</p>
-            <note>
-                <title>Self Check</title>
-            </note>
-    <exercise label="HASH_1">
-        <statement>
-
-                <p>Q-2: In a hash table of size 13 which index positions would the following two keys map to?  27,  130</p>
-
-        </statement>
-<choices>
-
-            <choice>
-                <statement>
-                    <p>1, 10</p>
-                </statement>
-                <feedback>
-                    <p>Be careful to use modulo not integer division</p>
-                </feedback>
-            </choice>
-
-            <choice>
-                <statement>
-                    <p>13, 0</p>
-                </statement>
-                <feedback>
-                    <p>Don't divide by two, use the modulo operator.</p>
-                </feedback>
-            </choice>
-
-            <choice correct="yes">
-                <statement>
-                    <p>1, 0</p>
-                </statement>
-                <feedback>
-                    <p>27 % 13 == 1 and 130 % 13 == 0</p>
-                </feedback>
-            </choice>
-
-            <choice>
-                <statement>
-                    <p>2, 3</p>
-                </statement>
-                <feedback>
-                    <p>Use the modulo operator</p>
-                </feedback>
-            </choice>
-</choices>
-
-    </exercise>
-
-    <exercise label="HASH_2">
-        <statement>
-
-                <p>Q-3: Suppose you are given the following set of keys to insert into a hash table that holds exactly 11 values:  113 , 117 , 97 , 100 , 114 , 108 , 121 , 105 , 99 Which of the following best demonstrates the contents of the hash table after all the keys have been inserted using linear probing?</p>
-
-        </statement>
-<choices>
-
-            <choice>
-                <statement>
-                    <p>100, __, __, 113, 114, 105, 121, 117, 97, 108, 99</p>
-                </statement>
-                <feedback>
-                    <p>It looks like you may have been doing modulo 2 arithmentic.  You need to use the hash table size as the modulo value.</p>
-                </feedback>
-            </choice>
-
-            <choice correct="yes">
-                <statement>
-                    <p>121, 100, 99, 113, 114, __, 105, 117, __, 97, 108</p>
-                </statement>
-                <feedback>
-                    <p>Using modulo 11 arithmetic and linear probing gives these values</p>
-                </feedback>
-            </choice>
-
-            <choice>
-                <statement>
-                    <p>100, 113, 117, 97, 14, 108, 121, 105, 99, __, __</p>
-                </statement>
-                <feedback>
-                    <p>It looks like you are using modulo 10 arithmetic, use the table size.</p>
-                </feedback>
-            </choice>
-
-            <choice>
-                <statement>
-                    <p>117, 114, 108, 121, 105, 99, __, __, 97, 100, 113</p>
-                </statement>
-                <feedback>
-                    <p>Be careful to use modulo not integer division.</p>
-                </feedback>
-            </choice>
-</choices>
-
-    </exercise>
+            
             
         </subsection>
         <subsection xml:id="search-hash_implementing-the-map-abstract-data-type">
@@ -1109,6 +1014,102 @@ print(H[99])
                 If we are using chaining, the average number of comparisons is
                 <math>1 + \frac {\lambda}{2}</math> for the successful case, and simply
                 <math>\lambda</math> comparisons if the search is unsuccessful.</p>
+                <reading-questions xml:id="rq-hashing-search">
+                    <exercise label="HASH_1">
+                        <statement>
+                    
+                                <p>In a hash table of size 13 which index positions would the following two keys map to?  27,  130</p>
+                    
+                        </statement>
+                    <choices>
+                    
+                            <choice>
+                                <statement>
+                                    <p>1, 10</p>
+                                </statement>
+                                <feedback>
+                                    <p>Be careful to use modulo not integer division</p>
+                                </feedback>
+                            </choice>
+                    
+                            <choice>
+                                <statement>
+                                    <p>13, 0</p>
+                                </statement>
+                                <feedback>
+                                    <p>Don't divide by two, use the modulo operator.</p>
+                                </feedback>
+                            </choice>
+                    
+                            <choice correct="yes">
+                                <statement>
+                                    <p>1, 0</p>
+                                </statement>
+                                <feedback>
+                                    <p>27 % 13 == 1 and 130 % 13 == 0</p>
+                                </feedback>
+                            </choice>
+                    
+                            <choice>
+                                <statement>
+                                    <p>2, 3</p>
+                                </statement>
+                                <feedback>
+                                    <p>Use the modulo operator</p>
+                                </feedback>
+                            </choice>
+                    </choices>
+                    
+                    </exercise>
+                    
+                    <exercise label="HASH_2">
+                        <statement>
+                    
+                                <p>Suppose you are given the following set of keys to insert into a hash table that holds exactly 11 values:  113 , 117 , 97 , 100 , 114 , 108 , 121 , 105 , 99 Which of the following best demonstrates the contents of the hash table after all the keys have been inserted using linear probing?</p>
+                    
+                        </statement>
+                    <choices>
+                    
+                            <choice>
+                                <statement>
+                                    <p>100, __, __, 113, 114, 105, 121, 117, 97, 108, 99</p>
+                                </statement>
+                                <feedback>
+                                    <p>It looks like you may have been doing modulo 2 arithmentic.  You need to use the hash table size as the modulo value.</p>
+                                </feedback>
+                            </choice>
+                    
+                            <choice correct="yes">
+                                <statement>
+                                    <p>121, 100, 99, 113, 114, __, 105, 117, __, 97, 108</p>
+                                </statement>
+                                <feedback>
+                                    <p>Using modulo 11 arithmetic and linear probing gives these values</p>
+                                </feedback>
+                            </choice>
+                    
+                            <choice>
+                                <statement>
+                                    <p>100, 113, 117, 97, 14, 108, 121, 105, 99, __, __</p>
+                                </statement>
+                                <feedback>
+                                    <p>It looks like you are using modulo 10 arithmetic, use the table size.</p>
+                                </feedback>
+                            </choice>
+                    
+                            <choice>
+                                <statement>
+                                    <p>117, 114, 108, 121, 105, 99, __, __, 97, 100, 113</p>
+                                </statement>
+                                <feedback>
+                                    <p>Be careful to use modulo not integer division.</p>
+                                </feedback>
+                            </choice>
+                    </choices>
+                    
+                    </exercise>
+                    </reading-questions>
         </subsection>
+ 
     </section>
     

--- a/pretext/SearchHash/Hashing.ptx
+++ b/pretext/SearchHash/Hashing.ptx
@@ -481,7 +481,7 @@ int main() {
                 the analysis for hashing at the end of this section.</p>
             <note>
                 <title>Self Check</title>
-
+            </note>
     <exercise label="HASH_1">
         <statement>
 
@@ -575,7 +575,7 @@ int main() {
 </choices>
 
     </exercise>
-            </note>
+            
         </subsection>
         <subsection xml:id="search-hash_implementing-the-map-abstract-data-type">
             <title>Implementing the <c>Map</c> Abstract Data Type</title>

--- a/pretext/SearchHash/TheBinarySearch.ptx
+++ b/pretext/SearchHash/TheBinarySearch.ptx
@@ -301,7 +301,7 @@ main()
                 performing a sequential search from the start may be the best choice.</p>
             <note>
                 <title>Self Check</title>
-
+            </note>
     <exercise label="BSRCH_1">
         <statement>
 
@@ -395,7 +395,7 @@ main()
 </choices>
 
     </exercise>
-            </note>
+            
         </subsection>
     </section>
 

--- a/pretext/SearchHash/TheBinarySearch.ptx
+++ b/pretext/SearchHash/TheBinarySearch.ptx
@@ -299,13 +299,11 @@ main()
                 search many times, the cost of the sort is not so significant. However,
                 for large lists, sorting even once can be so expensive that simply
                 performing a sequential search from the start may be the best choice.</p>
-            <note>
-                <title>Self Check</title>
-            </note>
+<reading-questions xml:id="rq-binary-search">
     <exercise label="BSRCH_1">
         <statement>
 
-                <p>Q-7: Suppose you have the following sorted list [3, 5, 6, 8, 11, 12, 14, 15, 17, 18] and are using the recursive binary search algorithm.  Which group of numbers correctly shows the sequence of comparisons used to find the key 8.</p>
+                <p>Suppose you have the following sorted list [3, 5, 6, 8, 11, 12, 14, 15, 17, 18] and are using the recursive binary search algorithm.  Which group of numbers correctly shows the sequence of comparisons used to find the key 8.</p>
 
         </statement>
 <choices>
@@ -352,7 +350,7 @@ main()
     <exercise label="BSRCH_2">
         <statement>
 
-                <p>Q-8: Suppose you have the following sorted list [3, 5, 6, 8, 11, 12, 14, 15, 17, 18] and are using the recursive binary search algorithm.  Which group of numbers correctly shows the sequence of comparisons used to search for the key 16?</p>
+                <p>Suppose you have the following sorted list [3, 5, 6, 8, 11, 12, 14, 15, 17, 18] and are using the recursive binary search algorithm.  Which group of numbers correctly shows the sequence of comparisons used to search for the key 16?</p>
 
         </statement>
 <choices>
@@ -395,7 +393,7 @@ main()
 </choices>
 
     </exercise>
-            
+</reading-questions>            
         </subsection>
     </section>
 

--- a/pretext/SearchHash/TheSequentialSearch.ptx
+++ b/pretext/SearchHash/TheSequentialSearch.ptx
@@ -279,7 +279,7 @@ int main() {
             </tabular></table>
             <note>
                 <title>Self Check</title>
-
+            </note>
     <exercise label="question_SRCH_1">
         <statement>
 
@@ -373,7 +373,7 @@ int main() {
 </choices>
 
     </exercise>
-            </note>
+            
         </subsection>
     </section>
 

--- a/pretext/SearchHash/TheSequentialSearch.ptx
+++ b/pretext/SearchHash/TheSequentialSearch.ptx
@@ -168,9 +168,7 @@ int main() {
                 immediately. <xref ref="lst-seqsearchpython2"/> shows this variation of the
                 sequential search function.</p>
 
-        <exercise>
-            <statement>
-    <p>Q-3: For the following unordered sequential list: {0, 1, 2, 13, 8, 19, 17, 32, 42}, searching for <BlankNode/> would produce the best case scenario, and searching for <BlankNode/> would produce the worst case scenario. <var/>  <var/>  </p></statement><setup><var><condition number="[0, 0]"><feedback><p>Correct! 0 is at the beginning of the list wich would provide the best case of O(1)</p></feedback></condition><condition string="^\s*.*\s*$"><feedback><p>No! try again, only one value place in this list will produce the best case.</p></feedback></condition></var><var><condition number="[42, 42]"><feedback><p>Correct! 42 is at the end of the list wich would provide the worst case of O(n)</p></feedback></condition><condition string="^\s*.*\s*$"><feedback><p>No! try again, only one value in this list will produce the worst case.</p></feedback></condition></var></setup></exercise>            
+          
             <figure align="center" xml:id="fig-seqsearch2">
                 <caption>Sequential Search of an Ordered List of Integers</caption>
                     <image source="SearchHash/seqsearch2.png" width="80%">
@@ -277,13 +275,16 @@ int main() {
                     
                 
             </tabular></table>
-            <note>
-                <title>Self Check</title>
-            </note>
+
+<reading-questions xml:id="rq-squential-search">
+
+            <exercise>
+                <statement>
+        <p>For the following unordered sequential list: {0, 1, 2, 13, 8, 19, 17, 32, 42}, searching for <BlankNode/> <var/> would produce the best case scenario, and searching for <BlankNode/> <var/> would produce the worst case scenario.    </p></statement><setup><var><condition number="[0]"><feedback><p>Correct! 0 is at the beginning of the list wich would provide the best case of O(1)</p></feedback></condition><condition string="^\s*.*\s*$"><feedback><p>No! try again, only one value place in this list will produce the best case.</p></feedback></condition></var><var><condition number="[42]"><feedback><p>Correct! 42 is at the end of the list wich would provide the worst case of O(n)</p></feedback></condition><condition string="^\s*.*\s*$"><feedback><p>No! try again, only one value in this list will produce the worst case.</p></feedback></condition></var></setup></exercise>   
     <exercise label="question_SRCH_1">
         <statement>
 
-                <p>Q-6: Suppose you are doing a sequential search of the list [15, 18, 2, 19, 18, 0, 8, 14, 19, 14].  How many comparisons would you need to do in order to find the key 18?</p>
+                <p>Suppose you are doing a sequential search of the list [15, 18, 2, 19, 18, 0, 8, 14, 19, 14].  How many comparisons would you need to do in order to find the key 18?</p>
 
         </statement>
 <choices>
@@ -330,7 +331,7 @@ int main() {
     <exercise label="question_SRCH_2">
         <statement>
 
-                <p>Q-7: Suppose you are doing a sequential search using a program that is enhanced to handle ordered lists more efficiently. When passing the list [3, 5, 6, 8, 11, 12, 14, 15, 17, 18] as a parameter, how many comparisons would you need to do in order to find the key 13?</p>
+                <p>Suppose you are doing a sequential search using a program that is enhanced to handle ordered lists more efficiently. When passing the list [3, 5, 6, 8, 11, 12, 14, 15, 17, 18] as a parameter, how many comparisons would you need to do in order to find the key 13?</p>
 
         </statement>
 <choices>
@@ -373,6 +374,7 @@ int main() {
 </choices>
 
     </exercise>
+</reading-questions>
             
         </subsection>
     </section>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description
<!--- Describe your changes in detail -->
(Update) I fixed all the broken self-check questions across chapter 6. As in the issue described, all of the questions became broken because they were in the Note tag, but what I did is I remove the Note tag. Instead, I put them in the <reading-questions> tag so they will no longer break, and also, they will no longer be in the checkpoint section.
## Related Issue
fix #524 
<!--- This project prefers pull requests related to open issues -->
<!--- If suggesting a change, please discuss it in an issue first -->
<!--- Please link to the issue here: -->

## How Has This Been Tested?
1. Make changes locally.
2. Veryfiy the changes locally.
![image](https://github.com/pearcej/cppds/assets/117699634/e796bd08-5e13-4286-b106-888bfc7bcaee)
![image](https://github.com/pearcej/cppds/assets/117699634/8590c53d-333c-439a-a6c3-1555bf5f4240)
![image](https://github.com/pearcej/cppds/assets/117699634/b4a8aa20-0795-4b95-8679-260f932aa58c)

