### PR TITLE
Fix broken self-check questions across Chapter 8 in cppds-v2

### DIFF
--- a/pretext/Trees/AVLTreeImplementation.ptx
+++ b/pretext/Trees/AVLTreeImplementation.ptx
@@ -314,11 +314,13 @@ void rebalance(TreeNode *node){
         <p>At this point we have implemented a functional AVL-Tree, unless you need
             the ability to delete a node. We leave the deletion of the node and
             subsequent updating and rebalancing as an exercise for you.</p>
+<reading-questions xml:id="rqs-avl-tree-impl">
+    <title>Reading Question</title>
 
     <exercise label="AVLbalancetree">
         <statement>
 
-        <p>Q-1: How does adding a new leaf in an AVL Tree affect the parent's balance factor?</p>
+        <p>How does adding a new leaf in an AVL Tree affect the parent's balance factor?</p>
 
         </statement>
 <choices>
@@ -370,5 +372,6 @@ void rebalance(TreeNode *node){
 </choices>
 
     </exercise>
+</reading-questions>
     </section>
 

--- a/pretext/Trees/BinaryHeapImplementation.ptx
+++ b/pretext/Trees/BinaryHeapImplementation.ptx
@@ -456,9 +456,14 @@ main()
                 time, you will construct a sorting algorithm that uses a heap and sorts
                 a vector in <math>O(n\log{n}))</math> as an exercise at the end of this
                 chapter.</p>
-
+<reading-questions xml:id="rq-binary-heap-implementation">
+    <title>Reading Question</title>
+    
+    
+    
         <exercise>
             <statement>
-    <p>Q-3: What is the vector used in the binary tree in the first image of <xref ref="fig-percdown"/>? Exclude any whitespace. <var/>  </p></statement><setup><var><condition string="^\s*0,9,14,11,17,18,19,21,33,27\s*$"><feedback><p>Is the correct answer!</p></feedback></condition><condition string="^\s*.*9,14,11,17,18,19,21,33,27\s*$"><feedback><p>Remember what has to be at the beginning of the vector to accurately traverse through the binary tree. Look back at chp. 8.9.2.</p></feedback></condition><condition string="^\s*.*\s*$"><feedback><p>Refer to section 8.10.1 and 8.10.2</p></feedback></condition></var></setup></exercise>        </subsection>
+    <p>What is the vector used in the binary tree in the first image of <xref ref="fig-percdown"/>? Exclude any whitespace. <var/>  </p></statement><setup><var><condition string="^\s*0,9,14,11,17,18,19,21,33,27\s*$"><feedback><p>Is the correct answer!</p></feedback></condition><condition string="^\s*.*9,14,11,17,18,19,21,33,27\s*$"><feedback><p>Remember what has to be at the beginning of the vector to accurately traverse through the binary tree. Look back at chp. 8.9.2.</p></feedback></condition><condition string="^\s*.*\s*$"><feedback><p>Refer to section 8.10.1 and 8.10.2</p></feedback></condition></var></setup></exercise> </reading-questions>
+</subsection>
     </section>
 

--- a/pretext/Trees/ExamplesofTrees.ptx
+++ b/pretext/Trees/ExamplesofTrees.ptx
@@ -89,11 +89,11 @@
             <c>&lt;html&gt;</c> and the last is <c>&lt;/html&gt;</c> All the rest of the tags in the
             page are inside the pair. If you check, you will see that this nesting
             property is true at all levels of the tree.</p>
-
+<reading-questions xml:id="rq-example-tree">
+    <title>Reading Question</title>
     <exercise label="treeProperties">
         <statement>
-
-        <p>Q-1: Which of the following are properties of a tree?</p>
+        <p>Which of the following are properties of a tree?</p>
 
         </statement>
 <choices>
@@ -136,5 +136,6 @@
 </choices>
 
     </exercise>
+</reading-questions>
     </section>
 

--- a/pretext/Trees/NodesandReferences.ptx
+++ b/pretext/Trees/NodesandReferences.ptx
@@ -299,11 +299,13 @@ main()
         </input>
     </program>
             </TabNode></exercise>
+<reading-questions xml:id="rq-nodes-and-references">
+    <title>Reading Question</title>
 
     <exercise label="treeLike">
         <statement>
 
-        <p>Q-3: Which data structure resembles the above implementation of a tree?</p>
+        <p>Which data structure resembles the above implementation of a tree?</p>
 
         </statement>
 <choices>
@@ -346,5 +348,6 @@ main()
 </choices>
 
     </exercise>
+</reading-questions>
     </section>
 

--- a/pretext/Trees/NodesandReferences.ptx
+++ b/pretext/Trees/NodesandReferences.ptx
@@ -298,7 +298,7 @@ def main():
 main()
         </input>
     </program>
-            </TabNode></exercise>
+            </TabNode>
 <reading-questions xml:id="rq-nodes-and-references">
     <title>Reading Question</title>
     <exercise label="treeLike">

--- a/pretext/Trees/ParseTree.ptx
+++ b/pretext/Trees/ParseTree.ptx
@@ -489,13 +489,17 @@ def evaluate(parseTree):
             the top level <c>'+'</c> operator and all that is left to do is finish the
             call to <c>operator.add(3,20)</c>. The result of the evaluation of the
             entire expression tree for <math>(3 + (4 * 5))</math> is 23.</p>
+<reading-questions xml:id="rq-parse-tree">
+    <title>Reading Question</title>
+    
 
 <exercise label="drawParseTree">
     <statement>
-        <p>Q-3: Take a moment and draw the parse tree for the expression (2*12/6+3)-17+2*0.
+        <p>Take a moment and draw the parse tree for the expression (2*12/6+3)-17+2*0.
             You do not need to write anything here.</p>
 
     </statement>
-</exercise> 
+</exercise>
+</reading-questions> 
     </section>
 

--- a/pretext/Trees/SearchTreeAnalysis.ptx
+++ b/pretext/Trees/SearchTreeAnalysis.ptx
@@ -44,8 +44,9 @@
             But remember that the worst-case scenario to find the successor is also
             just the height of the tree which means that you would simply double the
             work. Since doubling is a constant factor it does not change worst case</p>
-
-        <exercise>
+<reading-questions xml:id="rq-search-tree">
+    <title>Reading Question</title>
+<exercise>
             <statement>
-    <p>Q-1: The worst-case performance of the del function is O(<BlankNode/>)? <var/>  </p></statement><setup><var><condition string="^\s*n\s*$"><feedback><p>Is the correct answer!</p></feedback></condition><condition string="^\s*.*\s*$"><feedback><p>Read carefully the restrictions of the the functions</p></feedback></condition></var></setup></exercise>    </section>
+    <p>The worst-case performance of the del function is O(<BlankNode/><var/>)?   </p></statement><setup><var><condition string="^\s*n\s*$"><feedback><p>Is the correct answer!</p></feedback></condition><condition string="^\s*.*\s*$"><feedback><p>Read carefully the restrictions of the the functions</p></feedback></condition></var></setup></exercise>  </reading-questions>  </section>
 

--- a/pretext/Trees/SearchTreeImplementation.ptx
+++ b/pretext/Trees/SearchTreeImplementation.ptx
@@ -1120,7 +1120,7 @@ def main():
 main()
         </input>
     </program>
-            </TabNode></exercise>
+            </TabNode>
 
             <reading-questions xml:id="rq-search-tree">
                 <title>Reading Questions</title>

--- a/pretext/Trees/SearchTreeImplementation.ptx
+++ b/pretext/Trees/SearchTreeImplementation.ptx
@@ -41,52 +41,7 @@
             <c>BinarySearchTree</c> class constructor along with a few other
             miscellaneous functions is shown in <xref ref="lst-bst1"/>.</p>
 
-    <exercise label="question1_2">
-        <statement>
-
-        <p>Q-1: How many children can a node have in a binary search tree?</p>
-
-        </statement>
-<choices>
-
-            <choice>
-                <statement>
-                    <p>At least 4</p>
-                </statement>
-                <feedback>
-                    <p>Incorrect. Refer back to the definition of a binary search tree.</p>
-                </feedback>
-            </choice>
-
-            <choice>
-                <statement>
-                    <p>At most 3</p>
-                </statement>
-                <feedback>
-                    <p>Incorrect.</p>
-                </feedback>
-            </choice>
-
-            <choice>
-                <statement>
-                    <p>At least 1</p>
-                </statement>
-                <feedback>
-                    <p>Incorrect, it has a limit.</p>
-                </feedback>
-            </choice>
-
-            <choice correct="yes">
-                <statement>
-                    <p>At most 2</p>
-                </statement>
-                <feedback>
-                    <p>Correct!</p>
-                </feedback>
-            </choice>
-</choices>
-
-    </exercise>
+    
         
         <p xml:id="trees_lst-bst1" names="lst_bst1"><term>Listing 1</term></p>
         <pre>class BinarySearchTree{
@@ -262,44 +217,7 @@ void _put(int key, string val, TreeNode *currentNode){
         <note>
             <title>Self Check</title>
 
-    <exercise label="bst_1">
-        <statement>
-
-            <p>Q-2: Which of the trees shows a correct binary search tree given that the keys were
-                inserted in the following order 5, 30, 2, 40, 25, 4.</p>
-
-        </statement>
-<choices>
-
-            <choice>
-                <statement>
-                    <p><image source="../_static/bintree_a.png" width="50%"><description><p/></description></image></p>
-                </statement>
-                <feedback>
-                    <p>Remember, starting at the root keys less than the root must be in the left subtree, while keys greater than the root go in the right subtree.</p>
-                </feedback>
-            </choice>
-
-            <choice correct="yes">
-                <statement>
-                    <p><image source="../_static/bintree_b.png" width="50%"><description><p/></description></image></p>
-                </statement>
-                <feedback>
-                    <p>good job.</p>
-                </feedback>
-            </choice>
-
-            <choice>
-                <statement>
-                    <p><image source="../_static/bintree_c.png" width="50%"><description><p/></description></image></p>
-                </statement>
-                <feedback>
-                    <p>This looks like a binary tree that satisfies the full tree property needed for a heap.</p>
-                </feedback>
-            </choice>
-</choices>
-
-    </exercise>
+    
         </note>
         <p>Once the tree is constructed, the next task is to implement the
             retrieval of a value for a given key. The <c>get</c> method is even easier
@@ -1203,5 +1121,96 @@ main()
         </input>
     </program>
             </TabNode></exercise>
+
+            <reading-questions xml:id="rq-search-tree">
+                <title>Reading Questions</title>
+                
+                <exercise label="question1_2">
+                    <statement>
+            
+                    <p>How many children can a node have in a binary search tree?</p>
+            
+                    </statement>
+            <choices>
+            
+                        <choice>
+                            <statement>
+                                <p>At least 4</p>
+                            </statement>
+                            <feedback>
+                                <p>Incorrect. Refer back to the definition of a binary search tree.</p>
+                            </feedback>
+                        </choice>
+            
+                        <choice>
+                            <statement>
+                                <p>At most 3</p>
+                            </statement>
+                            <feedback>
+                                <p>Incorrect.</p>
+                            </feedback>
+                        </choice>
+            
+                        <choice>
+                            <statement>
+                                <p>At least 1</p>
+                            </statement>
+                            <feedback>
+                                <p>Incorrect, it has a limit.</p>
+                            </feedback>
+                        </choice>
+            
+                        <choice correct="yes">
+                            <statement>
+                                <p>At most 2</p>
+                            </statement>
+                            <feedback>
+                                <p>Correct!</p>
+                            </feedback>
+                        </choice>
+            </choices>
+            
+                </exercise>
+                <exercise label="bst_1">
+                    <statement>
+            
+                        <p>Which of the trees shows a correct binary search tree given that the keys were
+                            inserted in the following order 5, 30, 2, 40, 25, 4.</p>
+            
+                    </statement>
+            <choices>
+            
+                        <choice>
+                            <statement>
+                                <p><image source="../_static/bintree_a.png" width="50%"><description><p/></description></image></p>
+                            </statement>
+                            <feedback>
+                                <p>Remember, starting at the root keys less than the root must be in the left subtree, while keys greater than the root go in the right subtree.</p>
+                            </feedback>
+                        </choice>
+            
+                        <choice correct="yes">
+                            <statement>
+                                <p><image source="../_static/bintree_b.png" width="50%"><description><p/></description></image></p>
+                            </statement>
+                            <feedback>
+                                <p>good job.</p>
+                            </feedback>
+                        </choice>
+            
+                        <choice>
+                            <statement>
+                                <p><image source="../_static/bintree_c.png" width="50%"><description><p/></description></image></p>
+                            </statement>
+                            <feedback>
+                                <p>This looks like a binary tree that satisfies the full tree property needed for a heap.</p>
+                            </feedback>
+                        </choice>
+            </choices>
+            
+                </exercise>
+                
+            </reading-questions>
+            
     </section>
 

--- a/pretext/Trees/TreeTraversals.ptx
+++ b/pretext/Trees/TreeTraversals.ptx
@@ -368,6 +368,10 @@ def printexp(tree):
             parentheses around each number. While not incorrect, the parentheses are
             clearly not needed. In the exercises at the end of this chapter you are
             asked to modify the <c>printexp</c> function to remove this set of parentheses.</p>
+<reading-questions xml:id="rq-tree-traversal">
+    <title>Reading Questions</title>
+    
+    
 
 <exercise label="treeTraversalTypes">
     <statement><p>Drag the tree traversal to its corresponding pattern.</p></statement>
@@ -376,7 +380,7 @@ def printexp(tree):
     <exercise label="question1_1">
         <statement>
 
-        <p>Q-2: If you print out the data at each node, what would be the result of using
+        <p>If you print out the data at each node, what would be the result of using
             the preorder traversal method on <xref ref="fig-booktree"/>?</p>
 
         </statement>
@@ -414,5 +418,6 @@ Section 2.1, Section 2.2.1, Section 2.2.2, Section 2.2, Chapter 2, Book</p>
 </choices>
 
     </exercise>
+</reading-questions>
     </section>
 

--- a/pretext/Trees/VocabularyandDefinitions.ptx
+++ b/pretext/Trees/VocabularyandDefinitions.ptx
@@ -131,11 +131,15 @@
         nodes than that, but we do not know unless we look deeper into the tree.</p>
     
     <figure align="center" xml:id="fig-recursivetree"><caption xmlns:c="https://www.sphinx-doc.org/" xmlns:changeset="https://www.sphinx-doc.org/" xmlns:citation="https://www.sphinx-doc.org/" xmlns:cpp="https://www.sphinx-doc.org/" xmlns:index="https://www.sphinx-doc.org/" xmlns:js="https://www.sphinx-doc.org/" xmlns:math="https://www.sphinx-doc.org/" xmlns:py="https://www.sphinx-doc.org/" xmlns:rst="https://www.sphinx-doc.org/" xmlns:std="https://www.sphinx-doc.org/">Figure 4: A recursive Definition of a tree</caption><image source="Trees/Figures/TreeDefRecursive.png" width="50%" alt="image"/></figure>
-
-<exercise label="treeDefinition">
-<statement>
-    <p>Q-1: In your own words, define a tree relative to the first definition provided above.</p>
-
-</statement>
-</exercise> 
+<reading-questions xml:id="rq-vocabulary-tree">
+    <title>
+        Reading Question
+    </title>  
+<exercise>
+        <statement>
+            <p>In your own words, define a tree relative to the first definition provided above.</p>
+        </statement> 
+        <response/>
+    </exercise>
+</reading-questions> 
 </section>


### PR DESCRIPTION

# Description
<!--- Describe your changes in detail -->
I fixed all the broken self-check questions across chapter 8. As in the issue described, all of the questions became broken because they were in the Note tag, but what I did is I remove the Note tag. Instead, I put them in the <reading-questions> tag so they will no longer break, and also, they will no longer be in the checkpoint section.
## Related Issue
fix #526
<!--- This project prefers pull requests related to open issues -->
<!--- If suggesting a change, please discuss it in an issue first -->
<!--- Please link to the issue here: -->

## How Has This Been Tested?
1. Make changes locally.
2. Veryfiy the changes locally.
![image](https://github.com/pearcej/cppds/assets/117699634/75429ceb-abb0-4281-904a-9c363268758c)
![image](https://github.com/pearcej/cppds/assets/117699634/97c65bc9-d376-4bcc-a28a-5c163a00e272)
![image](https://github.com/pearcej/cppds/assets/117699634/058c010c-7672-4e81-aad6-1fcff4868c81)
