### PR TITLE
Fixed The 4 Missing Cross-References In 9.5 For Issue #586

### DIFF
--- a/pretext/Graphs/AnAdjacencyList.ptx
+++ b/pretext/Graphs/AnAdjacencyList.ptx
@@ -8,7 +8,7 @@
             a dictionary rather than a list where the dictionary keys are the
             vertices, and the values are the weights. <xref ref="fig-adjlist"/>
             illustrates the adjacency list representation for the graph in
-            <xref ref="graphs_vocabularyand-definitions"/>.</p>
+            <xref ref="fig-dgsimple" text="section Vocabulary and Definitions"/>.</p>
         <figure align="center" xml:id="fig-adjlist">
             <caption>Three Types of Logic Gates</caption>
                 <image source="Graphs/adjlist.png" width="80%">

--- a/pretext/Graphs/AnAdjacencyMatrix.ptx
+++ b/pretext/Graphs/AnAdjacencyMatrix.ptx
@@ -7,7 +7,7 @@
             there is an edge from vertex <m>v</m> to vertex <m>w</m>. When two
             vertices are connected by an edge, we say that they are <idx>adjacent</idx><term>adjacent</term>.
             <xref ref="fig-adjmat"/> illustrates the adjacency matrix for the graph in
-            <xref ref="graphs_vocabularyand-definitions"/>. A value in a cell represents the weight of the
+            <xref ref="fig-dgsimple" text="section Vocabulary and Definitions"/>. A value in a cell represents the weight of the
             edge from vertex <m>v</m> to vertex <m>w</m>.</p>
         <figure align="center" xml:id="fig-adjmat">
             <caption>An Adjacency Matrix Representation for a Graph</caption>

--- a/pretext/Graphs/Implementation.ptx
+++ b/pretext/Graphs/Implementation.ptx
@@ -1,7 +1,7 @@
 <section xml:id="graphs_implementation">
         <title>Implementation</title>
         <p>Using a map, or dictionaries in Python, it is easy to implement the adjacency list. In our implementation of the Graph abstract data type we will
-            create two classes (see <xref ref="lst-vertex"/> and <xref ref="lst-graph"/>), <c>Graph</c>, which holds the master list of vertices,
+            create two classes (see <xref ref="graphs_lst-vertex" text="section Implementation"/> 1 and <xref ref="graphs_lst-graph" text="section Implementation"/> 2), <c>Graph</c>, which holds the master list of vertices,
             and <c>Vertex</c>, which will represent each vertex in the graph.</p>
         <p>Each <c>Vertex</c> uses a map to keep track of the vertices to which
             it is connected, and the weight of each edge. This map is called
@@ -140,13 +140,13 @@ ostream &amp;operator&lt;&lt;(ostream &amp;stream, Graph &amp;grph) {
     return stream;
 }</pre>
         <p>Using the <c>Graph</c> and <c>Vertex</c> classes just defined, the following
-            Python session creates the graph in <xref ref="graphs_vocabularyand-definitions"/>. First we
+            Python session creates the graph in <xref ref="fig-dgsimple" text="section Vocabulary and Definitions"/>. First we
             create six vertices numbered 0 through 5. Then we display the vertex
             dictionary. Notice that for each key 0 through 5 we have created an
             instance of a <c>Vertex</c>. Next, we add the edges that connect the
             vertices together. Finally, a nested loop verifies that each edge in the
             graph is properly stored. You should check the output of the edge list
-            at the end of this session against <xref ref="graphs_vocabularyand-definitions"/>.</p>
+            at the end of this session against <xref ref="fig-dgsimple" text="section Vocabulary and Definitions"/>.</p>
         <TabNode tabname="C++" tabnode_options="{'subchapter': 'Implementation', 'chapter': 'Graphs', 'basecourse': 'cppds', 'optional': '', 'optclass': '', 'tabname': 'C++'}">
 
     <program xml:id="graph_implementation_cpp" interactive="activecode" language="cpp">


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Fixed The 4 Missing Cross-References For Issue #586
# Description
<!--- Describe your changes in detail -->
I fixed the reference IDs within the code.  However, the references to the listings are referred to as paragraphs in the text because that is their classification in the code but, they still link to the correct portion of the section.
## Related Issue
<!--- This project prefers pull requests related to open issues -->
<!--- If suggesting a change, please discuss it in an issue first -->
<!--- Please link to the issue here: -->
https://github.com/pearcej/cppds/issues/586
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
I built the changes in my localhost and @moisedk reviewed them.