### PR TITLE
Fixed all the other issues related to issue #654 in chapter 1, cppds2.

### DIFF
--- a/pretext/Introduction/Glossary.ptx
+++ b/pretext/Introduction/Glossary.ptx
@@ -11,13 +11,13 @@
                 <gi>
                     <title>abstraction</title>
                     
-                        <p>Focusing on desired behaviors and properties while disregarding what is irrelevant/unimportant</p>
+                        <p>Focusing on desired behaviors and properties while disregarding what is irrelevant/unimportant.</p>
                     
                 </gi>
                 <gi>
                     <title>access keywords</title>
                     
-                        <p>Keywords such as &#8216;'public'', private'', and &#8216;'protected'' that indicates what class properties/behaviors a user can change</p>
+                        <p>Keywords such as &#8216;'public'', private'', and &#8216;'protected'' that indicates what class properties/behaviors a user can change.</p>
                     
                 </gi>
                 <gi>
@@ -83,7 +83,7 @@
                 <gi>
                     <title>class</title>
                     
-                        <p>A template for creating (instantiating) objects, for providing initial values for state via member variables, and for implementations of behavior via member functions or methods</p>
+                        <p>A template for creating (instantiating) objects, for providing initial values for state via member variables, and for implementations of behavior via member functions or methods.</p>
                     
                 </gi>
                 <gi>
@@ -162,7 +162,7 @@
                 <gi>
                     <title>encapsulation</title>
                     
-                        <p>Hiding the contents of a class except when absolutely necessary</p>
+                        <p>Hiding the contents of a class except when absolutely necessary.</p>
                     
                 </gi>
                 <gi>
@@ -180,7 +180,7 @@
                 <gi>
                     <title>friend function</title>
                     
-                        <p>A function defined outside that class' scope but has access to private and protected members of the class</p>
+                        <p>A function defined outside that class' scope but has access to private and protected members of the class.</p>
                     
                 </gi>
                 <gi>
@@ -222,7 +222,7 @@
                 <gi>
                     <title>inheritance</title>
                     
-                        <p>Sharing/gaining the same behavior as another class</p>
+                        <p>Sharing/gaining the same behavior as another class.</p>
                     
                 </gi>
                 <gi>
@@ -234,7 +234,7 @@
                 <gi>
                     <title>instance</title>
                     
-                        <p>An occurrence of an object</p>
+                        <p>An occurrence of an object.</p>
                     
                 </gi>
                 <gi>
@@ -282,13 +282,13 @@
                 <gi>
                     <title>object attribute</title>
                     
-                        <p>A property of an object that describes what it <q>looks like</q></p>
+                        <p>A property of an object that describes what it <q>looks like</q>.</p>
                     
                 </gi>
                 <gi>
                     <title>object-oriented programming language</title>
                     
-                        <p>Programming language that uses objects to represent data and methods such as C++ and Java</p>
+                        <p>Programming language that uses objects to represent data and methods such as C++ and Java.</p>
                     
                 </gi>
                 <gi>

--- a/pretext/Introduction/Graphics.ptx
+++ b/pretext/Introduction/Graphics.ptx
@@ -794,7 +794,7 @@ int main(){
 <match order="1"><premise>stops filling the shape.</premise><response>turtle.endfill</response></match>
 <match order="2"><premise>change the pen color.</premise><response>turtle.pencolor</response></match>
 <match order="3"><premise>change the pen size.</premise><response> turtle.width</response></match>
-<match order="4"><premise>change the speed</premise><response> turtle.speed</response></match>
+<match order="4"><premise>change the speed.</premise><response> turtle.speed</response></match>
 <match order="5"><premise>move backward.</premise><response> turtle.back</response></match>
 <match order="6"><premise>move forward.</premise><response> turtle.forward</response></match>
 <match order="7"><premise>move to a specific coordinate.</premise><response> turtle.goto</response></match>

--- a/pretext/Introduction/ProgrammingExercises.ptx
+++ b/pretext/Introduction/ProgrammingExercises.ptx
@@ -18,7 +18,7 @@
             </li>
             <li>
                 <p>Implement the remaining relational operators (<c>&gt;</c>,
-                    <c>&gt;=</c>, <c>&lt;</c>, <c>&lt;=</c>, and <c>!=</c>)</p>
+                    <c>&gt;=</c>, <c>&lt;</c>, <c>&lt;=</c>, and <c>!=</c>).</p>
             </li>
             <li>
                 <p>Modify the constructor for the fraction class so that it checks to


### PR DESCRIPTION
Fixed all formatting issues in chapter 1, cppds2 

# Description
The bad format was not only in answer choices but in many sections. Add a period after all the sentences that did not have them, while others in the same section had periods. 

## Related Issue
#654 

## How Has This Been Tested?
Tested in local browser. 
