### PR TITLE
Fixing all formatting issues (#654) in chapter 5, cppds2

### DIFF
--- a/pretext/Recursion/DynamicProgramming.ptx
+++ b/pretext/Recursion/DynamicProgramming.ptx
@@ -145,7 +145,7 @@ main()
             results.</p>
         
         <figure align="center" xml:id="fig-c1ctcpp">
-            <caption>Call Tree for Listing 7</caption>
+            <caption>Call Tree for Listing 7.</caption>
                 <image source="Recursion/callTree.png" width="80%">
                 <description>Diagram of a call tree for a recursive process, as seen in Listing 7. The tree starts at the top with the root node labeled '26', branching down to nodes labeled '25' and '1'. Each node further branches out, with the left branch subtracting '1' and the right branch subtracting '5'. The pattern continues until reaching the leaf nodes, which are either '1' or a number that can no longer be reduced by five. Arrows indicate the direction of the call flow, starting from '26' and moving down through the levels of the tree. </description>
                 </image>
@@ -289,14 +289,14 @@ main()
             minimum number of coins for 11 cents.</p>
         
         <figure align="center" xml:id="fig-dpcoinscpp">
-            <caption>Minimum Number of Coins Needed to Make</caption>
+            <caption>Minimum Number of Coins Needed to Make.</caption>
                 <image source="Recursion/changeTable.png" width="80%">
                 <description>Image of a table representing the minimum number of coins needed to make change. The columns are labeled with the 'Change to Make' values from 1 to 11. The rows correspond to 'Steps of the Algorithm', with each cell filled with the minimum number of coins needed at that step for the corresponding amount of change. Initial rows are partially filled with increasing sequences of numbers, indicating the progression of the algorithm. The bottom rows are blurred and continue with an ellipsis, suggesting the continuation of the process beyond what is shown.  </description>
                 </image>
             </figure>
         
         <figure align="center" xml:id="fig-id3">
-            <caption>Three Options to Consider for the Minimum Number of Coins for Eleven Cents</caption>
+            <caption>Three Options to Consider for the Minimum Number of Coins for Eleven Cents.</caption>
                 <image source="Recursion/elevenCents.png" width="80%">
                 <description>Image of a curved numerical table representing three options to calculate the minimum number of coins for eleven cents. The table is labeled with numbers from 1 to 5 corresponding to the counts of coins used. Below the table, there are three curved arrows pointing to the number '11' from '11-1', '11-5', and '11-10', indicating the subtraction of 1, 5, and 10 cents from 11 cents to determine the next step in the calculation. The last cell under '11' is labeled with '??' to indicate the unknown minimum number of coins needed.  </description>
                 </image>

--- a/pretext/Recursion/ExploringaMaze.ptx
+++ b/pretext/Recursion/ExploringaMaze.ptx
@@ -109,7 +109,7 @@
             maze. In this instance, we will stick to a text-only representation (ASCII).</p>
         <p><ul>
             <li>
-                <p><c>__init__</c> Initializes basic variables to default values, and calls <c>readMazeFile</c></p>
+                <p><c>__init__</c> Initializes basic variables to default values, and calls <c>readMazeFile</c>.</p>
             </li>
             <li>
                 <p><c>readMazeFile</c> Reads the text of the maze text file, and calls <c>findStartPosition</c>.</p>
@@ -213,7 +213,7 @@ def searchFrom(maze, startRow, startColumn):
         <p>The <c>searchFrom</c> method uses this internal representation to traverse
             throughout the maze.</p>
         
-        <p xml:id="recursion_fig-exmaze" names="fig_exmaze">Figure 3: An Example Maze Data File</p>
+        <p xml:id="recursion_fig-exmaze" names="fig_exmaze">Figure 3: An Example Maze Data File.</p>
         <DataFileNode line="208" runestone_options="{'subchapter': 'ExploringaMaze', 'chapter': 'Recursion', 'basecourse': 'cppds', 'optional': '', 'optclass': '', 'divid': 'maze1.txt', 'qnumber': 'Q-2', 'cols': 27, 'rows': 20, 'filecontent': '++++++++++++++++++++++\n+   +   ++ ++     +   \u200f\u200f\u200e \u200e\n+ +   +       +++ + ++\n+ + +  ++  ++++   + ++\n+++ ++++++    +++ +  +\n+          ++  ++    +\n+++++ ++++++   +++++ +\n+     +   +++++++  + +\n+ +++++++      S +   +\n+                + +++\n++++++++++++++++++ +++\n', 'hidden': '', 'edit': 'false', 'question_label': '5.11.1'}" source="/srv/web2py/applications/runestone/books/cppds/_sources/Recursion/ExploringaMaze.rst">
         </DataFileNode>
         <p>Finally, the <c>isOnEdge</c> method uses our current position

--- a/pretext/Recursion/StackFramesImplementingRecursion.ptx
+++ b/pretext/Recursion/StackFramesImplementingRecursion.ptx
@@ -80,7 +80,7 @@ main()
             them into the final result, <c>"1010"</c>.</p>
         
         <figure align="center" xml:id="fig-recstack">
-            <caption>Strings Placed on the Stack During Conversion</caption>
+            <caption>Strings Placed on the Stack During Conversion.</caption>
                 <image source="Recursion/recstack.png" width="50%">
                 <description>Image of a stack with character strings representing the result of a conversion process. The stack shows four blocks, each containing a single character. From top to bottom, the blocks are labeled '1', '0', '1', and '0', aligned vertically above a horizontal line that represents the base of the stack. This illustrates the sequence of characters placed on the stack during a number conversion, presumably from a recursive process.</description>
                 </image>
@@ -94,7 +94,7 @@ main()
             call stack after the return statement on line 4.</p>
         
         <figure align="center" xml:id="fig-callstack">
-            <caption>Call Stack Generated from <literal>toStr(10,2)</literal></caption>
+            <caption>Call Stack Generated from <literal>toStr(10,2).</literal></caption>
                 <image source="Recursion/newcallstack.png" width="50%">
                 <description>Diagram illustrating a call stack generated from the function toStr(10,2), which converts the number 10 into a base 2 string. The bottom of the stack shows 'toStr(10/2, 2) + convertString[10%2]', then above it 'toStr(5,2) n = 5 base = 2' with 'toStr(5/2,2) + convertString[5%2]', followed by 'toStr(2,2) n = 2 base = 2' and at the top 'toStr(2/2,2) + convertString[2%2]'. A single character '1' floats above the stack, indicating the start of the conversion process.</description>
                 </image>

--- a/pretext/Recursion/TowerofHanoi.ptx
+++ b/pretext/Recursion/TowerofHanoi.ptx
@@ -24,7 +24,7 @@
             and poles&#8211;a pile of books or pieces of paper will work.</p>
         
         <figure align="center" xml:id="fig-hanoicpp">
-            <caption>An Example Arrangement of Disks for the Tower of Hanoi</caption>
+            <caption>An Example Arrangement of Disks for the Tower of Hanoi.</caption>
                 <image source="Recursion/hanoi.png" width="80%">
                 <description>Image depicting the initial setup of the Tower of Hanoi puzzle. It shows three vertical poles labeled 'fromPole', 'withPole', and 'toPole' on a horizontal base. The 'fromPole' has three disks stacked on it, with the largest at the bottom and the smallest at the top, while the other two poles are empty. This is a classic configuration for the start of the puzzle, which involves moving the disks to another pole under certain rules. </description>
                 </image>
@@ -165,6 +165,6 @@ main()
 
                 <exercise>
                     <statement>
-            <p>If you change the tower height in Line 17 from 3 to 6, how many moves must you make to complete the Hanoi tower? (hint, try implementing a counter to return the correct number) <var/>  </p></statement><setup><var><condition number="[63, 63]"><feedback><p>Correct, you can make a global counter at line 3, and then cout the increasing total under line 11.</p></feedback></condition><condition number="[62, 62]"><feedback><p>Technically you are correct but, you are off by one.</p></feedback></condition><condition string="^\s*.*\s*$"><feedback><p>Please try again you need to add a statement at line 3, and under line 11.</p></feedback></condition></var></setup></exercise>    </reading-questions>   
+            <p>If you change the tower height in Line 17 from 3 to 6, how many moves must you make to complete the Hanoi tower? (Hint, try implementing a counter to return the correct number.) <var/>  </p></statement><setup><var><condition number="[63, 63]"><feedback><p>Correct, you can make a global counter at line 3, and then cout the increasing total under line 11.</p></feedback></condition><condition number="[62, 62]"><feedback><p>Technically you are correct but, you are off by one.</p></feedback></condition><condition string="^\s*.*\s*$"><feedback><p>Please try again you need to add a statement at line 3, and under line 11.</p></feedback></condition></var></setup></exercise>    </reading-questions>   
     </section>
 

--- a/pretext/Recursion/pythondsCalculatingtheSumofaListofNumbers.ptx
+++ b/pretext/Recursion/pythondsCalculatingtheSumofaListofNumbers.ptx
@@ -142,7 +142,7 @@ main()
             point where the problem cannot get any smaller.</p>
 
         <figure align="center" xml:id="fig-recsumin">
-            <caption>Series of Recursive Calls Adding a List of Numbers</caption>
+            <caption>Series of Recursive Calls Adding a List of Numbers.</caption>
                 <image source="Recursion/sumlistIn.png" width="50%">
                 <description>Stacked visualization of recursive function calls to sum a list of numbers. The top box shows 'sum(1,3,5,7,9)' with an arrow pointing to '1 +'. The next box down shows 'sum(3,5,7,9)' with an arrow pointing to '3 +', followed by boxes for 'sum(5,7,9)' with '5 +', 'sum(7,9)' with '7 +', and the last box 'sum(9)' with just '9'. Each box is connected to the next, representing the recursive nature of the calls.</description>
                 </image>
@@ -157,7 +157,7 @@ main()
             problem, we have the solution to the whole problem.</p>
         
         <figure align="center" xml:id="fig-recsumout">
-            <caption>Series of Recursive Returns from Adding a List of Numbers</caption>
+            <caption>Series of Recursive Returns from Adding a List of Numbers.</caption>
                 <image source="Recursion/sumlistOut.png" width="50%">
                 <description>Diagram illustrating the resolution of recursive function calls summing a list of numbers. The bottom box shows 'sum(9)' equaling '9', with an arrow pointing left to the next box 'sum(7,9)' showing '7 + 9'. Above that, 'sum(5,7,9)' equals '5 + 16', then 'sum(3,5,7,9)' with '3 + 21', and at the top, 'sum(1,3,5,7,9)' resulting in '1 + 24'. Each function call resolves to a value that is used in the computation of the previous call, with the final sum at the top being '25'.</description>
                 </image>

--- a/pretext/Recursion/pythondsConvertinganIntegertoaStringinAnyBase.ptx
+++ b/pretext/Recursion/pythondsConvertinganIntegertoaStringinAnyBase.ptx
@@ -52,7 +52,7 @@
             right side of the diagram.</p>
         
         <figure align="center" xml:id="fig-tostr">
-            <caption>Converting an Integer to a String in Base 10</caption>
+            <caption>Converting an Integer to a String in Base 10.</caption>
                 <image source="Recursion/toStr.png" width="50%">
                 <description>Flowchart demonstrating the conversion of an integer to a string in base 10 using recursion. The process starts with 'toStr(769)', which divides '769' by '10' and adds the remainder 'g'. The result feeds into 'toStr(76)', which again divides by '10' to add the remainder '6'. The final call is 'toStr(7)', which is less than '10' and therefore converts directly to '7'. The remainders at each step are used to build the string representation of the integer.</description>
                 </image>
@@ -115,7 +115,7 @@ main()
             to its base 2 string representation (<c>"1010"</c>).</p>
     
         <figure align="center" xml:id="fig-tostr2">
-            <caption>Converting the Number 10 to its Base 2 String Representation</caption>
+            <caption>Converting the Number 10 to its Base 2 String Representation.</caption>
                 <image source="Recursion/toStrBase2.png" width="50%">
                 <description>Flowchart depicting the recursive process of converting the number 10 to its binary (base 2) string representation. The topmost operation 'toStr(10)' shows the division '10 / 2' with a remainder '0'. This leads to 'toStr(5)', with division '5 / 2' and remainder '1', followed by 'toStr(2)' with division '2 / 2' and remainder '0', and finally 'toStr(1)' indicating '1 &lt; 2' and yielding a remainder '1'. The remainders collected at each step form the binary representation of the number 10.</description>
                 </image>
@@ -197,28 +197,28 @@ int main(){
             <p>Write a function that takes a string as a parameter and returns True if the string is a palindrome, False otherwise.  Remember that a string is a palindrome if it is spelled the same both forward and backward.  For example:  radar is a palindrome.  for bonus points palindromes can also be phrases, but you need to remove the spaces and punctuation before checking.  for example:  madam i'm adam  is a palindrome.  Other fun palindromes include:</p>
             <p><ul>
                 <li>
-                    <p>kayak</p>
+                    <p>kayak.</p>
                 </li>
                 <li>
-                    <p>aibohphobia</p>
+                    <p>aibohphobia.</p>
                 </li>
                 <li>
-                    <p>Live not on evil</p>
+                    <p>Live not on evil.</p>
                 </li>
                 <li>
-                    <p>Reviled did I live, said I, as evil I did deliver</p>
+                    <p>Reviled did I live, said I, as evil I did deliver.</p>
                 </li>
                 <li>
                     <p>Go hang a salami; I'm a lasagna hog.</p>
                 </li>
                 <li>
-                    <p>Able was I ere I saw Elba</p>
+                    <p>Able was I ere I saw Elba.</p>
                 </li>
                 <li>
-                    <p>Kanakanak &#8211;  a town in Alaska</p>
+                    <p>Kanakanak &#8211;  a town in Alaska.</p>
                 </li>
                 <li>
-                    <p>Wassamassaw &#8211; a town in South Dakota</p>
+                    <p>Wassamassaw &#8211; a town in South Dakota.</p>
                 </li>
             </ul></p>
             <blockquote>

--- a/pretext/Recursion/pythondsSierpinskiTriangle.ptx
+++ b/pretext/Recursion/pythondsSierpinskiTriangle.ptx
@@ -14,7 +14,7 @@
             drawing the Sierpinski triangle yourself, using the method described.</p>
         
         <figure align="center" xml:id="fig-sierpinski">
-            <caption>The Sierpinski Triangle</caption>
+            <caption>The Sierpinski Triangle.</caption>
                 <image source="Recursion/sierpinski.png" width="50%">
                 <description>"Image of the Sierpinski Triangle, a fractal composed of colored triangles. The main triangle is outlined with progressively smaller triangles in alternating colors of red, green, and white, forming a pattern that repeats at smaller scales. The center of the triangle features a large inverted blue triangle, emphasizing the fractal's characteristic self-similarity.</description>
                 </image>
@@ -157,7 +157,7 @@ main()
             finished with the bottom left it moves to the bottom middle, and so on.</p>
         
         <figure align="center" xml:id="fig-stcalltree">
-            <caption>Building a Sierpinski Triangle</caption>
+            <caption>Building a Sierpinski Triangle.</caption>
                 <image source="Recursion/stCallTree.png" width="50%">
                 <description>Diagram showing the recursive construction of a Sierpinski Triangle using a tree structure. The diagram starts with a single top circle labeled 'top', branching out into three interconnected circles labeled 'left', 'top', and 'right'. Each of these circles further branches out in a similar pattern, with the process repeating for several iterations. The circles decrease in size from top to bottom, representing the fractal's recursive nature. The grayscale shading of the circles suggests depth or iteration levels.</description>
                 </image>

--- a/pretext/Recursion/pythondsintro-VisualizingRecursion.ptx
+++ b/pretext/Recursion/pythondsintro-VisualizingRecursion.ptx
@@ -220,14 +220,14 @@ main()
             to the smallest twig on the left.</p>
         
         <figure align="center" xml:id="fig-tree1">
-            <caption>The Beginning of a Fractal Tree</caption>
+            <caption>The Beginning of a Fractal Tree.</caption>
                 <image source="Recursion/tree1.png" width="50%">
                 <description>Screenshot of a computer window titled 'Python Turtle Graphics' showing the initial stage of a fractal tree drawing. The window displays a simple black curve on a white background, representing the trunk of the tree starting to branch off. This image captures the first step in a programming exercise to draw a complex fractal tree using recursive functions.</description>
                 </image>
             </figure>
 
         <figure align="center" xml:id="fig-tree2">
-            <caption>The First Half of the Tree</caption>
+            <caption>The First Half of the Tree.</caption>
                 <image source="Recursion/tree2.png" width="50%">
                 <description>Screenshot of a computer window with the title 'Python Turtle Graphics', depicting a partially completed fractal tree drawing. The graphic shows a black tree with a simple trunk that splits into several branching limbs and smaller branches, all rendered on a white background. The image visually represents the midpoint of a recursive drawing process in programming, with the tree structure becoming increasingly complex towards the top.</description>
                 </image>


### PR DESCRIPTION
Fixing formatting issues in Chapter 5

# Description
Inconsistency in some of the sentences. Some had a period after while others did not. So, I fixed that by putting periods after all sentences. Another problem was an independent sentence was started with a lower-case letter. 

## Related Issue
#654 originally, but the issues are within all the chapters. Therefore, I am fixing all of them.

## How Has This Been Tested?
Tested by rebuilding the book in the local library. 
