### PR TITLE
Fix broken self-check questions across Chapter 9 in cppds-v2 

### DIFF
--- a/pretext/Graphs/DijkstrasAlgorithm.ptx
+++ b/pretext/Graphs/DijkstrasAlgorithm.ptx
@@ -138,13 +138,16 @@ def dijkstra(aGraph,start):
             variations of the algorithm allow each router to discover the graph as
             they go. One such algorithm that you may want to read about is called
             the <q>distance vector</q> routing algorithm.</p>
-        <note>
-            <title>Self Check</title>
-
+        <reading-questions xml:id="rq-dijkstras-algo">
+            <title>Reading Question</title>
+            
+            
+            
+        
     <exercise label="dijkstraq1">
         <statement>
 
-            <p>Q-1: What purpose does the Priority Queue in the Dijkstra's algorithm serve?</p>
+            <p>What purpose does the Priority Queue in the Dijkstra's algorithm serve?</p>
 
         </statement>
 <choices>
@@ -187,6 +190,6 @@ def dijkstra(aGraph,start):
 </choices>
 
     </exercise>
-        </note>
-    </section>
+</reading-questions>  
+  </section>
 

--- a/pretext/Graphs/ImplementingKnightsTour.ptx
+++ b/pretext/Graphs/ImplementingKnightsTour.ptx
@@ -147,13 +147,15 @@ def knightTour(n,path,u,limit):
                 <description>Image depicting a graph overlaid on an 8x8 chessboard grid representing a complete Knight's Tour. The nodes, numbered from 0 to 63, correspond to the squares of the chessboard. Lines crisscross the grid, mapping the knight's moves in a sequential path that visits each square exactly once. The complex web of lines indicates the knight's route, creating a Hamiltonian circuit where the start and end points are connected. Captioned 'Figure 11: A Complete Tour of the Board'.</description>
                 </image>
             </figure>
-        <note>
-            <title>Self Check</title>
+      <reading-questions xml:id="rq-knights-tour-imp">
+        <title>Reading Questions</title>
+        
+        
 
     <exercise label="KnightsTour">
         <statement>
 
-            <p>Q-1: True/False: The Knight's Tour Graph contains as many vertices as there are tiles on a chessboard.</p>
+            <p>True/False: The Knight's Tour Graph contains as many vertices as there are tiles on a chessboard.</p>
 
         </statement>
 <choices>
@@ -200,6 +202,7 @@ def knightTour(n,path,u,limit):
 <cline><area>else:</area>:</cline>
 <cline>    <area>done = True</area>:</cline>
 <cline><area>return done</area>:</cline>
-</areas></exercise>        </note>
+</areas></exercise>        </reading-questions>  
+      
     </section>
 

--- a/pretext/Graphs/KnightsTourAnalysis.ptx
+++ b/pretext/Graphs/KnightsTourAnalysis.ptx
@@ -150,13 +150,16 @@ def orderByAvail(n):
     resList.sort(key=lambda x: x[0])
     return [y[1] for y in resList]
 </input></program>
-        <note>
-            <title>Self Check</title>
+        <reading-questions xml:id="rq-knights-tour-impl">
+           <title>Reading Question</title>
+           
+            
+       
 
     <exercise label="knightO">
         <statement>
 
-            <p>Q-2: What is the big O of the Knight's Tour function?</p>
+            <p>What is the big O of the Knight's Tour function?</p>
 
         </statement>
 <choices>
@@ -199,6 +202,6 @@ def orderByAvail(n):
 </choices>
 
     </exercise>
-        </note>
+</reading-questions>
     </section>
 

--- a/pretext/Graphs/PrimsSpanningTreeAlgorithm.ptx
+++ b/pretext/Graphs/PrimsSpanningTreeAlgorithm.ptx
@@ -172,18 +172,22 @@ def prim(G,start):
                 <description>This image shows the final step of Prim's algorithm where the minimum spanning tree is completed. All the nodes labeled from A to G are connected with the shortest paths indicated by the edge weights. The distances from the starting node are labeled next to each node with the letter 'd' followed by the distance value. The priority queue (PQ) is empty, indicating that all nodes have been visited and the algorithm is complete.</description>
                 </image>
             </figure>
-        <note>
-            <title>Self Check</title>
+       
+
+            <reading-questions xml:id="rq-prims-span-tree-algo">
+                <title>
+                    Reading Question
+                </title>
+                
+    <exercise label="primswhims">
+        <statement>
             <figure align="center" xml:id="fig-primsalg">
                 <caption>Tracing Prim's Algorithm</caption>
-                    <image source="Graphs/primsalg.png" width="80%">
+                    <image source="Graphs/primsalg.png" width="50%">
                     <description>Undirected graph with five nodes labeled A to E. Edges connect the nodes with the following weights: A-B with 1, A-D with 4, B-C with 2, C-D with 3, D-E with 6, and C-E with 5, forming a pentagon shape with a cross-connection between B and D.</description>
                     </image>
                 </figure>
-    <exercise label="primswhims">
-        <statement>
-
-            <p>Q-1: Beginning at node E, how will Prim's algorithm span across the graph?</p>
+            <p>Beginning at node E, how will Prim's algorithm span across the graph?</p>
 
         </statement>
 <choices>
@@ -226,6 +230,6 @@ def prim(G,start):
 </choices>
 
     </exercise>
-        </note>
-    </section>
+</reading-questions>
+</section>
 

--- a/pretext/Graphs/TheGraphAbstractDataType.ptx
+++ b/pretext/Graphs/TheGraphAbstractDataType.ptx
@@ -35,9 +35,25 @@
             described above. There are two well-known implementations of a graph,
             the <idx>adjacency matrix</idx><term>adjacency matrix</term> and the <idx>adjacency list</idx><term>adjacency list</term>. We will explain
             both of these options, and then implement one as a Python class.</p>
-
+<reading-questions xml:id="rq-graph-adt">
+    <title>
+Reading Question
+    </title>
 <exercise label="gadt">
     <statement><p>Drag and drop each graph abstract data type to its corresponding definition.</p></statement>
     <feedback><p>This is feedback.</p></feedback>
-<matches><match order="1"><premise>Graph()</premise><response>creates a new, empty graph.</response></match><match order="2"><premise>addVertex(vert)</premise><response>adds an instance of Vertex to the graph.</response></match><match order="3"><premise>addEdge(fromVert, toVert)</premise><response>Adds a new, directed edge to the graph that connects two vertices.</response></match><match order="4"><premise>addEdge(fromVert, toVert, weight)</premise><response>Adds a new, weighted, directed edge to the graph that connects two vertices.</response></match><match order="5"><premise>getVertex(vertKey)</premise><response>finds the vertex in the graph named vertKey.</response></match><match order="6"><premise>getVertices()</premise><response>returns the list of all vertices in the graph.</response></match><match order="7"><premise>in</premise><response>returns True for a statement of the form vertex in graph, if the given vertex is in the graph, False otherwise.</response></match></matches></exercise>    </section>
+<matches><match order="1"><premise>Graph()</premise><response>creates a new, empty graph.</response></match>
+<match order="2"><premise>addVertex(vert)</premise><response>adds an instance of Vertex to the graph.</response></match>
+<match order="3"><premise>addEdge(fromVert, toVert)</premise><response>Adds a new, directed edge to the graph that connects two vertices.</response></match></matches>
+</exercise>
+
+<exercise label="gadt1">
+    <statement><p>Drag and drop each graph abstract data type to its corresponding definition.</p></statement>
+    <feedback><p>This is feedback.</p></feedback>
+<matches><match order="1"><premise>addEdge(fromVert, toVert, weight)</premise><response>Adds a new, weighted, directed edge to the graph that connects two vertices.</response></match>
+    <match order="2"><premise>getVertex(vertKey)</premise><response>finds the vertex in the graph named vertKey.</response></match><match order="6"><premise>getVertices()</premise><response>returns the list of all vertices in the graph.</response></match><match order="3"><premise>in</premise><response>returns True for a statement of the form vertex in graph, if the given vertex is in the graph, False otherwise.</response></match></matches>
+
+</exercise>
+</reading-questions>
+</section>
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description
<!--- Describe your changes in detail -->
I fixed all the broken self-check questions across chapter 9. As in the issue described, all of the questions became broken because they were in the Note tag, but what I did is I remove the Note tag. Instead, I put them in the tag so they will no longer break, and also, they will no longer be in the checkpoint section.
## Related Issue
<!--- This project prefers pull requests related to open issues -->
<!--- If suggesting a change, please discuss it in an issue first -->
<!--- Please link to the issue here: -->
fix #527 
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
1. Make changes locally.
2. Veryfiy the changes locally.
![image](https://github.com/pearcej/cppds/assets/117699634/b13332a9-f03c-451a-9743-1ec24a1d0b9c)
![image](https://github.com/pearcej/cppds/assets/117699634/98525905-efd6-4fcb-bc58-20aecf5ffb65)
![image](https://github.com/pearcej/cppds/assets/117699634/9874ff5d-e019-4a2d-8d6b-f434626804bc)


