### PR TITLE
Fixed issue 480

### DIFF
--- a/_sources/Introduction/Graphics.rst
+++ b/_sources/Introduction/Graphics.rst
@@ -241,7 +241,6 @@ See if you can match each method description with their names!
 
 .. dragndrop:: cturtle_dnd_1
     :optional:
-
     :match_1: turn to the left.|||turtle.left
     :match_2: turn to the left.|||turtle.right
     :match_3: pick pen up.|||turtle.penup

--- a/pretext/Introduction/Glossary.ptx
+++ b/pretext/Introduction/Glossary.ptx
@@ -5,7 +5,7 @@
                 <gi>
                     <title>abstract data type/ADT</title>
                     
-                        <p>A mathematical model for data.</p>
+                        <p>A mathematical model for data. </p>
                     
                 </gi>
                 <gi>

--- a/pretext/Introduction/Glossary.ptx
+++ b/pretext/Introduction/Glossary.ptx
@@ -15,6 +15,24 @@
                     
                 </gi>
                 <gi>
+                    <title>Child Class</title>
+                    
+                        <p>inherit characteristic data and/or behaviors from a parent class</p>
+                    
+                </gi>
+                <gi>
+                    <title>Parent Class</title>
+                    
+                        <p>A class that has been extended by another existing class</p>
+                    
+                </gi>
+                <gi>
+                    <title>Virtual function</title>
+                    
+                        <p>Member function which is declared within a base class and is overwritten by a derived class</p>
+                    
+                </gi>
+                <gi>
                     <title>access keywords</title>
                     
                         <p>Keywords such as &#8216;'public'', private'', and &#8216;'protected'' that indicates what class properties/behaviors a user can change</p>


### PR DESCRIPTION
 I removed a space in the causing a parsons issue for Activity 1.14.2.3 in cppds. 

# Description
introduction-->Graphics.rst caused both questions and answers to display incorrectly  


## Related Issue
 I removed a space in the causing a parsons issue for Activity 1.14.2.3 in cppds. 

## How Has This Been Tested?
 I removed an extra space in the code and displayed it in my local host and it fixed the issue 
