### PR TITLE
Fixing issue 180

### DIFF
--- a/_sources/Introduction/ObjectOrientedProgrammingDefiningClasses.rst
+++ b/_sources/Introduction/ObjectOrientedProgrammingDefiningClasses.rst
@@ -194,14 +194,14 @@ following figure:
 
     .. image:: Figures/fractions_partsofwhole.png
 
-Since we are using classes to create abstract data types, we should probably discuss the meaning of
-the word "abstract" in this context.
-**Abstraction** in object-oriented programming requires you to focus only on the desired properties
-and behaviors of the objects
-and discard what is unimportant or irrelevant. Hence, if we do not need to think about
-the "parts of a whole" metaphor, then we will not include it in the class. If that metaphor
-is important, then we will include it. For our purposes, we want to think of
-fractions as numbers, so we will not use the "parts of a whole" visual metaphor.
+Because we are using classes to create abstract data types, we should probably
+define the term "abstract" in this context. In object-oriented programming,
+abstraction requires you to focus solely on the desired properties and behaviors of
+the objects, discarding everything else that is unimportant or irrelevant. As a result,
+if we don't need to consider the "parts of a whole" metaphor, we won't cover it in
+class. If the metaphor is important, we will include it. For our purposes, we want to
+think of fractions as numbers, so we will avoid using the "parts of a whole" visual
+metaphor.
 
 The object-oriented principle of **encapsulation** is the notion that we should
 hide the contents of a class, except what is

--- a/_sources/Introduction/ObjectOrientedProgrammingDefiningClasses.rst
+++ b/_sources/Introduction/ObjectOrientedProgrammingDefiningClasses.rst
@@ -408,7 +408,7 @@ stream is changed by the stream operator.
 
             int main() {
                 Fraction myfraction(3, 5);
-                cout << myfraction;
+                cout << myfraction << " is my fraction" << endl;
 
                 return 0;
             }

--- a/_sources/LinearBasic/InfixPrefixandPostfixExpressions.rst
+++ b/_sources/LinearBasic/InfixPrefixandPostfixExpressions.rst
@@ -226,9 +226,9 @@ in the original expression is reversed in the resulting postfix
 expression.
 
 As we process the expression, the operators have to be saved somewhere
-since their corresponding right operands are not seen yet. Also, the
-order of these saved operators may need to be reversed due to their
-precedence. This is the case with the addition and the multiplication in
+since their corresponding right operands are not seen yet. Additionally,
+because of their priority, the order of these saved operators might need
+to be changed, which is the case for multiplication and addition in
 this example. Since the addition operator comes before the
 multiplication operator and has lower precedence, it needs to appear
 after the multiplication operator is used. Because of this reversal of

--- a/_sources/LinearBasic/SimpleBalancedParentheses.rst
+++ b/_sources/LinearBasic/SimpleBalancedParentheses.rst
@@ -92,7 +92,7 @@ this algorithm is shown in :ref:`ActiveCode 1 <lst_parcheck1>`.
       :caption: Solving the Balanced Parentheses Problem
       :language: cpp
 
-      //simple program that checks for missing parantheses
+      //simple program that checks for missing parentheses
       #include <iostream>
       #include <stack>
       #include <string>
@@ -143,7 +143,7 @@ this algorithm is shown in :ref:`ActiveCode 1 <lst_parcheck1>`.
 	   
        #Program that detects if a set of parentheses is complete.
 
-       #simple program that checks for missing parantheses 
+       #simple program that checks for missing parentheses 
        from pythonds.basic.stack import Stack
 
        #returns whether the parentheses in the input are balanced  

--- a/_sources/Trees/AVLTreeImplementation.rst
+++ b/_sources/Trees/AVLTreeImplementation.rst
@@ -112,7 +112,7 @@ sacrificing performance. In order to bring an AVL Tree back into balance
 we will perform one or more **rotations** on the tree.
 
 To understand what a rotation is let us look at a very simple example.
-Consider the tree in the left half of :ref:`Figure 3 <fig_unbalsimple>`. This tree
+Consider the tree in the left half of :ref:`Figure 1 <fig_unbalsimple>`. This tree
 is out of balance with a balance factor of -2. To bring this tree into
 balance we will use a left rotation around the subtree rooted at node A.
 
@@ -121,7 +121,7 @@ balance we will use a left rotation around the subtree rooted at node A.
 .. figure:: Figures/simpleunbalanced.png
    :align: center
 
-   Figure 3: Transforming an Unbalanced Tree Using a Left Rotation
+   Figure 1: Transforming an Unbalanced Tree Using a Left Rotation
 
 
 To perform a left rotation we essentially do the following:
@@ -143,7 +143,7 @@ Furthermore we need to make sure to update all of the parent pointers
 appropriately.
 
 Let's look at a slightly more complicated tree to illustrate the right
-rotation. The left side of :ref:`Figure 4 <fig_rightrot1>` shows a tree that is
+rotation. The left side of :ref:`Figure 2 <fig_rightrot1>` shows a tree that is
 left-heavy and with a balance factor of 2 at the root. To perform a
 right rotation we essentially do the following:
 
@@ -162,7 +162,7 @@ right rotation we essentially do the following:
 .. figure:: Figures/rightrotate1.png
   :align: center
 
-  Figure 4: Transforming an Unbalanced Tree Using a Right Rotation
+  Figure 2: Transforming an Unbalanced Tree Using a Right Rotation
 
 Now that you have seen the rotations and have the basic idea of how a
 rotation works let us look at the code. :ref:`Listing 2 <lst_bothrotations>` shows the
@@ -183,7 +183,7 @@ to point to the new root; otherwise we change the parent of the right
 child to point to the new root. (lines 10-13).
 Finally we set the parent of the old root to be the new root. This is a
 lot of complicated bookkeeping, so we encourage you to trace through
-this function while looking at :ref:`Figure 3 <fig_unbalsimple>`. The
+this function while looking at :ref:`Figure 1 <fig_unbalsimple>`. The
 ``rotateRight`` method is symmetrical to ``rotateLeft`` so we will leave
 it to you to study the code for ``rotateRight``.
 
@@ -235,10 +235,10 @@ convince you that these lines are correct.
 .. figure:: Figures/bfderive.png
    :align: center
 
-   Figure 5: A Left Rotation
+   Figure 3: A Left Rotation
 
 
-:ref:`Figure 5 <fig_bfderive>` shows a left rotation. B and D are the pivotal
+:ref:`Figure 3 <fig_bfderive>` shows a left rotation. B and D are the pivotal
 nodes and A, C, E are their subtrees. Let :math:`h_x` denote the
 height of a particular subtree rooted at node :math:`x`. By definition
 we know the following:
@@ -303,7 +303,7 @@ exercises for you.
 
 Now you might think that we are done. We know how to do our left and
 right rotations, and we know when we should do a left or right rotation,
-but take a look at :ref:`Figure 6 <fig_hardrotate>`. Since node A has a balance
+but take a look at :ref:`Figure 4 <fig_hardrotate>`. Since node A has a balance
 factor of -2 we should do a left rotation. But, what happens when we do
 the left rotation around A?
 
@@ -312,10 +312,10 @@ the left rotation around A?
 .. figure:: Figures/hardunbalanced.png
    :align: center
 
-   Figure 6: An Unbalanced Tree that is More Difficult to Balance
+   Figure 4: An Unbalanced Tree that is More Difficult to Balance
 
 
-:ref:`Figure 7 <fig_badrotate>` shows us that after the left rotation we are now
+:ref:`Figure 5 <fig_badrotate>` shows us that after the left rotation we are now
 out of balance the other way. If we do a right rotation to correct the
 situation we are right back where we started.
 
@@ -324,7 +324,7 @@ situation we are right back where we started.
 .. figure:: Figures/badrotate.png
    :align: center
 
-   Figure 7: After a Left Rotation the Tree is Out of Balance in the Other Direction
+   Figure 5: After a Left Rotation the Tree is Out of Balance in the Other Direction
 
 
 To correct this problem we must use the following set of rules:
@@ -339,8 +339,8 @@ To correct this problem we must use the following set of rules:
    right heavy then do a left rotation on the left child, followed by
    the original right rotation.
 
-:ref:`Figure 8 <fig_rotatelr>` shows how these rules solve the dilemma we
-encountered in :ref:`Figure 6 <fig_hardrotate>` and :ref:`Figure 7 <fig_badrotate>`. Starting
+:ref:`Figure 6 <fig_rotatelr>` shows how these rules solve the dilemma we
+encountered in :ref:`Figure 4 <fig_hardrotate>` and :ref:`Figure 5 <fig_badrotate>`. Starting
 with a right rotation around node C puts the tree in a position where
 the left rotation around A brings the entire subtree back into balance.
 
@@ -349,7 +349,7 @@ the left rotation around A brings the entire subtree back into balance.
 .. figure:: Figures/rotatelr.png
    :align: center
 
-   Figure 8: A Right Rotation Followed by a Left Rotation
+   Figure 6: A Right Rotation Followed by a Left Rotation
 
 
 The code that implements these rules can be found in our ``rebalance``
@@ -400,7 +400,7 @@ The :ref:`discussion questions <tree_discuss>` provide you the opportunity to re
 that requires a left rotation followed by a right. In addition the
 discussion questions provide you with the opportunity to rebalance some
 trees that are a little more complex than the tree in
-:ref:`Figure 8 <fig_rotatelr>`.
+:ref:`Figure 6 <fig_rotatelr>`.
 
 By keeping the tree in balance at all times, we can ensure that the
 ``get`` method will run in order :math:`O(log_2(n))` time. But the

--- a/_sources/Trees/AVLTreeImplementation.rst
+++ b/_sources/Trees/AVLTreeImplementation.rst
@@ -95,8 +95,7 @@ the calls to ``updateBalance`` on lines 8 and 17.
 
 
 
-The new ``updateBalance`` method is where most of the work is done. This
-implements the recursive procedure we just described. The
+The new ``updateBalance`` method is where most of the work is done. The
 ``updateBalance`` method first checks to see if the current node is out
 of balance enough to require rebalancing (line 16). If that
 is the case then the rebalancing is done and no further updating to

--- a/pretext/LinearBasic/InfixPrefixandPostfixExpressions.ptx
+++ b/pretext/LinearBasic/InfixPrefixandPostfixExpressions.ptx
@@ -319,9 +319,9 @@
                 in the original expression is reversed in the resulting postfix
                 expression.</p>
             <p>As we process the expression, the operators have to be saved somewhere
-                since their corresponding right operands are not seen yet. Also, the
-                order of these saved operators may need to be reversed due to their
-                precedence. This is the case with the addition and the multiplication in
+                since their corresponding right operands are not seen yet. Additionally,
+                because of their priority, the order of these saved operators might need
+                to be changed, which is the case for the multiplication and addition in
                 this example. Since the addition operator comes before the
                 multiplication operator and has lower precedence, it needs to appear
                 after the multiplication operator is used. Because of this reversal of

--- a/pretext/LinearBasic/SimpleBalancedParentheses.ptx
+++ b/pretext/LinearBasic/SimpleBalancedParentheses.ptx
@@ -60,7 +60,7 @@
 
     <program xml:id="parcheck1_cpp" interactive="activecode" language="cpp">
         <input>
-//simple program that checks for missing parantheses
+//simple program that checks for missing parentheses
 #include &lt;iostream&gt;
 #include &lt;stack&gt;
 #include &lt;string&gt;
@@ -110,7 +110,7 @@ int main() {
         <input>
 #Program that detects if a set of parentheses is complete.
 
-#simple program that checks for missing parantheses
+#simple program that checks for missing parentheses
 from pythonds.basic.stack import Stack
 
 #returns whether the parentheses in the input are balanced


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Rephrased the paragraph in question to add clarity

# Description
<!--- Describe your changes in detail -->
Replaced the paragraph with "Because we are using classes to create abstract data types, we should probably define the term "abstract" in this context. In object-oriented programming, abstraction requires you to focus solely on the desired properties and behaviors of the objects, discarding everything else that is unimportant or irrelevant. As a result, if we don't need to consider the "parts of a whole" metaphor, we won't cover it in class. If the metaphor is important, we will include it. For our purposes, we want to think of fractions as numbers, so we will avoid using the "parts of a whole" visual metaphor."

## Related Issue
<!--- This project prefers pull requests related to open issues -->
<!--- If suggesting a change, please discuss it in an issue first -->
<!--- Please link to the issue here: -->
Issue #180 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
Tested on localhost