### PR TITLE
Fixed all the formatting issues in chapter 8, cppds2

### DIFF
--- a/pretext/Trees/AVLTreeImplementation.ptx
+++ b/pretext/Trees/AVLTreeImplementation.ptx
@@ -94,7 +94,7 @@ int updateBalance(TreeNode *node){
             is out of balance with a balance factor of -2. To bring this tree into
             balance we will use a left rotation around the subtree rooted at node A.</p>
         
-        <figure align="center" xml:id="fig-unbalsimple"><caption xmlns:c="https://www.sphinx-doc.org/" xmlns:changeset="https://www.sphinx-doc.org/" xmlns:citation="https://www.sphinx-doc.org/" xmlns:cpp="https://www.sphinx-doc.org/" xmlns:index="https://www.sphinx-doc.org/" xmlns:js="https://www.sphinx-doc.org/" xmlns:math="https://www.sphinx-doc.org/" xmlns:py="https://www.sphinx-doc.org/" xmlns:rst="https://www.sphinx-doc.org/" xmlns:std="https://www.sphinx-doc.org/">Transforming an Unbalanced Tree Using a Left Rotation</caption><image source="Trees/simpleunbalanced.png" width="70%"/></figure>
+        <figure align="center" xml:id="fig-unbalsimple"><caption xmlns:c="https://www.sphinx-doc.org/" xmlns:changeset="https://www.sphinx-doc.org/" xmlns:citation="https://www.sphinx-doc.org/" xmlns:cpp="https://www.sphinx-doc.org/" xmlns:index="https://www.sphinx-doc.org/" xmlns:js="https://www.sphinx-doc.org/" xmlns:math="https://www.sphinx-doc.org/" xmlns:py="https://www.sphinx-doc.org/" xmlns:rst="https://www.sphinx-doc.org/" xmlns:std="https://www.sphinx-doc.org/">Transforming an Unbalanced Tree Using a Left Rotation.</caption><image source="Trees/simpleunbalanced.png" width="70%"/></figure>
         <p>To perform a left rotation we essentially do the following:</p>
         <p><ul>
             <li>
@@ -136,7 +136,7 @@ int updateBalance(TreeNode *node){
             </li>
         </ul></p>
         
-        <figure align="center" xml:id="fig-rightrot1"><caption xmlns:c="https://www.sphinx-doc.org/" xmlns:changeset="https://www.sphinx-doc.org/" xmlns:citation="https://www.sphinx-doc.org/" xmlns:cpp="https://www.sphinx-doc.org/" xmlns:index="https://www.sphinx-doc.org/" xmlns:js="https://www.sphinx-doc.org/" xmlns:math="https://www.sphinx-doc.org/" xmlns:py="https://www.sphinx-doc.org/" xmlns:rst="https://www.sphinx-doc.org/" xmlns:std="https://www.sphinx-doc.org/">Transforming an Unbalanced Tree Using a Right Rotation</caption><image source="Trees/rightrotate1.png" width="70%"/></figure>
+        <figure align="center" xml:id="fig-rightrot1"><caption xmlns:c="https://www.sphinx-doc.org/" xmlns:changeset="https://www.sphinx-doc.org/" xmlns:citation="https://www.sphinx-doc.org/" xmlns:cpp="https://www.sphinx-doc.org/" xmlns:index="https://www.sphinx-doc.org/" xmlns:js="https://www.sphinx-doc.org/" xmlns:math="https://www.sphinx-doc.org/" xmlns:py="https://www.sphinx-doc.org/" xmlns:rst="https://www.sphinx-doc.org/" xmlns:std="https://www.sphinx-doc.org/">Transforming an Unbalanced Tree Using a Right Rotation.</caption><image source="Trees/rightrotate1.png" width="70%"/></figure>
         <p>Now that you have seen the rotations and have the basic idea of how a
             rotation works let us look at the code. <xref ref="lst-bothrotations"/> shows the
             code for both the right and the left rotations. In line&#160;2
@@ -194,7 +194,7 @@ void rotateLeft(TreeNode *rotRoot){
             the heights of the new subtrees? The following derivation should
             convince you that these lines are correct.</p>
         
-        <figure align="center" xml:id="id3"><caption xmlns:c="https://www.sphinx-doc.org/" xmlns:changeset="https://www.sphinx-doc.org/" xmlns:citation="https://www.sphinx-doc.org/" xmlns:cpp="https://www.sphinx-doc.org/" xmlns:index="https://www.sphinx-doc.org/" xmlns:js="https://www.sphinx-doc.org/" xmlns:math="https://www.sphinx-doc.org/" xmlns:py="https://www.sphinx-doc.org/" xmlns:rst="https://www.sphinx-doc.org/" xmlns:std="https://www.sphinx-doc.org/">A Left Rotation</caption><image source="Trees/bfderive.png" width="70%"/></figure>
+        <figure align="center" xml:id="id3"><caption xmlns:c="https://www.sphinx-doc.org/" xmlns:changeset="https://www.sphinx-doc.org/" xmlns:citation="https://www.sphinx-doc.org/" xmlns:cpp="https://www.sphinx-doc.org/" xmlns:index="https://www.sphinx-doc.org/" xmlns:js="https://www.sphinx-doc.org/" xmlns:math="https://www.sphinx-doc.org/" xmlns:py="https://www.sphinx-doc.org/" xmlns:rst="https://www.sphinx-doc.org/" xmlns:std="https://www.sphinx-doc.org/">A Left Rotation.</caption><image source="Trees/bfderive.png" width="70%"/></figure>
         <p><xref ref="fig-bfderive"/> shows a left rotation. B and D are the pivotal
             nodes and A, C, E are their subtrees. Let <m>h_x</m> denote the
             height of a particular subtree rooted at node <m>x</m>. By definition
@@ -239,12 +239,12 @@ rotRoot.balanceFactor = rotRoot.balanceFactor + 1 - min(0,newRoot.balanceFactor)
             factor of -2 we should do a left rotation. But, what happens when we do
             the left rotation around A?</p>
         
-        <figure align="center" xml:id="id4"><caption xmlns:c="https://www.sphinx-doc.org/" xmlns:changeset="https://www.sphinx-doc.org/" xmlns:citation="https://www.sphinx-doc.org/" xmlns:cpp="https://www.sphinx-doc.org/" xmlns:index="https://www.sphinx-doc.org/" xmlns:js="https://www.sphinx-doc.org/" xmlns:math="https://www.sphinx-doc.org/" xmlns:py="https://www.sphinx-doc.org/" xmlns:rst="https://www.sphinx-doc.org/" xmlns:std="https://www.sphinx-doc.org/">An Unbalanced Tree that is More Difficult to Balance</caption><image source="Trees/hardunbalanced.png" width="20%"/></figure>
+        <figure align="center" xml:id="id4"><caption xmlns:c="https://www.sphinx-doc.org/" xmlns:changeset="https://www.sphinx-doc.org/" xmlns:citation="https://www.sphinx-doc.org/" xmlns:cpp="https://www.sphinx-doc.org/" xmlns:index="https://www.sphinx-doc.org/" xmlns:js="https://www.sphinx-doc.org/" xmlns:math="https://www.sphinx-doc.org/" xmlns:py="https://www.sphinx-doc.org/" xmlns:rst="https://www.sphinx-doc.org/" xmlns:std="https://www.sphinx-doc.org/">An Unbalanced Tree that is More Difficult to Balance.</caption><image source="Trees/hardunbalanced.png" width="20%"/></figure>
         <p><xref ref="fig-badrotate"/> shows us that after the left rotation we are now
             out of balance the other way. If we do a right rotation to correct the
             situation we are right back where we started.</p>
         
-        <figure align="center" xml:id="id5"><caption xmlns:c="https://www.sphinx-doc.org/" xmlns:changeset="https://www.sphinx-doc.org/" xmlns:citation="https://www.sphinx-doc.org/" xmlns:cpp="https://www.sphinx-doc.org/" xmlns:index="https://www.sphinx-doc.org/" xmlns:js="https://www.sphinx-doc.org/" xmlns:math="https://www.sphinx-doc.org/" xmlns:py="https://www.sphinx-doc.org/" xmlns:rst="https://www.sphinx-doc.org/" xmlns:std="https://www.sphinx-doc.org/">After a Left Rotation the Tree is Out of Balance in the Other Direction</caption><image source="Trees/badrotate.png" width="20%"/></figure>
+        <figure align="center" xml:id="id5"><caption xmlns:c="https://www.sphinx-doc.org/" xmlns:changeset="https://www.sphinx-doc.org/" xmlns:citation="https://www.sphinx-doc.org/" xmlns:cpp="https://www.sphinx-doc.org/" xmlns:index="https://www.sphinx-doc.org/" xmlns:js="https://www.sphinx-doc.org/" xmlns:math="https://www.sphinx-doc.org/" xmlns:py="https://www.sphinx-doc.org/" xmlns:rst="https://www.sphinx-doc.org/" xmlns:std="https://www.sphinx-doc.org/">After a Left Rotation the Tree is Out of Balance in the Other Direction.</caption><image source="Trees/badrotate.png" width="20%"/></figure>
         <p>To correct this problem we must use the following set of rules:</p>
         <p><ul>
             <li>
@@ -265,7 +265,7 @@ rotRoot.balanceFactor = rotRoot.balanceFactor + 1 - min(0,newRoot.balanceFactor)
             with a right rotation around node C puts the tree in a position where
             the left rotation around A brings the entire subtree back into balance.</p>
         
-        <figure align="center" xml:id="id6"><caption xmlns:c="https://www.sphinx-doc.org/" xmlns:changeset="https://www.sphinx-doc.org/" xmlns:citation="https://www.sphinx-doc.org/" xmlns:cpp="https://www.sphinx-doc.org/" xmlns:index="https://www.sphinx-doc.org/" xmlns:js="https://www.sphinx-doc.org/" xmlns:math="https://www.sphinx-doc.org/" xmlns:py="https://www.sphinx-doc.org/" xmlns:rst="https://www.sphinx-doc.org/" xmlns:std="https://www.sphinx-doc.org/">A Right Rotation Followed by a Left Rotation</caption><image source="Trees/rotatelr.png" width="80%"/></figure>
+        <figure align="center" xml:id="id6"><caption xmlns:c="https://www.sphinx-doc.org/" xmlns:changeset="https://www.sphinx-doc.org/" xmlns:citation="https://www.sphinx-doc.org/" xmlns:cpp="https://www.sphinx-doc.org/" xmlns:index="https://www.sphinx-doc.org/" xmlns:js="https://www.sphinx-doc.org/" xmlns:math="https://www.sphinx-doc.org/" xmlns:py="https://www.sphinx-doc.org/" xmlns:rst="https://www.sphinx-doc.org/" xmlns:std="https://www.sphinx-doc.org/">A Right Rotation Followed by a Left Rotation.</caption><image source="Trees/rotatelr.png" width="80%"/></figure>
         <p>The code that implements these rules can be found in our <c>rebalance</c>
             method, which is shown in <xref ref="lst-rebalance"/>. Rule number 1 from
             above is implemented by the <c>if</c> statement starting on line&#160;2.

--- a/pretext/Trees/AVLTreePerformance.ptx
+++ b/pretext/Trees/AVLTreePerformance.ptx
@@ -10,7 +10,7 @@
             illustrates the most unbalanced left-heavy tree possible under the new
             rules.</p>
         
-        <figure align="center" xml:id="fig-worstavl"><caption xmlns:c="https://www.sphinx-doc.org/" xmlns:changeset="https://www.sphinx-doc.org/" xmlns:citation="https://www.sphinx-doc.org/" xmlns:cpp="https://www.sphinx-doc.org/" xmlns:index="https://www.sphinx-doc.org/" xmlns:js="https://www.sphinx-doc.org/" xmlns:math="https://www.sphinx-doc.org/" xmlns:py="https://www.sphinx-doc.org/" xmlns:rst="https://www.sphinx-doc.org/" xmlns:std="https://www.sphinx-doc.org/">Worst-Case Left-Heavy AVL Trees</caption><image source="Trees/worstAVL.png" width="50%"/></figure>
+        <figure align="center" xml:id="fig-worstavl"><caption xmlns:c="https://www.sphinx-doc.org/" xmlns:changeset="https://www.sphinx-doc.org/" xmlns:citation="https://www.sphinx-doc.org/" xmlns:cpp="https://www.sphinx-doc.org/" xmlns:index="https://www.sphinx-doc.org/" xmlns:js="https://www.sphinx-doc.org/" xmlns:math="https://www.sphinx-doc.org/" xmlns:py="https://www.sphinx-doc.org/" xmlns:rst="https://www.sphinx-doc.org/" xmlns:std="https://www.sphinx-doc.org/">Worst-Case Left-Heavy AVL Trees.</caption><image source="Trees/worstAVL.png" width="50%"/></figure>
         <p>Looking at the total number of nodes in the tree we see that for a tree
             of height 0 there is 1 node, for a tree of height 1 there is <m>1+1
                 = 2</m> nodes, for a tree of height 2 there are <m>1+1+2 = 4</m> and

--- a/pretext/Trees/BalancedBinarySearchTrees.ptx
+++ b/pretext/Trees/BalancedBinarySearchTrees.ptx
@@ -26,6 +26,6 @@
             back into balance. <xref ref="fig-unbal"/> shows an example of an unbalanced,
             right-heavy tree and the balance factors of each node.</p>
         
-        <figure align="center" xml:id="fig-unbal"><caption xmlns:c="https://www.sphinx-doc.org/" xmlns:changeset="https://www.sphinx-doc.org/" xmlns:citation="https://www.sphinx-doc.org/" xmlns:cpp="https://www.sphinx-doc.org/" xmlns:index="https://www.sphinx-doc.org/" xmlns:js="https://www.sphinx-doc.org/" xmlns:math="https://www.sphinx-doc.org/" xmlns:py="https://www.sphinx-doc.org/" xmlns:rst="https://www.sphinx-doc.org/" xmlns:std="https://www.sphinx-doc.org/">An Unbalanced Right-Heavy Tree with Balance Factors</caption><image source="Trees/unbalanced.png" width="50%"/></figure>
+        <figure align="center" xml:id="fig-unbal"><caption xmlns:c="https://www.sphinx-doc.org/" xmlns:changeset="https://www.sphinx-doc.org/" xmlns:citation="https://www.sphinx-doc.org/" xmlns:cpp="https://www.sphinx-doc.org/" xmlns:index="https://www.sphinx-doc.org/" xmlns:js="https://www.sphinx-doc.org/" xmlns:math="https://www.sphinx-doc.org/" xmlns:py="https://www.sphinx-doc.org/" xmlns:rst="https://www.sphinx-doc.org/" xmlns:std="https://www.sphinx-doc.org/">An Unbalanced Right-Heavy Tree with Balance Factors.</caption><image source="Trees/unbalanced.png" width="50%"/></figure>
     </section>
 

--- a/pretext/Trees/BinaryHeapImplementation.ptx
+++ b/pretext/Trees/BinaryHeapImplementation.ptx
@@ -13,7 +13,7 @@
                 shows an example of a complete binary tree.</p>
             
             <figure align="center" xml:id="fig-comptree">
-                <caption>A Complete Binary Tree</caption>
+                <caption>A Complete Binary Tree.</caption>
                     <image source="Trees/compTree.png" width="80%">
                     <description>Diagram of a complete binary tree. The top node, or the root, is labeled '5'. This root node has two child nodes: '9' to the left and '11' to the right. Each of these child nodes further branches out into two more nodes. The left child '9' has nodes '14' and '18' as children. '14' has a single left child labeled '33', while '18' has two children labeled '17' and '27'. On the right side, the child '11' has two children labeled '19' and '21'. The tree is balanced and each level is fully filled except for the last level, which is filled from the left. The image is labeled 'Figure 1: A Complete Binary Tree'.</description>
                     </image>
@@ -46,7 +46,7 @@
             
 
             <figure align="center" xml:id="fig-heaporder">
-                <caption>A Complete Binary Tree, along with its Vector Representation</caption>
+                <caption>A Complete Binary Tree, along with its Vector Representation.</caption>
                     <image source="Trees/heapOrder.png" width="80%">
                     <description>The image depicts a complete binary tree at the top and its corresponding vector representation at the bottom. The binary tree has a root node labeled '5', which branches out to two nodes labeled '9' on the left and '11' on the right. The '9' node further branches into '14' and '18', which in turn have children '33' and '17', and '27', respectively. The '11' node branches into '19' and '21'. Below the binary tree, there is a vector representation with indexed positions from 0 to 11. The values in the vector are arranged as '5', '9', '11', '14', '18', '19', '21', '33', '17', '27', respecting the binary tree's structure. The image is labeled 'Figure 2: A Complete Binary Tree, along with its Vector Representation'.</description>
                     </image>
@@ -87,7 +87,7 @@
                 series of swaps needed to percolate the newly added item up to its
                 proper position in the tree.</p>
             
-            <figure align="center" xml:id="id3"><caption xmlns:c="https://www.sphinx-doc.org/" xmlns:changeset="https://www.sphinx-doc.org/" xmlns:citation="https://www.sphinx-doc.org/" xmlns:cpp="https://www.sphinx-doc.org/" xmlns:index="https://www.sphinx-doc.org/" xmlns:js="https://www.sphinx-doc.org/" xmlns:math="https://www.sphinx-doc.org/" xmlns:py="https://www.sphinx-doc.org/" xmlns:rst="https://www.sphinx-doc.org/" xmlns:std="https://www.sphinx-doc.org/">Percolate the New Node up to Its Proper Position</caption><image source="Trees/percUp.png" width="50%" alt="image"/></figure>
+            <figure align="center" xml:id="id3"><caption xmlns:c="https://www.sphinx-doc.org/" xmlns:changeset="https://www.sphinx-doc.org/" xmlns:citation="https://www.sphinx-doc.org/" xmlns:cpp="https://www.sphinx-doc.org/" xmlns:index="https://www.sphinx-doc.org/" xmlns:js="https://www.sphinx-doc.org/" xmlns:math="https://www.sphinx-doc.org/" xmlns:py="https://www.sphinx-doc.org/" xmlns:rst="https://www.sphinx-doc.org/" xmlns:std="https://www.sphinx-doc.org/">Percolate the New Node up to Its Proper Position.</caption><image source="Trees/percUp.png" width="50%" alt="image"/></figure>
             
             <p>Notice that when we percolate an item up, we are restoring the heap
                 property between the newly added item and the parent. We are also
@@ -137,7 +137,7 @@
                 the series of swaps needed to move the new root node to its proper
                 position in the heap.</p>
             
-            <figure align="center" xml:id="id4"><caption xmlns:c="https://www.sphinx-doc.org/" xmlns:changeset="https://www.sphinx-doc.org/" xmlns:citation="https://www.sphinx-doc.org/" xmlns:cpp="https://www.sphinx-doc.org/" xmlns:index="https://www.sphinx-doc.org/" xmlns:js="https://www.sphinx-doc.org/" xmlns:math="https://www.sphinx-doc.org/" xmlns:py="https://www.sphinx-doc.org/" xmlns:rst="https://www.sphinx-doc.org/" xmlns:std="https://www.sphinx-doc.org/">Percolating the Root Node down the Tree</caption><image source="Trees/percDown.png" width="50%" alt="image"/></figure>
+            <figure align="center" xml:id="id4"><caption xmlns:c="https://www.sphinx-doc.org/" xmlns:changeset="https://www.sphinx-doc.org/" xmlns:citation="https://www.sphinx-doc.org/" xmlns:cpp="https://www.sphinx-doc.org/" xmlns:index="https://www.sphinx-doc.org/" xmlns:js="https://www.sphinx-doc.org/" xmlns:math="https://www.sphinx-doc.org/" xmlns:py="https://www.sphinx-doc.org/" xmlns:rst="https://www.sphinx-doc.org/" xmlns:std="https://www.sphinx-doc.org/">Percolating the Root Node down the Tree.</caption><image source="Trees/percDown.png" width="50%" alt="image"/></figure>
             <p>In order to maintain the heap order property, all we need to do is swap
                 the root with its smallest child less than the root. After the initial
                 swap, we may repeat the swapping process with a node and its children
@@ -221,7 +221,7 @@ int minChild(int i){
     }
 }</pre>
             
-            <figure align="center" xml:id="id5"><caption xmlns:c="https://www.sphinx-doc.org/" xmlns:changeset="https://www.sphinx-doc.org/" xmlns:citation="https://www.sphinx-doc.org/" xmlns:cpp="https://www.sphinx-doc.org/" xmlns:index="https://www.sphinx-doc.org/" xmlns:js="https://www.sphinx-doc.org/" xmlns:math="https://www.sphinx-doc.org/" xmlns:py="https://www.sphinx-doc.org/" xmlns:rst="https://www.sphinx-doc.org/" xmlns:std="https://www.sphinx-doc.org/">Building a Heap from the vector [9, 6, 5, 2, 3]</caption><image source="Trees/buildheap.png" width="50%" alt="image"/></figure>
+            <figure align="center" xml:id="id5"><caption xmlns:c="https://www.sphinx-doc.org/" xmlns:changeset="https://www.sphinx-doc.org/" xmlns:citation="https://www.sphinx-doc.org/" xmlns:cpp="https://www.sphinx-doc.org/" xmlns:index="https://www.sphinx-doc.org/" xmlns:js="https://www.sphinx-doc.org/" xmlns:math="https://www.sphinx-doc.org/" xmlns:py="https://www.sphinx-doc.org/" xmlns:rst="https://www.sphinx-doc.org/" xmlns:std="https://www.sphinx-doc.org/">Building a Heap from the vector [9, 6, 5, 2, 3].</caption><image source="Trees/buildheap.png" width="50%" alt="image"/></figure>
             <p><xref ref="fig-buildheap"/> shows the swaps that the <c>buildHeap</c> method
                 makes as it moves the nodes in an initial tree of [9, 6, 5, 2, 3] into
                 their proper positions. Although we start out in the middle of the tree

--- a/pretext/Trees/BinaryHeapPriorityQExample.ptx
+++ b/pretext/Trees/BinaryHeapPriorityQExample.ptx
@@ -8,7 +8,7 @@
         
 
         <figure align="center" xml:id="fig-trees_pq-insertion">
-            <caption>Homework insertion process into priority queue</caption>
+            <caption>Homework insertion process into priority queue.</caption>
                 <image source="Trees/Homework_PQ.png" width="80%">
                 <description>A sequence of diagrams depicting the insertion process into a priority queue represented by a binary tree. Starting with a single node labeled '3', the first diagram shows 'Insert 10', leading to a new node '10' added as a child. The next step 'Insert 5' adds a new node '5', followed by 'Insert 8' which adds node '8'. Another step shows 'Insert 7' with a node '7' being added, and the sequence progresses with each insertion maintaining the binary tree structure. The diagrams show the dynamic reordering of nodes to maintain the priority queue property, with the final structure at the bottom left displaying a balanced binary tree with node '2' at the top, leading to nodes '3' and '7', which branch out to further nodes '10', '8', '5', and '2'. Arrows indicate the insertion order and the adjustments within the tree. </description>
                 </image>
@@ -17,7 +17,7 @@
         
 
         <figure align="center" xml:id="fig-trees_pq-del">
-            <caption>After finishing the earliest homework, the root is removed and rearranges the priority queue</caption>
+            <caption>After finishing the earliest homework, the root is removed and rearranges the priority queue.</caption>
                 <image source="Trees/PQ_Del.png" width="80%">
                 <description>Two diagrams showing the process of removing the root from a binary heap that represents a priority queue. The first diagram on the left shows a binary tree with the root node '3', which has two children: '7' on the left with its own children '10' and '8', and '5' on the right. An arrow points from this tree to the second diagram on the right, indicating the removal of the root node. The second diagram shows the tree after the root has been removed and the heap has been restructured: the node '5' has been moved to the root position, with '7' as its left child and '3' as its right child, maintaining the heap property. The nodes '10' and '8' remain as children of '7'. The tree restructuring is shown with curved arrows indicating the new parent-child relationships.</description>
                 </image>

--- a/pretext/Trees/ExamplesofTrees.ptx
+++ b/pretext/Trees/ExamplesofTrees.ptx
@@ -24,7 +24,7 @@
         
     
         <figure align="center" xml:id="fig-biotree">
-            <caption>Taxonomy of Some Common Animals Shown as a Tree</caption>
+            <caption>Taxonomy of Some Common Animals Shown as a Tree.</caption>
                 <image source="Trees/biology.png" width="80%">
                 <description>The image displays a taxonomy tree diagram of some common animals, illustrating their scientific classification from kingdom to species. At the top, 'Animalia' branches into 'Chordate' and 'Arthropoda', leading down to classifications such as 'Mammal' and 'Insect'. Specific branches detail the classification of humans, chimpanzees, house cats, lions, and houseflies, listing their respective taxonomic ranks from 'Kingdom' down to 'Species'. Each species is paired with its common name, like 'Homo sapiens' for human, 'Pan troglodytes' for chimpanzee, 'Felis domestica' for house cat, 'Panthera leo' for lion, and 'Musca domestica' for housefly. </description>
                 </image>
@@ -59,7 +59,7 @@
         
 
         <figure align="center" xml:id="fig-filetree">
-            <caption>A Small Part of the Unix File System Hierarchy</caption>
+            <caption>A Small Part of the Unix File System Hierarchy.</caption>
                 <image source="Trees/directory.png" width="90%">
                 <description>The image shows a hierarchical diagram representing a small part of the Unix file system structure. It starts from a single root node that branches out to various directories such as '/dev/', '/etc/', '/sbin/', '/tmp/', '/Users/', '/usr/', and '/var/'. Each of these main directories further branches into subdirectories like '/cups/' and '/httpd/' under '/dev/', or '/bin/', '/lib/', and '/local/' under '/usr/'. The diagram visually organizes the structure and relationships of these directories in a tree-like format, indicating how files and subdirectories are organized within a Unix-based operating system.  </description>
                 </image>
@@ -97,7 +97,7 @@
         
 
         <figure align="center" xml:id="fig-htmltree">
-            <caption>A Tree Corresponding to the Markup Elements of a Web Page</caption>
+            <caption>A Tree Corresponding to the Markup Elements of a Web Page.</caption>
                 <image source="Trees/htmltree.png" width="80%">
                 <description>A diagrammatic representation of a web page's Document Object Model (DOM) tree. The tree has 'html' as the root node, which branches off into 'head' and 'body' nodes. The 'head' node further branches into 'meta' and 'title', while the 'body' node extends into 'ul', 'h1', and 'h2' nodes. The 'ul' (unordered list) node has two 'li' (list item) child nodes, and the 'h2' node has an 'a' (anchor) child node, representing a hyperlink. This tree structure visually maps out the hierarchy and relationships of markup elements within a web page.   </description>
                 </image>

--- a/pretext/Trees/Glossary.ptx
+++ b/pretext/Trees/Glossary.ptx
@@ -6,20 +6,20 @@
                     <title>AVL tree</title>
                     
                         <p>a binary search tree that automatically makes sure the tree remains
-                            balanced at all times</p>
+                            balanced at all times.</p>
                     
                 </gi>
                 <gi>
                     <title>balance factor</title>
                     
                         <p>the difference between the height of the left and right subtrees of
-                            a node</p>
+                            a node.</p>
                     
                 </gi>
                 <gi>
                     <title>binary heap</title>
                     
-                        <p>a complete binary tree that follows heap ordering rules</p>
+                        <p>a complete binary tree that follows heap ordering rules.</p>
                     
                 </gi>
                 <gi>
@@ -27,13 +27,13 @@
                     
                         <p>a binary tree in which each node has no more than 2 children; node values
                             in the left sub-tree are less than the parent while node values in the
-                            right sub-tree are</p>
+                            right sub-tree are.</p>
                     
                 </gi>
                 <gi>
                     <title>binary tree</title>
                     
-                        <p>a tree with a maximum of two children for each node</p>
+                        <p>a tree with a maximum of two children for each node.</p>
                     
                 </gi>
                 <gi>
@@ -41,26 +41,26 @@
                     
                         <p>property of a binary search key in which the keys that are less than
                             the parent are found in the left subtree and keys that are greater
-                            than the parent are found in the right subtree</p>
+                            than the parent are found in the right subtree.</p>
                     
                 </gi>
                 <gi>
                     <title>children</title>
                     
-                        <p>the nodes that one node leads to</p>
+                        <p>the nodes that one node leads to.</p>
                     
                 </gi>
                 <gi>
                     <title>complete binary tree</title>
                     
                         <p>a tree in which each level has all of its nodes, with the exception of
-                            the bottom level</p>
+                            the bottom level.</p>
                     
                 </gi>
                 <gi>
                     <title>edge</title>
                     
-                        <p>connects two nodes in a tree; has only one incoming edge</p>
+                        <p>connects two nodes in a tree; has only one incoming edge.</p>
                     
                 </gi>
                 <gi>
@@ -68,114 +68,114 @@
                     
                         <p>property of the heap based on min heap or max heap (i.e. in a min heap,
                             every node x with a parent p, the key in p is smaller than or equal to
-                            the key in x)</p>
+                            the key in x).</p>
                     
                 </gi>
                 <gi>
                     <title>height</title>
                     
-                        <p>the maximum level of any node in the tree</p>
+                        <p>the maximum level of any node in the tree.</p>
                     
                 </gi>
                 <gi>
                     <title>inorder</title>
                     
                         <p>recursive tree traversal in which the left subtree is visited, then the
-                            root node, followed by the right subtree</p>
+                            root node, followed by the right subtree.</p>
                     
                 </gi>
                 <gi>
                     <title>leaf node</title>
                     
-                        <p>a node that has no children</p>
+                        <p>a node that has no children.</p>
                     
                 </gi>
                 <gi>
                     <title>level</title>
                     
-                        <p>the number of edges on the path from the root to the current node</p>
+                        <p>the number of edges on the path from the root to the current node.</p>
                     
                 </gi>
                 <gi>
                     <title>max heap</title>
                     
-                        <p>a binary heap in which the largest key is always at the front</p>
+                        <p>a binary heap in which the largest key is always at the front.</p>
                     
                 </gi>
                 <gi>
                     <title>min heap</title>
                     
-                        <p>a binary heap in which the smallest key is always at the front</p>
+                        <p>a binary heap in which the smallest key is always at the front.</p>
                     
                 </gi>
                 <gi>
                     <title>node</title>
                     
-                        <p>part of the tree that holds information</p>
+                        <p>part of the tree that holds information.</p>
                     
                 </gi>
                 <gi>
                     <title>parent</title>
                     
-                        <p>a node that leads to other nodes</p>
+                        <p>a node that leads to other nodes.</p>
                     
                 </gi>
                 <gi>
                     <title>path</title>
                     
-                        <p>an ordered list of nodes connected by edges</p>
+                        <p>an ordered list of nodes connected by edges.</p>
                     
                 </gi>
                 <gi>
                     <title>postorder</title>
                     
                         <p>recursive tree traversal in which the left subtree is visited, then the
-                            right, followed by the root node</p>
+                            right, followed by the root node.</p>
                     
                 </gi>
                 <gi>
                     <title>preorder</title>
                     
                         <p>recursive tree traversal in which the root node is visited, then the
-                            left, followed by the right subtree</p>
+                            left, followed by the right subtree.</p>
                     
                 </gi>
                 <gi>
                     <title>priority queue</title>
                     
-                        <p>a queue whose elements have a priority that determines their order</p>
+                        <p>a queue whose elements have a priority that determines their order.</p>
                     
                 </gi>
                 <gi>
                     <title>root</title>
                     
-                        <p>the starting point of the tree; has no incoming edges</p>
+                        <p>the starting point of the tree; has no incoming edges.</p>
                     
                 </gi>
                 <gi>
                     <title>rotation</title>
                     
                         <p>rotating the parent and children nodes in a subtree to reorganize
-                            their hierarchy</p>
+                            their hierarchy.</p>
                     
                 </gi>
                 <gi>
                     <title>sibling</title>
                     
-                        <p>children of the same parent node</p>
+                        <p>children of the same parent node.</p>
                     
                 </gi>
                 <gi>
                     <title>subtree</title>
                     
-                        <p>a section of a tree</p>
+                        <p>a section of a tree.</p>
                     
                 </gi>
                 <gi>
                     <title>successor</title>
                     
                         <p>a node that can replace another node while preserving the binary search
-                            tree relationships; the next-largest key in the tree</p>
+                            tree relationships; the next-largest key in the tree.</p>
                     
                 </gi>
                 <gi>

--- a/pretext/Trees/NodesandReferences.ptx
+++ b/pretext/Trees/NodesandReferences.ptx
@@ -9,7 +9,7 @@
             structured like the one shown in <xref ref="fig-treerec"/>.</p>
         
         <figure align="center" xml:id="fig-treerec">
-            <caption>A Simple Tree Using a Nodes and References Approach</caption>
+            <caption>A Simple Tree Using a Nodes and References Approach.</caption>
                 <image source="Trees/treerecs.png" width="50%">
                 <description>Illustration of a binary tree structure with three levels. The top level shows a single node labeled 'a' with two pointers 'left' and 'right'. The second level has two nodes: 'b' on the left with its own 'left' and 'right' pointers, and 'c' on the right with pointers also labeled 'left' and 'right'. The third level shows three nodes: 'd' is the left child of 'b' with 'left' and 'right' pointers; 'e' is the right child of 'b' with pointers labeled 'left' and 'right'; 'f' is the right child of 'c' also with 'left' and 'right' pointers. Each pointer is represented by an arrow indicating the direction of the reference. </description>
                 </image>

--- a/pretext/Trees/ParseTree.ptx
+++ b/pretext/Trees/ParseTree.ptx
@@ -6,7 +6,7 @@
             trees can be used to represent real-world constructions like sentences or mathematical expressions.</p>
         
         <figure align="center" xml:id="fig-nlparse">
-            <caption>A Parse Tree for a Simple Sentence</caption>
+            <caption>A Parse Tree for a Simple Sentence.</caption>
                 <image source="Trees/nlParse.png" width="50%">
                 <description>Diagram of a parse tree for linguistic analysis. The root of the tree is labeled 'Sentence' which splits into two branches: 'Noun Phrase' and 'Verb Phrase'. The 'Noun Phrase' branch further breaks down into 'Proper Noun', which leads to the word 'Homer'. The 'Verb Phrase' branch divides into 'Verb', leading to the word 'Hit', and another 'Noun Phrase', which further breaks down into 'Proper Noun', leading to the word 'Bart'. The structure illustrates the grammatical relationships in a simple sentence. </description>
                 </image>
@@ -16,7 +16,7 @@
             with the individual parts of the sentence by using subtrees.</p>
         
         <figure align="center" xml:id="fig-meparse">
-            <caption>Parse Tree for <m>((7+3)*(5-2))</m></caption>
+            <caption>Parse Tree for <m>((7+3)*(5-2))</m>.</caption>
                 <image source="Trees/meParse.png" width="50%">
                 <description>Diagram of a parse tree for an arithmetic expression. The root node is an asterisk '*', indicating multiplication. It has two child nodes: on the left, a plus sign '+' connects the numbers 7 and 3, and on the right, a minus sign '-' connects the numbers 5 and 2. This tree represents the mathematical expression ((7 + 3) * (5 - 2)). The image is labeled 'Figure 2: Parse Tree for ((7 + 3) * (5 - 2)). </description>
                 </image>
@@ -42,7 +42,7 @@
 
 
         <figure align="center" xml:id="fig-mesimple">
-            <caption>A Simplified Parse Tree for <m>((7+3)*(5-2))</m></caption>
+            <caption>A Simplified Parse Tree for <m>((7+3)*(5-2))</m>.</caption>
                 <image source="Trees/meSimple.png" width="50%">
                 <description>Diagram of a simplified parse tree for an arithmetic expression after evaluation. The root node is an asterisk '*', indicating multiplication. It has two child nodes, which are the results of the arithmetic operations: the number 10 on the left, which is the sum of 7 and 3, and the number 3 on the right, which is the result of subtracting 2 from 5. This tree represents the evaluated mathematical expression ((7 + 3) * (5 - 2)). The image is labeled 'Figure 3: A Simplified Parse Tree for ((7 + 3) * (5 - 2)). </description>
                 </image>
@@ -103,7 +103,7 @@
             token is processed.</p>
     
         <figure align="center" xml:id="fig-buildExp">
-            <caption>Tracing Parse Tree Construction</caption>
+            <caption>Tracing Parse Tree Construction.</caption>
                 <image source="Trees/buildExp1.png" width="15%"/>
                 <image source="Trees/buildExp2.png" width="25%"/>
                 <image source="Trees/buildExp3.png" width="25%"/>

--- a/pretext/Trees/SearchTreeAnalysis.ptx
+++ b/pretext/Trees/SearchTreeAnalysis.ptx
@@ -33,7 +33,7 @@
             such a tree is shown in <xref ref="fig-skewedtree-analysis"/>. In this case the
             performance of the <c>put</c> method is <m>O(n)</m>.</p>
         
-        <figure align="center" xml:id="fig-skewedtree-analysis"><caption xmlns:c="https://www.sphinx-doc.org/" xmlns:changeset="https://www.sphinx-doc.org/" xmlns:citation="https://www.sphinx-doc.org/" xmlns:cpp="https://www.sphinx-doc.org/" xmlns:index="https://www.sphinx-doc.org/" xmlns:js="https://www.sphinx-doc.org/" xmlns:math="https://www.sphinx-doc.org/" xmlns:py="https://www.sphinx-doc.org/" xmlns:rst="https://www.sphinx-doc.org/" xmlns:std="https://www.sphinx-doc.org/">A skewed binary search tree would give poor performance</caption><image source="Trees/skewedTree.png" width="50%"/></figure>
+        <figure align="center" xml:id="fig-skewedtree-analysis"><caption xmlns:c="https://www.sphinx-doc.org/" xmlns:changeset="https://www.sphinx-doc.org/" xmlns:citation="https://www.sphinx-doc.org/" xmlns:cpp="https://www.sphinx-doc.org/" xmlns:index="https://www.sphinx-doc.org/" xmlns:js="https://www.sphinx-doc.org/" xmlns:math="https://www.sphinx-doc.org/" xmlns:py="https://www.sphinx-doc.org/" xmlns:rst="https://www.sphinx-doc.org/" xmlns:std="https://www.sphinx-doc.org/">A skewed binary search tree would give poor performance.</caption><image source="Trees/skewedTree.png" width="50%"/></figure>
         <p>Now that you understand that the performance of
             the <c>put</c> method is limited by the height of the tree, you can
             probably guess that other methods, <c>get, in,</c> and <c>del</c>, are limited

--- a/pretext/Trees/SearchTreeImplementation.ptx
+++ b/pretext/Trees/SearchTreeImplementation.ptx
@@ -11,7 +11,7 @@
             subtree are less than the key in the root. All of the keys in the right
             subtree are greater than the root.</p>
         
-        <figure align="center" xml:id="fig-simplebst"><caption xmlns:c="https://www.sphinx-doc.org/" xmlns:changeset="https://www.sphinx-doc.org/" xmlns:citation="https://www.sphinx-doc.org/" xmlns:cpp="https://www.sphinx-doc.org/" xmlns:index="https://www.sphinx-doc.org/" xmlns:js="https://www.sphinx-doc.org/" xmlns:math="https://www.sphinx-doc.org/" xmlns:py="https://www.sphinx-doc.org/" xmlns:rst="https://www.sphinx-doc.org/" xmlns:std="https://www.sphinx-doc.org/">A Simple Binary Search Tree</caption><image source="Trees/simpleBST.png" width="50%"/></figure>
+        <figure align="center" xml:id="fig-simplebst"><caption xmlns:c="https://www.sphinx-doc.org/" xmlns:changeset="https://www.sphinx-doc.org/" xmlns:citation="https://www.sphinx-doc.org/" xmlns:cpp="https://www.sphinx-doc.org/" xmlns:index="https://www.sphinx-doc.org/" xmlns:js="https://www.sphinx-doc.org/" xmlns:math="https://www.sphinx-doc.org/" xmlns:py="https://www.sphinx-doc.org/" xmlns:rst="https://www.sphinx-doc.org/" xmlns:std="https://www.sphinx-doc.org/">A Simple Binary Search Tree.</caption><image source="Trees/simpleBST.png" width="50%"/></figure>
         <p>Now that you know what a binary search tree is, we will look at how a
             binary search tree is constructed. The search tree in
             <xref ref="fig-simplebst"/> represents the nodes that exist after we have
@@ -213,7 +213,7 @@ void _put(int key, string val, TreeNode *currentNode){
             into a binary search tree. The lightly shaded nodes indicate the nodes
             that were visited during the insertion process.</p>
         
-        <figure align="center" xml:id="fig-bstput"><caption xmlns:c="https://www.sphinx-doc.org/" xmlns:changeset="https://www.sphinx-doc.org/" xmlns:citation="https://www.sphinx-doc.org/" xmlns:cpp="https://www.sphinx-doc.org/" xmlns:index="https://www.sphinx-doc.org/" xmlns:js="https://www.sphinx-doc.org/" xmlns:math="https://www.sphinx-doc.org/" xmlns:py="https://www.sphinx-doc.org/" xmlns:rst="https://www.sphinx-doc.org/" xmlns:std="https://www.sphinx-doc.org/">Inserting a Node with Key = 19</caption><image source="Trees/bstput.png" width="50%"/></figure>
+        <figure align="center" xml:id="fig-bstput"><caption xmlns:c="https://www.sphinx-doc.org/" xmlns:changeset="https://www.sphinx-doc.org/" xmlns:citation="https://www.sphinx-doc.org/" xmlns:cpp="https://www.sphinx-doc.org/" xmlns:index="https://www.sphinx-doc.org/" xmlns:js="https://www.sphinx-doc.org/" xmlns:math="https://www.sphinx-doc.org/" xmlns:py="https://www.sphinx-doc.org/" xmlns:rst="https://www.sphinx-doc.org/" xmlns:std="https://www.sphinx-doc.org/">Inserting a Node with Key = 19.</caption><image source="Trees/bstput.png" width="50%"/></figure>
         <note>
             <title>Self Check</title>
 
@@ -318,7 +318,7 @@ TreeNode  *_get(int key, TreeNode *currentNode){
     }
 }</pre>
         
-        <figure align="center" xml:id="id3"><caption xmlns:c="https://www.sphinx-doc.org/" xmlns:changeset="https://www.sphinx-doc.org/" xmlns:citation="https://www.sphinx-doc.org/" xmlns:cpp="https://www.sphinx-doc.org/" xmlns:index="https://www.sphinx-doc.org/" xmlns:js="https://www.sphinx-doc.org/" xmlns:math="https://www.sphinx-doc.org/" xmlns:py="https://www.sphinx-doc.org/" xmlns:rst="https://www.sphinx-doc.org/" xmlns:std="https://www.sphinx-doc.org/">Deleting Node 16, a Node without Children</caption><image source="Trees/bstdel1.png" width="50%"/></figure>
+        <figure align="center" xml:id="id3"><caption xmlns:c="https://www.sphinx-doc.org/" xmlns:changeset="https://www.sphinx-doc.org/" xmlns:citation="https://www.sphinx-doc.org/" xmlns:cpp="https://www.sphinx-doc.org/" xmlns:index="https://www.sphinx-doc.org/" xmlns:js="https://www.sphinx-doc.org/" xmlns:math="https://www.sphinx-doc.org/" xmlns:py="https://www.sphinx-doc.org/" xmlns:rst="https://www.sphinx-doc.org/" xmlns:std="https://www.sphinx-doc.org/">Deleting Node 16, a Node without Children.</caption><image source="Trees/bstdel1.png" width="50%"/></figure>
         <p>The second case is only slightly more complicated (see <xref ref="lst-bst7"/>). If a node has only a
             single child, then we can simply promote the child to take the place of
             its parent. The code for this case is shown in the next listing. As
@@ -384,7 +384,7 @@ TreeNode  *_get(int key, TreeNode *currentNode){
     }
 }</pre>
         
-        <figure align="center" xml:id="id4"><caption xmlns:c="https://www.sphinx-doc.org/" xmlns:changeset="https://www.sphinx-doc.org/" xmlns:citation="https://www.sphinx-doc.org/" xmlns:cpp="https://www.sphinx-doc.org/" xmlns:index="https://www.sphinx-doc.org/" xmlns:js="https://www.sphinx-doc.org/" xmlns:math="https://www.sphinx-doc.org/" xmlns:py="https://www.sphinx-doc.org/" xmlns:rst="https://www.sphinx-doc.org/" xmlns:std="https://www.sphinx-doc.org/">Deleting Node 25, a Node That Has a Single Child</caption><image source="Trees/bstdel2.png" width="50%"/></figure>
+        <figure align="center" xml:id="id4"><caption xmlns:c="https://www.sphinx-doc.org/" xmlns:changeset="https://www.sphinx-doc.org/" xmlns:citation="https://www.sphinx-doc.org/" xmlns:cpp="https://www.sphinx-doc.org/" xmlns:index="https://www.sphinx-doc.org/" xmlns:js="https://www.sphinx-doc.org/" xmlns:math="https://www.sphinx-doc.org/" xmlns:py="https://www.sphinx-doc.org/" xmlns:rst="https://www.sphinx-doc.org/" xmlns:std="https://www.sphinx-doc.org/">Deleting Node 25, a Node That Has a Single Child.</caption><image source="Trees/bstdel2.png" width="50%"/></figure>
         <p><idx>successor node</idx>The third case is the most difficult case to handle (see <xref ref="lst-bst7"/>). If a node has two
             children, then it is unlikely that we can simply promote one of them to
             take the node's place. We can, however, search the tree for a node that
@@ -398,7 +398,7 @@ TreeNode  *_get(int key, TreeNode *currentNode){
             implemented. Once the successor has been removed, we simply put it in
             the tree in place of the node to be deleted.</p>
         
-        <figure align="center" xml:id="id5"><caption xmlns:c="https://www.sphinx-doc.org/" xmlns:changeset="https://www.sphinx-doc.org/" xmlns:citation="https://www.sphinx-doc.org/" xmlns:cpp="https://www.sphinx-doc.org/" xmlns:index="https://www.sphinx-doc.org/" xmlns:js="https://www.sphinx-doc.org/" xmlns:math="https://www.sphinx-doc.org/" xmlns:py="https://www.sphinx-doc.org/" xmlns:rst="https://www.sphinx-doc.org/" xmlns:std="https://www.sphinx-doc.org/">Deleting Node 5, a Node with Two Children</caption><image source="Trees/bstdel3.png" width="50%"/></figure>
+        <figure align="center" xml:id="id5"><caption xmlns:c="https://www.sphinx-doc.org/" xmlns:changeset="https://www.sphinx-doc.org/" xmlns:citation="https://www.sphinx-doc.org/" xmlns:cpp="https://www.sphinx-doc.org/" xmlns:index="https://www.sphinx-doc.org/" xmlns:js="https://www.sphinx-doc.org/" xmlns:math="https://www.sphinx-doc.org/" xmlns:py="https://www.sphinx-doc.org/" xmlns:rst="https://www.sphinx-doc.org/" xmlns:std="https://www.sphinx-doc.org/">Deleting Node 5, a Node with Two Children.</caption><image source="Trees/bstdel3.png" width="50%"/></figure>
         <p>The code to handle the third case is shown in the next listing.
             Notice that we make use of the helper methods <c>findSuccessor</c> and
             <c>findMin</c> to find the successor. To remove the successor, we make use

--- a/pretext/Trees/TreeTraversals.ptx
+++ b/pretext/Trees/TreeTraversals.ptx
@@ -88,7 +88,7 @@
             will stick with binary trees for now.</p>
  
         <figure align="center" xml:id="fig-booktree">
-            <caption>Representing a Book as a Tree</caption>
+            <caption>Representing a Book as a Tree.</caption>
                 <image source="Trees/booktree.png" width="50%">
                 <description>Diagram of a hierarchical tree representing the structure of a book. The root node at the top is labeled 'Book', which branches out to two child nodes labeled 'Chapter1' and 'Chapter2'. Each chapter node further divides into sections: 'Chapter1' into 'Section 1.1' and 'Section 1.2', while 'Chapter2' splits into 'Section 2.1' and 'Section 2.2'. Each section node also branches into subsections, with 'Section 1.1' leading to 'Section 1.2.1' and 'Section 1.2.2', and 'Section 2.2' leading to 'Section 2.2.1' and 'Section 2.2.2'. The nodes are connected by lines that represent the tree structure, demonstrating the organizational hierarchy of the book's contents. </description>
                 </image>

--- a/pretext/Trees/VocabularyandDefinitions.ptx
+++ b/pretext/Trees/VocabularyandDefinitions.ptx
@@ -121,7 +121,7 @@
         The arrowheads on the edges indicate the direction of the connection.</p>
 
     <figure align="center" xml:id="fig-nodeedgetree">
-        <caption>A Tree Consisting of a Set of Nodes and Edges</caption>
+        <caption>A Tree Consisting of a Set of Nodes and Edges.</caption>
             <image source="Trees/treedef1.png" width="50%">
             <description>The image shows a basic conceptual diagram of a tree data structure, consisting of a set of nodes connected by edges. The top of the tree features a 'rootnode', which branches into 'child1' and 'child2'. Below 'child1', there is 'node1' with three children labeled 'child1', 'child2', and 'child3', while 'child2' branches into 'node2' with a single 'child1'. Further down, 'node1' branches into 'node3', 'node4', and 'node5', and 'node2' branches into 'node6'. The nodes are represented by rectangles, and the connecting lines represent the edges of the tree. </description>
             </image>
@@ -137,7 +137,7 @@
     
    
     <figure align="center" xml:id="fig-recursivetree">
-        <caption>A recursive Definition of a tree</caption>
+        <caption>A recursive Definition of a tree.</caption>
             <image source="Trees/TreeDefRecursive.png" width="50%">
             <description>The image presents a simplified diagram of a tree data structure with a single 'root' node at the top, branching out into three 'subtrees' labeled 'subtree-1', 'subtree-2', and 'subtree-3'. This visual model illustrates the concept of recursion in data structures, where each subtree can be seen as a smaller instance of the larger structure. </description>
             </image>


### PR DESCRIPTION
Fixing formatting issues in Chapter 8

# Description
Inconsistency in some of the sentences. Some had a period after while others did not. So, I fixed that by putting periods after all sentences. 

## Related Issue
#654    originally, but the issues are within all the chapters. Therefore, I am fixing all of them.

## How Has This Been Tested?
Tested by rebuilding the book in the local library. 
