### PR TITLE
Fixing issue #329: The drag-drop was too long in the Glossary section. 

### DIFF
--- a/_sources/AlgorithmAnalysis/BigONotation.rst
+++ b/_sources/AlgorithmAnalysis/BigONotation.rst
@@ -249,8 +249,7 @@ to see that :math:`T(n)` then follows the quadratic function as
 
 .. admonition:: Self Check
 
-    Write two C++ functions to find the minimum number in an array.  The first function should compare each number to every other number on the array. :math:`O(n^2)`.  The second function should be linear :math:`O(n)`.
-
+    
 
     .. mchoice:: BIGO1
         :answer_a: 3.444

--- a/_sources/Introduction/ObjectOrientedProgrammingDefiningClasses.rst
+++ b/_sources/Introduction/ObjectOrientedProgrammingDefiningClasses.rst
@@ -575,7 +575,7 @@ addition, and then printing our result.
             print(f3)
 
 The addition method works as we desire, but a couple of things
-can be improved. When we use a binary operator like ``+`` we
+can be improved. When we use a binary operator like ``+``. We
 like more symmetry.
 Binary operators can either be members of their
 left-hand argument's class or friend functions.

--- a/_sources/LinearBasic/Glossary.rst
+++ b/_sources/LinearBasic/Glossary.rst
@@ -66,14 +66,23 @@ Matching
     :match_4: first-in first-out (FIFO)|||First item added is also the first removed
     :match_5: linear data structure|||Data structure with elements that have positions relative to each other
     :match_6: palindrome|||String that reads the same forward and backward
-    :match_7: postfix|||Expression notation in which all operators come after the two operands that they work on
+    :match_7: simulation|||Replica of a process or operations 
     :match_8: precedence|||Hierarchy on the order things occur
-    :match_9: prefix|||Expression notation in which all operators precede the two operands that they work on
-    :match_10: queue|||Ordered collection of items where the addition of new items happens at one end and the removal of existing items occurs at the other end
-    :match_11: last-in first-out (LIFO)|||Last item added is also the first removed
-    :match_12: simulation|||Replica of a process or operations
-    :match_13: stack|||Ordered collection of items where the addition of new items and the removal of existing items always takes place at the same end
-    :match_14: fully parenthesized|||Usage of one pair of parentheses for each operator
-    :match_15: infix|||Expression notation in which the operator is in between the two operands that it is working on
+    
+    Match the term with their corresponding definition 
+
+
+Matching
+--------
+
+.. dragndrop:: Matchchap3
+    :feedback: Incorrect
+    :match_1: postfix|||Expression notation in which all operators come after the two operands that they work on
+    :match_2: prefix|||Expression notation in which all operators precede the two operands that they work on
+    :match_3: queue|||Ordered collection of items where the addition of new items happens at one end and the removal of existing items occurs at the other end
+    :match_4: last-in first-out (LIFO)|||Last item added is also the first removed
+    :match_5: stack|||Ordered collection of items where the addition of new items and the removal of existing items always takes place at the same end
+    :match_6: fully parenthesized|||Usage of one pair of parentheses for each operator
+    :match_7: infix|||Expression notation in which the operator is in between the two operands that it is working on
 
     Match the term with their corresponding definition 

--- a/_sources/LinearLinked/DiscussionQuestions.rst
+++ b/_sources/LinearLinked/DiscussionQuestions.rst
@@ -5,15 +5,6 @@
 Discussion Questions
 --------------------
 
-#. Convert the following values to binary using “divide by 2.” Show the
-   stack of remainders.
-
-   -  17
-
-   -  45
-
-   -  96
-
 #. The alternative implementation of the ``Queue`` ADT is to use a list
    such that the rear of the queue is at the end of the list. What would
    this mean for Big-O performance?

--- a/_sources/SearchHash/TheBinarySearch.rst
+++ b/_sources/SearchHash/TheBinarySearch.rst
@@ -350,15 +350,17 @@ performing a sequential search from the start may be the best choice.
 
       Suppose you have the following sorted list [3, 5, 6, 8, 11, 12, 14, 15, 17, 18] and are using the recursive binary search algorithm.  Which group of numbers correctly shows the sequence of comparisons used to find the key 8.
 
-   .. mchoice:: BSRCH_2
-      :correct: d
-      :answer_a: 11, 17, 14, 15
-      :answer_b: 18, 17, 14, 15
-      :answer_c: 14, 12, 17, 15
-      :answer_d: 12, 17, 14, 15
-      :feedback_a:  Looks like you might be guilty of an off-by-one error.  Remember the first position is index 0.
-      :feedback_b:  Remember binary search starts in the middle and halves the list.
-      :feedback_c:  Looks like you might be off by one, be careful that you are calculating the midpont using integer arithmetic.
-      :feedback_d: Binary search starts at the midpoint and halves the list each time. It is done when the list is empty.
+  .. mchoice:: BSRCH_2
+   :correct: e
+   :answer_a: 11, 17, 14, 15
+   :answer_b: 18, 17, 14, 15
+   :answer_c: 14, 12, 17, 15
+   :answer_d: 12, 17, 14, 15
+   :answer_e: None of the above
+   :feedback_a: Looks like you might be guilty of an off-by-one error.  Remember the first position is index 0.
+   :feedback_b: Remember binary search starts in the middle and halves the list.
+   :feedback_c: Looks like you might be off by one, be careful that you are calculating the midpoint using integer arithmetic.
+   :feedback_d: Binary search starts at the midpoint and halves the list each time. It is done when the list is empty.
+   :feedback_e: Correct! The actual sequence of comparisons for searching the key 16 is 11, 15, 17.
 
-      Suppose you have the following sorted list [3, 5, 6, 8, 11, 12, 14, 15, 17, 18] and are using the recursive binary search algorithm.  Which group of numbers correctly shows the sequence of comparisons used to search for the key 16?
+   Suppose you have the following sorted list [3, 5, 6, 8, 11, 12, 14, 15, 17, 18] and are using the recursive binary search algorithm.  Which group of numbers correctly shows the sequence of comparisons used to search for the key 16?

--- a/_sources/Sort/TheBubbleSort.rst
+++ b/_sources/Sort/TheBubbleSort.rst
@@ -314,4 +314,4 @@ to as the **short bubble**.
        :feedback_d: You have been doing an insertion sort, not a bubble sort.
 
        Suppose you have the following array of numbers to sort:
-       [19, 1, 9, 7, 3, 10, 13, 15, 8, 12]. which array represents the partially sorted list after three complete passes of bubble sort?
+       [19, 1, 9, 7, 3, 10, 13, 15, 8, 12]. Which array represents the partially sorted list after three complete passes of bubble sort?

--- a/_sources/Sort/TheBubbleSort.rst
+++ b/_sources/Sort/TheBubbleSort.rst
@@ -314,4 +314,4 @@ to as the **short bubble**.
        :feedback_d: You have been doing an insertion sort, not a bubble sort.
 
        Suppose you have the following array of numbers to sort:
-       [19, 1, 9, 7, 3, 10, 13, 15, 8, 12] which array represents the partially sorted list after three complete passes of bubble sort?
+       [19, 1, 9, 7, 3, 10, 13, 15, 8, 12]. which array represents the partially sorted list after three complete passes of bubble sort?


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description
<!--- Describe your changes in detail -->
I split the table into two tables to make it easier to drag and drop.

## Related Issue
<!--- This project prefers pull requests related to open issues -->
<!--- If suggesting a change, please discuss it in an issue first -->
<!--- Please link to the issue here: -->
#329 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
I rebuilt the book locally to make sure the new changes took place. 
