### PR TITLE
Fixed all the formatting issues in chapter 6, cppds2

### DIFF
--- a/pretext/SearchHash/DiscussionQuestions.ptx
+++ b/pretext/SearchHash/DiscussionQuestions.ptx
@@ -3,7 +3,7 @@
         <p><ol label="1">
             <li>
                 <p>Using the hash table performance formulas given in the chapter,
-                    compute the average number of comparisons necessary when the table is</p>
+                    compute the average number of comparisons necessary when the table is:</p>
                 <p><ul>
                     <li>
                         <p>10% full</p>

--- a/pretext/SearchHash/Glossary.ptx
+++ b/pretext/SearchHash/Glossary.ptx
@@ -14,27 +14,27 @@
                     <title>chaining</title>
                     
                         <p>a method of collision resolution in which each slot in a hash table holds
-                            a reference to a collection of items</p>
+                            a reference to a collection of items.</p>
                     
                 </gi>
                 <gi>
                     <title>collision</title>
                     
                         <p>a conflict of having two or more items sharing the same slot in a hash
-                            table</p>
+                            table.</p>
                     
                 </gi>
                 <gi>
                     <title>collision resolution</title>
                     
-                        <p>a systematic method for resolving hash table collisions</p>
+                        <p>a systematic method for resolving hash table collisions.</p>
                     
                 </gi>
                 <gi>
                     <title>clustering</title>
                     
                         <p>items being mapped in a hash table near each other because of collisions
-                            and linear probing resulting in items with collisions being put together</p>
+                            and linear probing resulting in items with collisions being put together.</p>
                     
                 </gi>
                 <gi>
@@ -56,21 +56,21 @@
                 <gi>
                     <title>hash function</title>
                     
-                        <p>the mapping between an item and its slot in a hash table</p>
+                        <p>the mapping between an item and its slot in a hash table.</p>
                     
                 </gi>
                 <gi>
                     <title>hash table</title>
                     
                         <p>a collection of items which are stored in such a away as to make it easy
-                            to find them</p>
+                            to find them.</p>
                     
                 </gi>
                 <gi>
                     <title>linear probing</title>
                     
                         <p>an open addressing technique in which each slot is visited one at a time
-                            systematically</p>
+                            systematically.</p>
                     
                 </gi>
                 <gi>
@@ -83,7 +83,7 @@
                 <gi>
                     <title>map</title>
                     
-                        <p>an associate data type that stores key-data pairs</p>
+                        <p>an associate data type that stores key-data pairs.</p>
                     
                 </gi>
                 <gi>
@@ -97,46 +97,46 @@
                     <title>open addressing</title>
                     
                         <p>a collision resolution that tries to find the next open slot/address in
-                            the hash table</p>
+                            the hash table.</p>
                     
                 </gi>
                 <gi>
                     <title>perfect hash function</title>
                     
-                        <p>a hash function that maps each item to a unique hash slot</p>
+                        <p>a hash function that maps each item to a unique hash slot.</p>
                     
                 </gi>
                 <gi>
                     <title>quadratic probing</title>
                     
                         <p>a variation of linear probing in which rehashing is done using successive
-                            squared values</p>
+                            squared values.</p>
                     
                 </gi>
                 <gi>
                     <title>rehashing</title>
                     
-                        <p>putting an item into a hash table after a collision</p>
+                        <p>putting an item into a hash table after a collision.</p>
                     
                 </gi>
                 <gi>
                     <title>searching</title>
                     
                         <p>the algorithmic process of finding a particular item in a
-                            collection of items</p>
+                            collection of items.</p>
                     
                 </gi>
                 <gi>
                     <title>sequential search</title>
                     
                         <p>search method in which one follows the underlying ordering of items in a
-                            collection of data to find a specific item</p>
+                            collection of data to find a specific item.</p>
                     
                 </gi>
                 <gi>
                     <title>slot</title>
                     
-                        <p>a position in a hash table</p>
+                        <p>a position in a hash table.</p>
                     
                 </gi>
             

--- a/pretext/SearchHash/Hashing.ptx
+++ b/pretext/SearchHash/Hashing.ptx
@@ -26,7 +26,7 @@
         
         <blockquote>
             <figure align="center" xml:id="fig-hashtable">
-                <caption>Hash Table with 11 Empty Slots</caption>
+                <caption>Hash Table with 11 Empty Slots.</caption>
                     <image source="SearchHash/hashtable.png" width="80%">
                     <description>Image depicting a hash table data structure with eleven empty slots. The slots are numbered from 0 to 10 and each contains the word 'None', indicating that they are unoccupied. The table is presented in a horizontal format, with clear delineation between each slot.</description>
                     </image>
@@ -122,7 +122,7 @@
             <m>\lambda = \frac {6}{11}</m>.<idx>load factor</idx></p>
         
         <figure align="center" xml:id="fig-hashtable2">
-            <caption> Hash Table with Six Items</caption>
+            <caption> Hash Table with Six Items.</caption>
                 <image source="SearchHash/hashtable2.png" width="80%">
                 <description>Image showing a hash table with eleven slots, numbered from 0 to 10. Some slots contain integers while others are empty. Starting from the left, slot 0 contains '77', slot 4 contains '26', slot 5 contains '93', slot 6 contains '17', slot 9 contains '31', and slot 10 contains '54'. Slots 1, 2, 3, 7, and 8 are labeled 'None', indicating they are unoccupied. </description>
                 </image>
@@ -300,7 +300,7 @@ cout&lt;&lt;i&lt;&lt;endl;
                 to <c>tablesize</c>-1.</p>
             
             <figure align="center" xml:id="fig-stringhash">
-                <caption>Hashing a String Using Ordinal Values</caption>
+                <caption>Hashing a String Using Ordinal Values.</caption>
                     <image source="SearchHash/stringhash.png" width="80%">
                     <description>Diagram illustrating the process of hashing a string using ordinal values. Three characters 'c', 'a', and 't' are shown at the top with arrows pointing down to their respective ordinal values: '99', '97', and '116'. These values are summed to equal '312'. An arrow then points from this sum to an operation '312 % 11', which results in '4'. This demonstrates a simple hash function where the sum of the character ordinals is divided by 11 to get a remainder, which serves as the hash value.</description>
                     </image>
@@ -342,7 +342,7 @@ int main() {
                 modification to the <c>hash</c> function is left as an exercise.</p>
             
             <figure align="center" xml:id="fig-stringhash2">
-                <caption>Hashing a String Using Ordinal Values with Weighting</caption>
+                <caption>Hashing a String Using Ordinal Values with Weighting.</caption>
                     <image source="SearchHash/stringhash2.png" width="80%">
                     <description>Image depicting a hashing algorithm that uses ordinal values of characters with weighting by their positions. The character 'c' in position 1 is multiplied by its ordinal value '99' and added to 1, 'a' in position 2 is multiplied by '97' and added to 2, and 't' in position 3 is multiplied by '116' and added to 3. The resulting sums are combined to total '641'. This sum is then divided by 11, as shown by the operation '641 % 11', resulting in a hash value of '3'.</description>
                     </image>
@@ -388,7 +388,7 @@ int main() {
                 slot 9 is full, we begin to do linear probing. We visit slots 10, 0, 1,
                 and 2, and finally find an empty slot at position 3.</p>
             <figure align="center" xml:id="fig-linearprobing1">
-                <caption>Collision Resolution with Linear Probing</caption>
+                <caption>Collision Resolution with Linear Probing.</caption>
                     <image source="SearchHash/linearprobing1.png" width="80%">
                     <description>Image of a hash table illustrating collision resolution with linear probing. The table has eleven slots numbered from 0 to 10. Filled slots contain the following integers: '77' in slot 0, '44' in slot 1, '55' in slot 2, '20' in slot 3, '26' in slot 4, '93' in slot 5, '17' in slot 6, '31' in slot 9, and '54' in slot 10. Slots 7 and 8 are labeled 'None', indicating they are empty. This setup suggests that when a collision occurs, the algorithm probes sequentially through the table to find the next available slot.</description>
                     </image>
@@ -412,7 +412,7 @@ int main() {
                 <xref ref="fig-clustering"/>.</p>
 
             <figure align="center" xml:id="fig-clustering">
-                <caption>A Cluster of Items for Slot 0</caption>
+                <caption>A Cluster of Items for Slot 0.</caption>
                     <image source="SearchHash/clustering.png" width="80%">
                     <description>Image of a hash table with a series of filled and empty slots. The slots are numbered from 0 to 10. Slot 0 contains the number '77', followed by '44' in slot 1, '55' in slot 2, '20' in slot 3, '26' in slot 4, '93' in slot 5, and '17' in slot 6. Slots 7 and 8 are empty and labeled 'None'. Slot 9 contains the number '31', and slot 10 contains '54'. This demonstrates a clustering effect where a sequence of items are hashed to neighboring slots starting from slot 0.</description>
                     </image>
@@ -427,7 +427,7 @@ int main() {
                 collision occurs, we will look at every third slot until we find one
                 that is empty.</p>
             <figure align="center" xml:id="fig-linearprobing2">
-                <caption>Collision Resolution Using <q>Plus 3</q></caption>
+                <caption>Collision Resolution Using <q>Plus 3</q>.</caption>
                     <image source="SearchHash/linearprobing2.png" width="80%">
                     <description>Image of a hash table with eleven slots, demonstrating collision resolution using the 'Plus 3' strategy. The slots are numbered from 0 to 10, with '77' in slot 0, '55' in slot 1, 'None' in slot 2, '44' in slot 3, '26' in slot 4, '93' in slot 5, '17' in slot 6, '20' in slot 7, 'None' in slot 8, '31' in slot 9, and '54' in slot 10. The 'None' slots indicate empty positions where no value has been hashed to. The placement of numbers suggests that when a collision occurs, the item is placed in the next available slot that is three positions away.</description>
                     </image>
@@ -453,7 +453,7 @@ int main() {
                 this technique.</p> 
 
             <figure align="center" xml:id="fig-quadratic">
-                <caption>Collision Resolution with Quadratic Probing</caption>
+                <caption>Collision Resolution with Quadratic Probing.</caption>
                     <image source="SearchHash/quadratic.png" width="80%">
                     <description>Image of a hash table with eleven numbered slots, illustrating collision resolution with quadratic probing. The hash table contains the numbers '77' in slot 0, '44' in slot 1, '20' in slot 2, '55' in slot 3, '26' in slot 4, '93' in slot 5, '17' in slot 6, and slots 7 and 8 are empty, labeled 'None'. The table ends with '31' in slot 9 and '54' in slot 10. The 'None' slots indicate that no items have been placed there, and the distribution of numbers shows that quadratic probing has been used to resolve collisions by placing items in slots that are a quadratic function of the distance from the original hashed slot.</description>
                     </image>
@@ -468,7 +468,7 @@ int main() {
                 table that uses chaining to resolve collisions.</p>
                 
             <figure align="center" xml:id="fig-chaining">
-                <caption>Collision Resolution with Chaining</caption>
+                <caption>Collision Resolution with Chaining.</caption>
                     <image source="SearchHash/chaining.png" width="80%">
                     <description>Image of a hash table with eleven slots numbered from 0 to 10, demonstrating collision resolution with chaining. Each slot is either empty, labeled 'None', or contains a vertical list of numbers, representing a chain of items that have been hashed to the same slot. Slot 0 has a chain of '77', followed by '44' and '55'. Slot 4 has '26' and '93', slot 6 has '17', slot 9 has '31' and '54', and slot 10 has '20'. The chains are represented by numbers in boxes with arrows pointing downwards to the next number in the chain, depicting how collisions are resolved by linking items within the same slot.</description>
                     </image>

--- a/pretext/SearchHash/TheBinarySearch.ptx
+++ b/pretext/SearchHash/TheBinarySearch.ptx
@@ -21,7 +21,7 @@
             in <xref ref="lst-binarysearchpy"/>.</p>
             
         <figure align="center" xml:id="fig-binsearch">
-            <caption>Binary Search of an Ordered vector of Integers</caption>
+            <caption>Binary Search of an Ordered vector of Integers.</caption>
                 <image source="SearchHash/binsearch.png" width="80%">
                 <description>Diagram of an ordered sequence of boxes containing integers, indicative of a binary search algorithm. The numbers in the boxes are '17', '20', '26', '31', '44', '54', '55', '65', '77', and '93', arranged in ascending order. An arrow labeled 'Start' splits into two, pointing to the middle of the sequence, suggesting the initial step in binary search where the middle element is first compared with the target value.</description>
                 </image>

--- a/pretext/SearchHash/TheSequentialSearch.ptx
+++ b/pretext/SearchHash/TheSequentialSearch.ptx
@@ -17,7 +17,7 @@
             the item we were searching for was not present.</p>
         
         <figure align="center" xml:id="fig-seqsearch">
-            <caption>Sequential Search of a List of Integers</caption>
+            <caption>Sequential Search of a List of Integers.</caption>
                 <image source="SearchHash/seqsearch.png" width="80%">
                 <description>Diagram showing a horizontal sequence of connected boxes containing integers, illustrating a sequential search algorithm. Each box contains a unique number, with values visible in the image including '54', '26', '93', '17', '77', '31', '44', '55', '20', and '65'. A curved arrow labeled 'Start' points to the first box '54', indicating the beginning of the search process. The arrangement suggests that the search will proceed through the list of numbers from left to right. </description>
                 </image>
@@ -170,7 +170,7 @@ int main() {
 
           
             <figure align="center" xml:id="fig-seqsearch2">
-                <caption>Sequential Search of an Ordered List of Integers</caption>
+                <caption>Sequential Search of an Ordered List of Integers.</caption>
                     <image source="SearchHash/seqsearch2.png" width="80%">
                     <description>Image of a sequence of connected boxes in a horizontal line, each containing a number, representing a sequential search on an ordered list of integers. The numbers, displayed in ascending order, are '17', '20', '26', '31', '44', '54', '55', '65', '77', and '93'. A curved arrow labeled 'Start' points to the first box with '17', indicating the point where the search begins. The sequence suggests a methodical approach to searching, where each element is checked in order until the desired number is found. </description>
                     </image>


### PR DESCRIPTION
Fixing formatting issues in Chapter 6

# Description
Inconsistency in some of the sentences. Some had a period after while others did not. So, I fixed that by putting periods after all sentences. 

## Related Issue
#654  originally, but the issues are within all the chapters. Therefore, I am fixing all of them.

## How Has This Been Tested?
Tested by rebuilding the book in the local library. 
