### PR TITLE
Fix broken self-check questions across Chapter 7 in cppds-v2

### DIFF
--- a/pretext/Sort/TheBubbleSort.ptx
+++ b/pretext/Sort/TheBubbleSort.ptx
@@ -344,7 +344,7 @@ print(alist)
         <!--print(alist)-->
         <note>
             <title>Self Check</title>
-
+        </note>
     <exercise label="question_sort_1">
         <statement>
 
@@ -392,6 +392,6 @@ print(alist)
 </choices>
 
     </exercise>
-        </note>
+        
     </section>
 

--- a/pretext/Sort/TheInsertionSort.ptx
+++ b/pretext/Sort/TheInsertionSort.ptx
@@ -186,19 +186,12 @@ main()-->
 </raw>
         <note>
             <title>Self Check</title>
-
+        </note>
     <exercise label="question_sort_3">
         <statement>
 
-            <dl>
-                <li>
-                    <title>Q-5:  Suppose you have the following list of numbers to sort:</title>
+        <p>Q-5:  Suppose you have the following list of numbers to sort:[15, 5, 4, 18, 12, 19, 14, 10, 8, 20] which list represents the partially sorted list after three complete passes of insertion sort?</p>
                     
-                        <p>[15, 5, 4, 18, 12, 19, 14, 10, 8, 20] which list represents the partially sorted list after three complete passes of insertion sort?</p>
-                    
-                </li>
-            </dl>
-
         </statement>
 <choices>
 
@@ -240,6 +233,5 @@ main()-->
 </choices>
 
     </exercise>
-        </note>
     </section>
 

--- a/pretext/Sort/TheMergeSort.ptx
+++ b/pretext/Sort/TheMergeSort.ptx
@@ -282,7 +282,7 @@ merge_anim_init = function(divid)
             sets. In the case with using lists in python, the space complexity is <math>O(log n)</math>.</p>
         <note>
             <title>Self Check</title>
-
+        </note>
     <exercise label="question_sort_5">
         <statement>
 
@@ -376,6 +376,5 @@ merge_anim_init = function(divid)
 </choices>
 
     </exercise>
-        </note>
     </section>
 

--- a/pretext/Sort/TheQuickSort.ptx
+++ b/pretext/Sort/TheQuickSort.ptx
@@ -307,7 +307,9 @@ quick_anim_init = function(divid)
             <q>middle</q> value. This will be particularly useful when the original list
             is somewhat sorted to begin with. We leave the implementation of this
             pivot value selection as an exercise.</p>
-
+            <note>
+                <title>Self Check</title>
+            </note>
     <exercise label="question_sort_7">
         <statement>
 

--- a/pretext/Sort/TheSelectionSort.ptx
+++ b/pretext/Sort/TheSelectionSort.ptx
@@ -166,7 +166,7 @@ selection_anim_init = function(divid)
             typically executes faster in benchmark studies.</p>
         <note>
             <title>Self Check</title>
-
+        </note>
     <exercise label="question_sort_2">
         <statement>
 
@@ -214,6 +214,5 @@ selection_anim_init = function(divid)
 </choices>
 
     </exercise>
-        </note>
     </section>
 

--- a/pretext/Sort/TheShellSort.ptx
+++ b/pretext/Sort/TheShellSort.ptx
@@ -240,7 +240,7 @@ main()-->
             at <math>O(n^{\frac {3}{2}})</math>.</p>
         <note>
             <title>Self Check</title>
-
+        </note>
     <exercise label="question_sort_4">
         <statement>
 
@@ -288,6 +288,5 @@ main()-->
 </choices>
 
     </exercise>
-        </note>
     </section>
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description
<!--- Describe your changes in detail -->
I fixed all the broken self-check questions across chapter 7 as in the issue described all of the questions became broken because they were in the Note tag but what I did is I moved the Note tag by itself so that it would not break the questions.
## Related Issue
fix #525 
<!--- This project prefers pull requests related to open issues -->
<!--- If suggesting a change, please discuss it in an issue first -->
<!--- Please link to the issue here: -->

## How Has This Been Tested?
1. Make changes locally.
2. Veryfiy the changes locally.
![image](https://github.com/pearcej/cppds/assets/117699634/2fc5d511-4791-4f07-956d-4c35fc3f418a)
![image](https://github.com/pearcej/cppds/assets/117699634/bb422e79-cc49-4e1d-a9a1-6e3a3b5bf238)
![image](https://github.com/pearcej/cppds/assets/117699634/e77e9d50-9427-498d-80bd-fc1f6e357219)
![image](https://github.com/pearcej/cppds/assets/117699634/61d9e932-bd09-4fa6-ab55-db7574a0bd9a)
![image](https://github.com/pearcej/cppds/assets/117699634/5e76d177-070b-4aa6-8a27-89da8dc29b46)
![image](https://github.com/pearcej/cppds/assets/117699634/39d808d4-9449-40e0-85cf-329f45bcbb28)
