### PR TITLE
Fixing formatting issues in chapter 4

### DIFF
--- a/pretext/LinearLinked/Glossary.ptx
+++ b/pretext/LinearLinked/Glossary.ptx
@@ -5,38 +5,38 @@
                 <gi>
                     <title>forward list</title>
                     
-                        <p>a list that is a singly-linked (only links to one other element) sequence container</p>
+                        <p>a list that is a singly-linked (only links to one other element) sequence container.</p>
                     
                 </gi>
                 <gi>
                     <title>head</title>
                     
-                        <p>the first item in a linked list</p>
+                        <p>the first item in a linked list.</p>
                     
                 </gi>
                 <gi>
                     <title>linked data structure</title>
                     
                         <p>a data structure which consists of a set of data structures called nodes
-                            which are linked together and organized by links created via references or pointers</p>
+                            which are linked together and organized by links created via references or pointers.</p>
                     
                 </gi>
                 <gi>
                     <title>linked list</title>
                     
-                        <p>a linear collection of data elements whose order is not determined by the placement in memory</p>
+                        <p>a linear collection of data elements whose order is not determined by the placement in memory.</p>
                     
                 </gi>
                 <gi>
                     <title>linked list traversal</title>
                     
-                        <p>the process of systematically visiting each node in a linked list</p>
+                        <p>the process of systematically visiting each node in a linked list.</p>
                     
                 </gi>
                 <gi>
                     <title>list</title>
                     
-                        <p>a doubly-linked (links to 2 other elements) container</p>
+                        <p>a doubly-linked (links to 2 other elements) container.</p>
                     
                 </gi>
                 <gi>
@@ -48,19 +48,19 @@
                 <gi>
                     <title>ordered linked list</title>
                     
-                        <p>a linked list whose elements are in an order</p>
+                        <p>a linked list whose elements are in an order.</p>
                     
                 </gi>
                 <gi>
                     <title>ordered list</title>
                     
-                        <p>a list whose elements are ordered</p>
+                        <p>a list whose elements are ordered.</p>
                     
                 </gi>
                 <gi>
                     <title>unordered linked list</title>
                     
-                        <p>a linked list whose elements are not in an order</p>
+                        <p>a linked list whose elements are not in an order.</p>
                     
                 </gi>
             

--- a/pretext/LinearLinked/ImplementinganUnorderedListLinkedLists.ptx
+++ b/pretext/LinearLinked/ImplementinganUnorderedListLinkedLists.ptx
@@ -16,7 +16,7 @@
             link from one item to the next.</p>
 
         <figure align="center" xml:id="fig-idea">
-            <caption>Items Not Constrained in Their Physical Placement</caption>
+            <caption>Items Not Constrained in Their Physical Placement.</caption>
                 <image source="LinearLinked/idea.png" width="50%">
                 <description>Image displaying a scattered set of numbers representing items not constrained in their physical placement. The numbers shown are '31' and '17' at the top, '26' to the right, '54' and '77' in the middle, and '93' at the bottom. They are arranged without a discernible pattern or alignment, suggesting a random or unstructured layout.</description>
                 </image>


### PR DESCRIPTION
Fixing formatting issues in chapter 4

# Description
Inconsistency in some of the sentences. Some had a period after while others did not. So, I fixed that by putting periods after all sentences. 

## Related Issue
#654 originally, but the issues are within all the chapters. Therefore, I am fixing all of them.

## How Has This Been Tested?
Tested by rebuilding book in local library. 
