### PR TITLE
Fixed all formatting issues in chapter 9, cppds2

### DIFF
--- a/pretext/Graphs/AnAdjacencyList.ptx
+++ b/pretext/Graphs/AnAdjacencyList.ptx
@@ -10,7 +10,7 @@
             illustrates the adjacency list representation for the graph in
             <xref ref="graphs_vocabularyand-definitions"/>.</p>
         <figure align="center" xml:id="fig-adjlist">
-            <caption>Three Types of Logic Gates</caption>
+            <caption>Three Types of Logic Gates.</caption>
                 <image source="Graphs/adjlist.png" width="80%">
                 <description>Image displaying an adjacency list representation of a graph. The illustration shows a table labeled 'Graph' with a column 'vertList' containing vertices 'V0' through 'V5'. Next to each vertex is a corresponding vertex object, with 'id' representing the vertex ID and 'adj' listing its adjacent vertices along with the edge weights. For example, 'V0' has an adjacent vertex 'V1' with a weight of 5 and 'V5' with a weight of 2, 'V1' is adjacent to 'V2' with a weight of 4, and so on. The bottom of the table states 'numVertices = 6', indicating the total number of vertices in the graph.</description>
                 </image>

--- a/pretext/Graphs/AnAdjacencyMatrix.ptx
+++ b/pretext/Graphs/AnAdjacencyMatrix.ptx
@@ -10,7 +10,7 @@
             <xref ref="graphs_vocabularyand-definitions"/>. A value in a cell represents the weight of the
             edge from vertex <m>v</m> to vertex <m>w</m>.</p>
         <figure align="center" xml:id="fig-adjmat">
-            <caption>An Adjacency Matrix Representation for a Graph</caption>
+            <caption>An Adjacency Matrix Representation for a Graph.</caption>
                 <image source="Graphs/adjMat.png" width="80%">
                 <description>Image showing an adjacency matrix representation for a graph. The matrix is a square grid labeled from V0 to V5 along both the top row and the left column, representing vertices of the graph. The cells within the matrix are mostly empty, indicating no edge between those vertex pairs, with a few cells filled with numbers indicating the weight of the edge between the vertices. Specifically, V0 has an edge to V1 with a weight of 5. V1 has an edge to V5 with a weight of 4. V2 has an edge to V3 with a weight of 9. V3 has edges to V4 and V5 with weights of 7 and 3, respectively. V4 has an edge to V0 with a weight of 1. V5 has edges to V2 and V4 with weights of 1 and 8, respectively.</description>
                 </image>

--- a/pretext/Graphs/BuildingtheKnightsTourGraph.ptx
+++ b/pretext/Graphs/BuildingtheKnightsTourGraph.ptx
@@ -7,7 +7,7 @@
             moves by a knight and the corresponding edges in a graph.</p>
         
         <figure align="center" xml:id="fig-knightmoves">
-            <caption>Legal Moves for a Knight on Square 12, and the Corresponding Graph</caption>
+            <caption>Legal Moves for a Knight on Square 12, and the Corresponding Graph.</caption>
                 <image source="Graphs/knightmoves.png" width="80%">
                 <description>Image depicting the legal moves for a knight on a chessboard and the corresponding graph. On the left, there is a 5x5 section of a chessboard with numbered squares from 1 to 25. The knight is placed on square 12, with its legal moves indicated by gray dots on squares 5, 9, 15, 19, 21, and 23. On the right, a graph illustrates the knight's moves as a network of connected nodes. The central node, labeled '12', represents the knight's position, and it is connected to nodes labeled '5', '9', '15', '19', '21', and '23', which correspond to the potential moves available to the knight from its current position. </description>
                 </image>
@@ -99,7 +99,7 @@ vector&lt;int&gt; genLegalMoves(int id, int bdSize) {
             the adjacency matrix would be only 8.2 percent full.</p>
     
         <figure align="center" xml:id="fig-bigknight">
-            <caption>All Legal Moves for a Knight on an <m>8 \times 8</m> Chessboard</caption>
+            <caption>All Legal Moves for a Knight on an <m>8 \times 8</m> Chessboard.</caption>
                 <image source="Graphs/bigknight.png" width="80%">
                 <description>Complex graph showing all legal moves for a knight on an 8 x 8 chessboard, visualized as a network. The nodes are arranged in a grid pattern, numbered from 0 to 63, corresponding to the squares of a chessboard. The lines connecting the nodes represent the knight's potential moves, with each node being connected to others that a knight could reach in a single move based on the rules of chess. The myriad of crisscrossing lines create an intricate web, illustrating the complexity of the knight's movement possibilities across the entire board. </description>
                 </image>

--- a/pretext/Graphs/BuildingtheWordLadderGraph.ptx
+++ b/pretext/Graphs/BuildingtheWordLadderGraph.ptx
@@ -10,7 +10,7 @@
             are unweighted.</p>
         
         <figure align="center" xml:id="fig-wordladder">
-                <caption>A Small Word Ladder Graph</caption>
+                <caption>A Small Word Ladder Graph.</caption>
                     <image source="Graphs/wordgraph.png" width="80%">
                     <description>Image of a word ladder graph showing connections between various words. The words 'fool' and 'sage' are highlighted in boxes, suggesting they are the start and end points. From 'fool', lines connect to 'foil', 'foul', 'cool', and 'pool'. From 'pool', there are connections to 'poll', 'pall', and 'pole', and 'pole' connects to 'pale' which in turn connects to 'page', 'sale', and 'sage'. Other words like 'fail', 'fall', and 'pope' are also connected in the graph. The graph demonstrates how each word can be transformed into another word by changing a single letter at a time.</description>
                     </image>
@@ -39,7 +39,7 @@
             that all the words in the bucket must be connected.</p>
             
         <figure align="center" xml:id="fig-wordbucket">
-                <caption>Word Buckets for Words That are Different by One Letter</caption>
+                <caption>Word Buckets for Words That are Different by One Letter.</caption>
                     <image source="Graphs/wordbuckets.png" width="80%">
                     <description>Image illustrating word buckets for a group of words that differ by only one letter. There are four buckets, each labeled with a word pattern. The first bucket 'OPE' includes 'POPE', 'ROPE', 'NOPE', 'HOPE', 'LOPE', 'MOPE', and 'COPE'. The second bucket 'P_PE' contains 'POPE', 'PIPE', and 'PAPE'. The third bucket 'PO_E' lists 'POPE', 'POLE', 'PORE', 'POSE', and 'POKE'. The last bucket 'POP' includes 'POPE' and 'POPS'. Each bucket groups words that can be formed by changing the letter represented by the underscore.</description>
                     </image>

--- a/pretext/Graphs/DijkstrasAlgorithm.ptx
+++ b/pretext/Graphs/DijkstrasAlgorithm.ptx
@@ -84,28 +84,28 @@ def dijkstra(aGraph,start):
             priority queue is empty and Dijkstra's algorithm exits.</p>
         
         <figure align="center" xml:id="fig-dija">
-            <caption>Tracing Dijkstra's Algorithm</caption>
+            <caption>Tracing Dijkstra's Algorithm.</caption>
                 <image source="Graphs/dijkstraa.png" width="80%">
                 <description>The image illustrates the initial state of Dijkstra's Algorithm being traced on a weighted graph. The graph includes six nodes: u, v, w, x, y, and z. Node u is marked as the starting point with a tentative distance of zero (d=0), while other nodes are yet to be visited and have undefined distances. Edges connecting the nodes have varying weights, such as the edge from u to x has a weight of 2, and the edge from x to v has a weight of 1. A priority queue (PQ) is depicted at the bottom, currently holding nodes x, v, and w, which will be processed according to the algorithm.</description>
                 </image>
             </figure>
         
         <figure align="center" xml:id="fig-dijb">
-            <caption>Tracing Dijkstra's Algorithm</caption>
+            <caption>Tracing Dijkstra's Algorithm.</caption>
                 <image source="Graphs/dijkstrab.png" width="80%">
                 <description> This image further traces Dijkstra's Algorithm on the same weighted graph. The priority queue (PQ) at the bottom has been updated to contain only nodes v and w. Node x has been visited with the shortest distance from u determined (d=1), indicated by a solid line. Other nodes have tentative distances, like node v with a distance of 2 (d=2). Dashed lines indicate unconfirmed paths that are still under consideration.</description>
                 </image>
             </figure>
 
         <figure align="center" xml:id="fig-dijc">
-            <caption>Tracing Dijkstra's Algorithm</caption>
+            <caption>Tracing Dijkstra's Algorithm.</caption>
                 <image source="Graphs/dijkstrac.png" width="80%">
                 <description>The image continues the progression of Dijkstra's Algorithm on the graph. Node v has now been confirmed with the shortest path from u (d=2) and is connected by solid lines. The priority queue (PQ) at the bottom now includes only node w. Node x shows the confirmed shortest path from u, and node y has a tentative distance of 2 (d=2). The algorithm visually demonstrates the process of finding the shortest paths from a single source to all other nodes in the graph.</description>
                 </image>
             </figure>
         
         <figure align="center" xml:id="fig-dijd">
-            <caption>Tracing Dijkstra's Algorithm</caption>
+            <caption>Tracing Dijkstra's Algorithm.</caption>
                 <image source="Graphs/dijkstrad.png" width="80%">
                 <description>The image shows a continuation of Dijkstra's Algorithm on a weighted graph. The graph's nodes u, v, w, x, y, and z are connected by directed edges with weights. Node w is the current focus, indicated by the priority queue (PQ) containing only w. Nodes u, x, and v have confirmed shortest paths with solid lines leading to them, and their distances from the starting node u are marked as d=0, d=1, and d=2, respectively. Dashed lines suggest potential paths still under consideration.</description>
                 </image>
@@ -113,7 +113,7 @@ def dijkstra(aGraph,start):
         
 
         <figure align="center" xml:id="fig-dije">
-            <caption>Tracing Dijkstra's Algorithm</caption>
+            <caption>Tracing Dijkstra's Algorithm.</caption>
                 <image source="Graphs/dijkstrae.png" width="80%">
                 <description>This step in Dijkstra's Algorithm shows node w with a confirmed shortest path from the starting node (d=3). The priority queue (PQ) at the bottom now contains only node z. The graph is further resolved with nodes u, x, v, and y having confirmed shortest paths, displayed with solid lines and distances marked. The algorithm's process is nearing completion, with almost all nodes having the shortest paths determined.</description>
                 </image>
@@ -121,7 +121,7 @@ def dijkstra(aGraph,start):
         
 
         <figure align="center" xml:id="fig-dijf">
-            <caption>Tracing Dijkstra's Algorithm</caption>
+            <caption>Tracing Dijkstra's Algorithm.</caption>
                 <image source="Graphs/dijkstraf.png" width="80%">
                 <description>The final image depicts the weighted graph after the completion of Dijkstra's Algorithm. All nodes have confirmed shortest paths from the starting node u, which are shown with solid lines. The priority queue (PQ) is now empty, indicating that the algorithm has finished running. Each node has a definitive shortest distance from u (d=0, d=1, d=2, d=3, etc.), and the pathfinding process is complete, showcasing the algorithm's effectiveness in solving the shortest path problem.</description>
                 </image>

--- a/pretext/Graphs/DiscussionQuestions.ptx
+++ b/pretext/Graphs/DiscussionQuestions.ptx
@@ -6,7 +6,7 @@
             </li>
         </ol></p>
         <figure align="center" xml:id="fig-adjMatEX">
-            <caption>Adjacency matrix</caption>
+            <caption>Adjacency matrix.</caption>
                 <image source="Graphs/adjMatEX.png" width="80%">
                 <description>Adjacency matrix with weighted edges between nodes A to F. A connects to B with 7, to E with 5, and to F with 1. B connects to A with 2, to D with 7, and to E with 3. C connects to B with 2 and to F with 8. D connects to A with 1, to C with 2, and to E with 4. E connects to A with 6 and to C with 5. F connects to A with 1 and to C with 8.</description>
                 </image>

--- a/pretext/Graphs/GeneralDepthFirstSearch.ptx
+++ b/pretext/Graphs/GeneralDepthFirstSearch.ptx
@@ -241,35 +241,35 @@ main()
             setting finish times and coloring vertices black.</p>
     
         <figure align="center" xml:id="fig-gdfsa">
-            <caption>Constructing the Depth First Search Tree-10</caption>
+            <caption>Constructing the Depth First Search Tree-10.</caption>
                 <image source="Graphs/gendfsa.png" width="80%">
                 <description>A graph with six nodes labeled A through F. Node A is marked as the starting point with a '1' and has directed edges to nodes B and D, showing the initial branching in a depth-first search tree.</description>
                 </image>
             </figure>
         
         <figure align="center" xml:id="fig-gdfsb">
-            <caption>Constructing the Depth First Search Tree-11</caption>
+            <caption>Constructing the Depth First Search Tree-11.</caption>
                 <image source="Graphs/gendfsb.png" width="80%">
                 <description>The graph extends from Figure 14, showing node B as the next node visited in the search, indicated by a '2'. Nodes E and C are shown as subsequent nodes, but not yet visited.</description>
                 </image>
             </figure>
         
         <figure align="center" xml:id="fig-gdfsc">
-            <caption> Constructing the Depth First Search Tree-12</caption>
+            <caption> Constructing the Depth First Search Tree-12.</caption>
                 <image source="Graphs/gendfsc.png" width="80%">
                 <description>Continuing the sequence, node C is now marked with a '3', showing the progression of the depth-first search moving to the next unvisited node in the tree.</description>
                 </image>
             </figure>
         
         <figure align="center" xml:id="fig-gdfsd">
-            <caption> Constructing the Depth First Search Tree-13</caption>
+            <caption> Constructing the Depth First Search Tree-13.</caption>
                 <image source="Graphs/gendfsd.png" width="80%">
                 <description>The graph further expands with node C's child nodes, marked as '3/4', indicating the depth-first search is exploring the deeper levels of the tree</description>
                 </image>
             </figure>
 
         <figure align="center" xml:id="fig-gdfse">
-            <caption> Constructing the Depth First Search Tree-14</caption>
+            <caption> Constructing the Depth First Search Tree-14.</caption>
                 <image source="Graphs/gendfse.png" width="80%">
                 <description>Depth-first search progression with node D marked '5', indicating its visit after nodes A, B, and C, and before node E.</description>
                 </image>
@@ -277,48 +277,48 @@ main()
         
         
         <figure align="center" xml:id="fig-gdfsf">
-            <caption> Constructing the Depth First Search Tree-15</caption>
+            <caption> Constructing the Depth First Search Tree-15.</caption>
                 <image source="Graphs/gendfsf.png" width="80%">
                 <description>Node E is visited, labeled '6' in the search sequence, following the exploration from node D in the depth-first search tree.</description>
                 </image>
             </figure>
         
         <figure align="center" xml:id="fig-gdfsg">
-            <caption> Constructing the Depth First Search Tree-16</caption>
+            <caption> Constructing the Depth First Search Tree-16.</caption>
                 <image source="Graphs/gendfsg.png" width="80%">
                 <description>The search continues with node F now visited, labeled with '7', and an unvisited node is connected to node C with a directed edge.</description>
                 </image>
             </figure>
         
         <figure align="center" xml:id="fig-gdfsh">
-            <caption> Constructing the Depth First Search Tree-17</caption>
+            <caption> Constructing the Depth First Search Tree-17.</caption>
                 <image source="Graphs/gendfsh.png" width="80%">
                 <description>The final stage of the depth-first search, with nodes F and B marked as '7/8', showing the completion of the tree traversal.</description>
                 </image>
             </figure>
 
         <figure align="center" xml:id="fig-gdfsi">
-            <caption> Constructing the Depth First Search Tree-18</caption>
+            <caption> Constructing the Depth First Search Tree-18.</caption>
                 <image source="Graphs/gendfsi.png" width="80%">
                 <description>A depth-first search tree diagram with nodes A to F, where nodes A, B, and C are sequentially numbered 1 to 3/4, and nodes D, E, and F are numbered 5, 6, and 7/8 respectively, showing the order of traversal.</description>
                 </image>
             </figure>
         <figure align="center" xml:id="fig-gdfsj">
-            <caption> Constructing the Depth First Search Tree-19</caption>
+            <caption> Constructing the Depth First Search Tree-19.</caption>
                 <image source="Graphs/gendfsj.png" width="80%">
                 <description>Continuation of the depth-first search tree, with node E now having two numbers, 6/9, indicating the backtracking process and further search.</description>
                 </image>
             </figure>
 
         <figure align="center" xml:id="fig-gdfsk">
-            <caption> Constructing the Depth First Search Tree-20</caption>
+            <caption> Constructing the Depth First Search Tree-20.</caption>
                 <image source="Graphs/gendfsk.png" width="80%">
                 <description>Further progress in the depth-first search tree, node B is now numbered 2/11, showing that the search has returned to this node after exploring other branches.</description>
                 </image>
             </figure>
         
         <figure align="center" xml:id="fig-gdfsl">
-            <caption> Constructing the Depth First Search Tree-21</caption>
+            <caption> Constructing the Depth First Search Tree-21.</caption>
                 <image source="Graphs/gendfsl.png" width="80%">
                 <description>The final stage in the depth-first search process with node A labeled as 1/12, completing the full traversal of the search tree.</description>
                 </image>
@@ -332,7 +332,7 @@ main()
             the tree constructed by the depth first search algorithm.</p>
         
         <figure align="center" xml:id="fig-dfstree">
-            <caption> The Resulting Depth First Search Tree</caption>
+            <caption> The Resulting Depth First Search Tree.</caption>
                 <image source="Graphs/dfstree.png" width="80%">
                 <description>A completed depth first search tree with six nodes labeled A to F. The nodes are interconnected with arrows indicating the path of the search. Each node is annotated with two numbers; the first number represents the order in which the node was first visited, and the second number represents the order in which the final visit occurred, marking the node’s completion in the search. Node A is labeled "1/12", B "2/11", C "3/4", D "5/10", E "6/9", and F "7/8". This indicates the starting point of the search at node A, the backtracking steps, and the overall path taken to explore all the nodes.</description>
                 </image>

--- a/pretext/Graphs/Glossary.ptx
+++ b/pretext/Graphs/Glossary.ptx
@@ -5,13 +5,13 @@
                 <gi>
                     <title>acyclic graph</title>
                     
-                        <p>A graph with no cycles</p>
+                        <p>A graph with no cycles.</p>
                     
                 </gi>
                 <gi>
                     <title>adjacency list</title>
                     
-                        <p>A list implementation where we keep a master list of all the vertices in the Graph object and then each vertex object in the graph maintains a list of the other vertices that it is connected to</p>
+                        <p>A list implementation where we keep a master list of all the vertices in the Graph object and then each vertex object in the graph maintains a list of the other vertices that it is connected to.</p>
                     
                 </gi>
                 <gi>
@@ -59,7 +59,7 @@
                 <gi>
                     <title>digraph</title>
                     
-                        <p>see directed graph</p>
+                        <p>see directed graph.</p>
                     
                 </gi>
                 <gi>
@@ -137,7 +137,7 @@
                 <gi>
                     <title>weight</title>
                     
-                        <p>Shows that there is a cost to go from one vertex to another</p>
+                        <p>Shows that there is a cost to go from one vertex to another.</p>
                     
                 </gi>
             

--- a/pretext/Graphs/ImplementingBreadthFirstSearch.ptx
+++ b/pretext/Graphs/ImplementingBreadthFirstSearch.ptx
@@ -47,10 +47,10 @@
                 <p>The new, unexplored vertex <c>nbr</c>, is colored gray.</p>
             </li>
             <li>
-                <p>The predecessor of <c>nbr</c> is set to the current node <c>currentVert</c></p>
+                <p>The predecessor of <c>nbr</c> is set to the current node <c>currentVert</c>.</p>
             </li>
             <li>
-                <p>The distance to <c>nbr</c> is set to the distance to <c>currentVert + 1</c></p>
+                <p>The distance to <c>nbr</c> is set to the distance to <c>currentVert + 1</c>.</p>
             </li>
             <li>
                 <p><c>nbr</c> is added to the end of a queue. Adding <c>nbr</c> to the end of
@@ -109,7 +109,7 @@ Graph bfs(Graph g, Vertex *start) {
             queue after this step.</p>
         
         <figure align="center" xml:id="fig-bfs1">
-            <caption>The First Step in the Breadth First Search</caption>
+            <caption>The First Step in the Breadth First Search.</caption>
                 <image source="Graphs/bfs1.png" width="80%">
                 <description>Image of a graph and a queue representing the first step in the breadth-first search algorithm. The graph has a central node labeled 'fool', with arrows pointing to four connected nodes: 'pool', 'foil', a second 'foul', and 'cool', each marked with the number '1' to indicate a step or level. Below the graph, there's a depiction of a queue with the words 'pool', 'foil', 'foul', and 'cool' enqueued in that order. This illustrates how the algorithm explores the neighbors of the starting node 'fool' and adds them to the queue for further exploration.</description>
                 </image>
@@ -123,7 +123,7 @@ Graph bfs(Graph g, Vertex *start) {
             poll. The new state of the tree and queue is shown in <xref ref="fig-bfs2"/>.</p>
         
         <figure align="center" xml:id="fig-bfs2">
-            <caption>The Second Step in the Breadth First Search</caption>
+            <caption>The Second Step in the Breadth First Search.</caption>
                 <image source="Graphs/bfs2.png" width="80%">
                 <description>Image showing the second step in a breadth-first search algorithm on a word graph. The central node is labeled 'fool', with connections to four adjacent nodes: 'pool', 'foil', 'foul', and 'cool', each marked with a '1' indicating they were reached in the first step of the search. 'Pool' is further connected to a node labeled 'poll', marked with a '2' indicating it is reached in the second step. Below the graph, a queue is shown containing 'foil', 'foul', 'cool', and 'poll', reflecting the order in which they are visited. This demonstrates the process of exploring each node's neighbors and tracking the search progression through levels or layers. </description>
                 </image>
@@ -135,14 +135,14 @@ Graph bfs(Graph g, Vertex *start) {
             vertices on the second level of the tree.</p>
         
         <figure align="center" xml:id="fig-bfs3">
-            <caption>Breadth First Search Tree After Completing One Level</caption>
+            <caption>Breadth First Search Tree After Completing One Level.</caption>
                 <image source="Graphs/bfs3.png" width="80%">
                 <description>Image of a breadth-first search tree after completing one level. The tree starts at the top with the word 'fool'. Below 'fool', there are four nodes labeled 'pool', 'foil', 'foul', and 'cool', each marked with the number '1'. From 'foil', there is an additional node labeled 'fail', marked with the number '2'. Similarly, 'pool' connects to 'poll', also marked with '2'. The diagram indicates the sequence of words explored from the starting word 'fool' by changing one letter at a time. Below the tree, there is a queue with the words 'pole' and 'pall', representing the next words to be visited in the search.</description>
                 </image>
             </figure>
         
         <figure align="center" xml:id="fig-bfsDone">
-            <caption>Final Breadth First Search Tree</caption>
+            <caption>Final Breadth First Search Tree.</caption>
                 <image source="Graphs/bfsDone.png" width="80%">
                 <description>Image showing the final breadth-first search tree. The root of the tree is the word 'fool' with four branches leading to the words 'pool', 'foil', 'foul', and 'cool', each marked with a '1' indicating the first level of connections. 'Pool' connects to 'poll' (level 2), which further connects to 'pole' (level 3), leading to 'pope' (level 4), then to 'page' (level 5), and finally to 'sage' (level 6). Similarly, 'foil' connects to 'fail' (level 2), and 'poll' also connects to 'pall' (level 3), leading to 'pale' (level 4) and 'sale' (level 5). The levels indicate the number of steps taken from the root word to reach each subsequent word by changing one letter at a time. An empty queue box is shown to the side, suggesting that the search has been completed.</description>
                 </image>

--- a/pretext/Graphs/ImplementingKnightsTour.ptx
+++ b/pretext/Graphs/ImplementingKnightsTour.ptx
@@ -61,7 +61,7 @@ def knightTour(n,path,u,limit):
             can refer to the figures below to follow the steps of the search. For
             this example we will assume that the call to the <c>getConnections</c>
             method on line 6 orders the nodes in
-            alphabetical order. We begin by calling <c>knightTour(0,path,A,6)</c></p>
+            alphabetical order. We begin by calling <c>knightTour(0,path,A,6)</c>.</p>
         <p><c>knightTour</c> starts with node A <xref ref="fig-kta"/>. The nodes adjacent to A are B and D.
             Since B is before D alphabetically, DFS selects B to expand next as
             shown in <xref ref="fig-ktb"/>. Exploring B happens when <c>knightTour</c> is
@@ -82,56 +82,56 @@ def knightTour(n,path,u,limit):
             we need to traverse the graph to visit each node exactly once.</p>
         
         <figure align="center" xml:id="fig-kta">
-            <caption>Start with node A</caption>
+            <caption>Start with node A.</caption>
                 <image source="Graphs/ktdfsa.png" width="80%">
                 <description>Graph with node 'fool' as the central node connected to four adjacent nodes labeled 'pool', 'foil', 'foul', and 'cool', each marked with the number '1'. Below the graph is a visual representation of a queue with the nodes 'pool', 'foil', 'foul', and 'cool' lined up in order.</description>
                 </image>
             </figure>
         
         <figure align="center" xml:id="fig-ktb">
-            <caption>Explore B</caption>
+            <caption>Explore B.</caption>
                 <image source="Graphs/ktdfsb.png" width="80%">
                 <description>Graph with nodes A, B, C, D, E, and F, with node B highlighted, indicating exploration from node B to nodes A and E.</description>
                 </image>
             </figure>
 
         <figure align="center" xml:id="fig-ktc">
-            <caption>Node C is a dead end</caption>
+            <caption>Node C is a dead end.</caption>
                 <image source="Graphs/ktdfsc.png" width="80%">
                 <description>Graph highlighting node C, showing no further connections, indicating that C is a dead end in the search process.</description>
                 </image>
             </figure>
         
         <figure align="center" xml:id="fig-ktd">
-            <caption>Backtrack to B</caption>
+            <caption>Backtrack to B.</caption>
                 <image source="Graphs/ktdfsd.png" width="80%">
                 <description>Graph with a backtrack path from node C to node B, illustrating the step of returning to node B to continue the search.</description>
                 </image>
             </figure>
         
         <figure align="center" xml:id="fig-kte">
-            <caption>Explore D</caption>
+            <caption>Explore D.</caption>
                 <image source="Graphs/ktdfse.png" width="80%">
                 <description>Graph with node D highlighted, indicating the exploration is continuing from node D to nodes A and E.</description>
                 </image>
             </figure>
         
         <figure align="center" xml:id="fig-ktf">
-            <caption>Explore E</caption>
+            <caption>Explore E.</caption>
                 <image source="Graphs/ktdfsf.png" width="80%">
                 <description>Graph focusing on node E, with exploration proceeding from node E to nodes B and D.</description>
                 </image>
             </figure>
         
         <figure align="center" xml:id="fig-ktg">
-            <caption>Explore F</caption>
+            <caption>Explore F.</caption>
                 <image source="Graphs/ktdfsg.png" width="80%">
                 <description>Graph with node F highlighted, representing the search exploring potential paths from node F to node C.</description>
                 </image>
             </figure>
         
         <figure align="center" xml:id="fig-kth">
-            <caption>Finish</caption>
+            <caption>Finish.</caption>
                 <image source="Graphs/ktdfsh.png" width="80%">
                 <description>Final graph with all nodes no longer highlighted, representing the completion of the depth-first search process.</description>
                 </image>
@@ -142,7 +142,7 @@ def knightTour(n,path,u,limit):
             and end at the same square.</p>
         
         <figure align="center" xml:id="fig-completeTour">
-            <caption>A Complete Tour of the Board</caption>
+            <caption>A Complete Tour of the Board.</caption>
                 <image source="Graphs/completeTour.png" width="80%">
                 <description>Image depicting a graph overlaid on an 8x8 chessboard grid representing a complete Knight's Tour. The nodes, numbered from 0 to 63, correspond to the squares of the chessboard. Lines crisscross the grid, mapping the knight's moves in a sequential path that visits each square exactly once. The complex web of lines indicates the knight's route, creating a Hamiltonian circuit where the start and end points are connected. Captioned 'Figure 11: A Complete Tour of the Board'.</description>
                 </image>

--- a/pretext/Graphs/KnightsTourAnalysis.ptx
+++ b/pretext/Graphs/KnightsTourAnalysis.ptx
@@ -25,14 +25,14 @@
             search tree.</p>
         
         <figure align="center" xml:id="fig-8array">
-            <caption>A Search Tree for the Knight's Tour</caption>
+            <caption>A Search Tree for the Knight's Tour.</caption>
                 <image source="Graphs/8arrayTree.png" width="80%">
                 <description>Image of a search tree representing the possible sequences of moves for a Knight's Tour on a chessboard. The tree structure fans out from a single root node at the top, branching out to successive levels that represent each move of the knight. Each node represents a position on the chessboard, with the links between them representing legal moves of the knight. The breadth of the tree at each level indicates the growing complexity of the tour as more moves are made. The tree is a visual representation of the decision process in computing the tour, with the expansive spread of nodes illustrating the many possible paths the knight can take.</description>
                 </image>
             </figure>
         
         <figure align="center" xml:id="fig-nummoves">
-            <caption>Number of Possible Moves for Each Square</caption>
+            <caption>Number of Possible Moves for Each Square.</caption>
                 <image source="Graphs/moveCount.png" width="80%">
                 <description>Diagram showing an 8x8 chessboard grid, each square labeled with a number indicating the total possible moves a knight can make from that position. The numbers range from '2' on the corners, up to '8' in the central squares, with varying numbers like '3', '4', and '6' on other squares based on their position. The layout demonstrates the accessibility of each square for a knight, with central squares being the most accessible. This visualization aids in understanding the knight's range of movement on a standard chessboard.</description>
                 </image>

--- a/pretext/Graphs/Objectives.ptx
+++ b/pretext/Graphs/Objectives.ptx
@@ -9,7 +9,7 @@
                     representations.</p>
             </li>
             <li>
-                <p>To see how graphs can be used to solve a wide variety of problems</p>
+                <p>To see how graphs can be used to solve a wide variety of problems.</p>
             </li>
         </ul></p>
         <p>In this chapter we will study graphs. Graphs are a more general
@@ -35,7 +35,7 @@
             and the order in which they must be taken to complete a major in
             computer science at Luther College.</p>
         <figure align="center" xml:id="graphs_fig1">
-            <caption>Prerequisites for a Computer Science Major</caption>
+            <caption>Prerequisites for a Computer Science Major.</caption>
                 <image source="Graphs/CS-Prereqs.png" width="80%">
                 <description>Flowchart outlining the prerequisites for a Computer Science major. The chart begins with 'Math-151' leading into 'CS-220'. Below this, 'CS-150' points to 'CS-151', which in turn branches into 'CS-250' and 'CS-230'. 'CS-230' continues to 'CS-466', and 'CS-151' also points to 'CS-360', which then leads to 'CS-490'. Additionally, 'CS-360' branches off to 'CS-477'. Each course is represented as a node, and the arrows indicate the prerequisite relationship, where one course must be completed before moving on to the next. </description>
                 </image>

--- a/pretext/Graphs/PrimsSpanningTreeAlgorithm.ptx
+++ b/pretext/Graphs/PrimsSpanningTreeAlgorithm.ptx
@@ -10,7 +10,7 @@
             listening to. <xref ref="fig-bcast1"/> illustrates the broadcast problem.</p>
         
         <figure align="center" xml:id="fig-bcast1">
-            <caption>The Broadcast Problem</caption>
+            <caption>The Broadcast Problem.</caption>
                 <image source="Graphs/bcast1.png" width="80%">
                 <description>The image illustrates a network graph representing the Broadcast Problem. It features seven nodes labeled A through G, with node A designated as the broadcast host. Directed edges connect the nodes, indicating the flow of the broadcast signal, with weights on the edges representing the cost or time of transmission. Four of the nodes are marked as listeners, depicted with computer icons. These listeners are at the terminus of the broadcast paths, showing the direction and flow of information from the host to the listeners through the network.</description>
                 </image>
@@ -64,7 +64,7 @@
             that are interested see a copy of the message.</p>
 
         <figure align="center" xml:id="fig-mst1">
-            <caption>Minimum Spanning Tree for the Broadcast Graph</caption>
+            <caption>Minimum Spanning Tree for the Broadcast Graph.</caption>
                 <image source="Graphs/mst1.png" width="80%">
                 <description>This image depicts a network graph titled "Minimum Spanning Tree for the Broadcast Graph". It consists of seven circular nodes labeled A through G, connected by lines which represent the edges of the tree. Each edge is marked with a number indicating the weight or cost associated with that connection. The structure is tree-like, with no cycles, starting from node A and branching out to all other nodes through the path of minimum total weight. Nodes B, C, E, F, and G are connected with the least number of edges to ensure coverage of the entire network, illustrating the concept of a minimum spanning tree in graph theory.</description>
                 </image>
@@ -128,46 +128,46 @@ def prim(G,start):
             to the tree.</p>
 
         <figure align="center" xml:id="fig-prima">
-            <caption>Tracing Prim's Algorithm</caption>
+            <caption>Tracing Prim's Algorithm.</caption>
                 <image source="Graphs/prima.png" width="80%">
                 <description>This image illustrates the process of Prim's algorithm applied to a graph. The graph has seven circular nodes labeled A through G, connected by lines with numbers indicating the weight of the edges. The algorithm starts at node A and progressively selects the edge with the lowest weight that connects a node inside the tree to a node outside the tree. As a result, the nodes are incrementally connected in a way that keeps the total weight of the tree at a minimum. The letters B, C, D, E, F, and G at the bottom signify the order in which the nodes are added to the growing tree.</description>
                 </image>
             </figure>
         <figure align="center" xml:id="fig-primb">
-            <caption>Tracing Prim's Algorithm</caption>
+            <caption>Tracing Prim's Algorithm.</caption>
                 <image source="Graphs/primb.png" width="80%">
                 <description>The image continues to detail Prim's algorithm, showing a partially completed minimum spanning tree. Nodes A, B, C, E, and F are connected with the shortest edges, marked with their respective weights and dashed lines indicating the edges considered at the current step. The remaining nodes D and G are yet to be connected. The bottom notation "PQ = C, D, E, F, G" lists the nodes in the priority queue awaiting to be connected.</description>
                 </image>
             </figure>
         
         <figure align="center" xml:id="fig-primc">
-            <caption>Tracing Prim's Algorithm</caption>
+            <caption>Tracing Prim's Algorithm.</caption>
                 <image source="Graphs/primc.png" width="80%">
                 <description>The final image in the sequence demonstrates a further step in Prim's algorithm. The minimum spanning tree now includes all nodes except for G, which is about to be connected. The edges between the nodes are highlighted, and the weights are updated to reflect the shortest paths from the tree to the remaining unconnected nodes. The bottom notation "PQ = D, E, F, G" updates the priority queue.</description>
                 </image>
             </figure>
         <figure align="center" xml:id="fig-primd">
-            <caption>Tracing Prim's Algorithm</caption>
+            <caption>Tracing Prim's Algorithm.</caption>
                 <image source="Graphs/primd.png" width="80%">
                 <description>This image shows a further stage in Prim's algorithm on a graph with seven nodes labeled A through G. The tree is almost complete, with solid lines connecting nodes A to F, and node G about to be connected. Each connection is annotated with the weight of the edge. The priority queue at the bottom, "PQ = E, F, G," lists the nodes considered for the next connection step.</description>
                 </image>
             </figure>
         <figure align="center" xml:id="fig-prime">
-            <caption>Tracing Prim's Algorithm</caption>
+            <caption>Tracing Prim's Algorithm.</caption>
                 <image source="Graphs/prime.png" width="80%">
                 <description>The image depicts the penultimate step in Prim's algorithm, where node G is the only one not yet included in the minimum spanning tree. The graph shows nodes A to F connected with the lowest weight edges, and the priority queue "PQ = F, G" indicates the next nodes to be considered for connection.</description>
                 </image>
             </figure>
         
         <figure align="center" xml:id="fig-primf">
-            <caption>Tracing Prim's Algorithm</caption>
+            <caption>Tracing Prim's Algorithm.</caption>
                 <image source="Graphs/primf.png" width="80%">
                 <description>IThe final image represents the completion of Prim's algorithm, where all nodes A through G are connected, forming the minimum spanning tree. Each edge's weight is displayed, reflecting the algorithm's choice of the shortest paths to connect all nodes without forming any cycles. The priority queue at the bottom, "PQ = G," shows the last node that was connected to complete the tree.</description>
                 </image>
             </figure>
         
         <figure align="center" xml:id="fig-primg">
-            <caption>Tracing Prim's Algorithm</caption>
+            <caption>Tracing Prim's Algorithm.</caption>
                 <image source="Graphs/primg.png" width="80%">
                 <description>This image shows the final step of Prim's algorithm where the minimum spanning tree is completed. All the nodes labeled from A to G are connected with the shortest paths indicated by the edge weights. The distances from the starting node are labeled next to each node with the letter 'd' followed by the distance value. The priority queue (PQ) is empty, indicating that all nodes have been visited and the algorithm is complete.</description>
                 </image>
@@ -182,7 +182,7 @@ def prim(G,start):
     <exercise label="primswhims">
         <statement>
             <figure align="center" xml:id="fig-primsalg">
-                <caption>Tracing Prim's Algorithm</caption>
+                <caption>Tracing Prim's Algorithm.</caption>
                     <image source="Graphs/primsalg.png" width="50%">
                     <description>Undirected graph with five nodes labeled A to E. Edges connect the nodes with the following weights: A-B with 1, A-D with 4, B-C with 2, C-D with 3, D-E with 6, and C-E with 5, forming a pentagon shape with a cross-connection between B and D.</description>
                     </image>

--- a/pretext/Graphs/ShortestPathProblems.ptx
+++ b/pretext/Graphs/ShortestPathProblems.ptx
@@ -9,7 +9,7 @@
             just enough to understand another very important graph algorithm.</p>
         
         <figure align="center" xml:id="fig-inet">
-            <caption>Overview of Connectivity in the Internet</caption>
+            <caption>Overview of Connectivity in the Internet.</caption>
                 <image source="Graphs/Internet.png" width="80%">
                 <description>This image represents a simplified network diagram, showing an overview of connectivity in the internet. Two routers, labeled as Router A and Router B, serve as the central connection points. Router A is connected to a cloud labeled "Internet," which symbolizes the global network. On the right side of Router A, there are connections leading to a desktop computer and a laptop, representing end-user devices. On the left side of Router B, connected to the same internet cloud, are two server icons, indicating server machines. The diagram visually explains how different types of hardware devices interface with the internet through routers, depicting a basic structure of network connectivity.</description>
                 </image>
@@ -55,7 +55,7 @@ Routers from One Host to the Next over the Internet</pre>
 
 
         <figure align="center" xml:id="fig-network">
-            <caption>Connections and Weights between Routers in the Internet</caption>
+            <caption>Connections and Weights between Routers in the Internet.</caption>
                 <image source="Graphs/routeGraph.png" width="80%">
                 <description>The image displays a weighted graph that models the connections and weights between routers in the Internet. The graph consists of six nodes, each representing a router labeled as u, v, w, x, y, and z. The nodes are interconnected by lines that signify the network links between routers. Each line is annotated with a number, representing the weight of the connection, which could indicate the cost, distance, or quality of the link. For instance, router u is connected to router x with a weight of 2, and router x is connected to router v with a weight of 2 and to router y with a weight of 1. This type of graph is typically used to represent the efficiency of data transfer paths in network routing algorithms.</description>
                 </image>

--- a/pretext/Graphs/StronglyConnectedComponents.ptx
+++ b/pretext/Graphs/StronglyConnectedComponents.ptx
@@ -16,7 +16,7 @@
             away from the CS home page.</p>
 
         <figure align="center" xml:id="fig-cshome">
-            <caption> The Graph Produced by Links from the Luther Computer Science Home Page</caption>
+            <caption> The Graph Produced by Links from the Luther Computer Science Home Page.</caption>
                 <image source="Graphs/cshome.png" width="95%">
                 <description>This image depicts a complex network graph that visualizes the web of links from the Luther Computer Science Home Page. The graph is a cluster of interconnected nodes, each representing a different page or external link. Central nodes like "Luther College History Department" have multiple connections radiating out to related nodes such as "Loyola College in Maryland" and "Iowa State University." Peripheral nodes link to a variety of topics, including "Recreational Sports - Luther College," "Luther College Administration," and "Cornell College - Chemistry." The links create a dense web, illustrating the interconnected nature of the website's structure. The graph is used to demonstrate the relationships and pathways between various academic departments, programs, and external educational institutions.</description>
                 </image>
@@ -42,7 +42,7 @@
             components are identified by the different shaded areas.</p>
         
         <figure align="center" xml:id="fig-scc1">
-            <caption> A Directed Graph with Three Strongly Connected Components</caption>
+            <caption> A Directed Graph with Three Strongly Connected Components.</caption>
                 <image source="Graphs/scc1.png" width="95%">
                 <description>The image shows a directed graph composed of three strongly connected components, each highlighted in a separate shaded area. The graph contains nine nodes labeled A through I. Nodes A, B, and C form the first component, with arrows indicating directed edges from A to B, B to A, and B to C. The second component consists of nodes D, E, and G, with directed edges connecting D to E, E to D, and D to G. The third component includes nodes F, H, and I, with edges from F to H, H to I, and I to F. Each component is a self-contained subgraph where every node is reachable from every other node within the same component, illustrating the concept of strong connectivity in graph theory.</description>
                 </image>
@@ -52,7 +52,7 @@
             strongly connected component into a single larger vertex. The simplified
             version of the graph in <xref ref="fig-scc1"/> is shown in <xref ref="fig-scc2"/>.</p>
         <figure align="center" xml:id="fig-scc2">
-            <caption> The Reduced Graph</caption>
+            <caption> The Reduced Graph.</caption>
                 <image source="Graphs/scc2.png" width="95%">
                 <description>The image depicts a simplified or reduced graph consisting of three nodes, which are labeled with the combined letters of the nodes from the strongly connected components they represent. The first node contains the letters "ABDEG," indicating it is a merged node of the first component. The second node is labeled "C," and the third node contains "FHI," representing the second and third components, respectively. There are directed edges from the "ABDEG" node to "C" and from "C" to "FHI," showing the flow between these combined nodes. This reduced graph emphasizes the hierarchical structure and the dependencies between the strongly connected components of the original directed graph.</description>
                 </image>
@@ -66,14 +66,14 @@
             graph then <m>G^T</m> will contain and edge from node B to node A.
             <xref ref="fig-tpa"/> and <xref ref="fig-tpb"/> show a simple graph and its transposition.</p>
         <figure align="center" xml:id="fig-transpose1">
-            <caption> A Graph <m>G</m></caption>
+            <caption> A Graph <m>G</m>.</caption>
                 <image source="Graphs/transpose1.png" width="80%">
                 <description>The image illustrates a directed graph G with four nodes labeled A, B, C, and D. There is a directed edge from A to B, indicating a one-way relationship, and two other directed edges, one from B to D and another from C to D, suggesting that both B and C can independently reach D.</description>
                 </image>
             </figure>
         
         <figure align="center" xml:id="fig-transpose2">
-            <caption> Its Transpose <mrow>G^T</mrow></caption>
+            <caption> Its Transpose <m>G^T</m>.</caption>
                 <image source="Graphs/transpose2.png" width="80%">
                 <description>The image shows the transpose of the graph  G^ T from Figure 33, where the direction of all the edges in the original graph  G has been reversed. In this transposed graph, there is a directed edge from B to A, and two other directed edges, one from D to B and another from D to C, indicating that D can reach both B and C. This represents the inverse relationships compared to the original graph G.</description>
                 </image>
@@ -108,14 +108,14 @@
             <xref ref="fig-sccalgb"/> shows the starting and finishing times computed by
             running DFS on the transposed graph.</p>
         <figure align="center" xml:id="fig-scc1a">
-            <caption> Finishing times for the original graph <m>G</m></caption>
+            <caption> Finishing times for the original graph <m>G</m>.</caption>
                 <image source="Graphs/scc1a.png" width="80%">
                 <description>The image displays a directed graph G consisting of nine nodes labeled A through I. Each node is annotated with a pair of numbers, representing the finishing times in the format 'start/finish'. The edges indicate the direction of connection between nodes. Solid arrows represent direct connections, while dashed arrows signify connections that are part of the graph but are not the primary path in the context shown. This graph is likely used to demonstrate an algorithmic concept such as Depth-First Search (DFS), where the numbers indicate the order in which nodes are fully processed.</description>
                 </image>
             </figure>
 
         <figure align="center" xml:id="fig-scc1b">
-            <caption>Finishing times for <md><mrow>G^T</mrow></md></caption>
+            <caption>Finishing times for <m>G^T</m>.</caption>
                 <image source="Graphs/scc1b.png" width="80%">
                 <description>This image depicts a directed graph, labeled G^T, which is the transpose of a previous graph G. It consists of nine nodes labeled A through I. Each node is marked with two numbers, indicating the finishing times, in a format that suggests the order in which they were processed, with the first number likely representing the start time and the second the finish time. The graph is interconnected with solid and dashed arrows indicating the direction of the edges, where the dashed arrows might represent the reverse of the original connections inG. This graph is typically used to demonstrate concepts such as the calculation of finishing times in a Depth-First Search (DFS) on the transposed graph for algorithms like Kosaraju's or other strong component identification algorithms.</description>
                 </image>
@@ -126,7 +126,7 @@
             we leave writing this program as an exercise.</p>
 
         <figure align="center" xml:id="fig-sccforest">
-            <caption>Strongly Connected Components</caption>
+            <caption>Strongly Connected Components.</caption>
                 <image source="Graphs/sccforest.png" width="80%">
                 <description> The diagram shows a directed graph illustrating the concept of strongly connected components within a network of nodes. Each node is labeled with a letter from A to I and a pair of numbers, which could represent the sequence in which a depth-first search algorithm processed them. The graph is organized with directed edges forming paths between the nodes, suggesting the presence of subgraphs where each node is reachable from every other node within the same subgraph. This kind of representation is commonly used in computer science to illustrate algorithms that identify strongly connected components within a graph, which are maximal sets of vertices with a path to every other vertex in the set.</description>
                 </image>

--- a/pretext/Graphs/TopologicalSorting.ptx
+++ b/pretext/Graphs/TopologicalSorting.ptx
@@ -12,7 +12,7 @@
             a graph.</p>
 
         <figure align="center" xml:id="fig-pancakes">
-            <caption> The Steps for Making Pancakes</caption>
+            <caption> The Steps for Making Pancakes.</caption>
                 <image source="Graphs/pancakes.png" width="80%">
                 <description>A flowchart detailing the steps for making pancakes. The process begins with three separate ingredients: 3/4 cup of milk, 1 egg, and 1 Tbl of oil, converging into a central step labeled '1 cup mix'. From there, the flowchart indicates to 'heat griddle', followed by 'pour 1/4 cup' of the mix onto the griddle. The next step is to 'turn when bubbly', indicating when to flip the pancakes. Two concurrent final steps are 'heat syrup' and 'eat', signifying the end of the pancake-making process. The flowchart effectively outlines the sequence of actions required to make pancakes from the initial ingredient preparation to the final eating stage.</description>
                 </image>
@@ -51,7 +51,7 @@
         <p><xref ref="fig-pancakesdfs"/> shows the depth first forest constructed by
             <c>dfs</c> on the pancake-making graph shown in <xref ref="fig-pancakes"/>.</p>
         <figure align="center" xml:id="fig-pancakesdfs">
-            <caption> Result of Depth First Search on the Pancake Graph</caption>
+            <caption> Result of Depth First Search on the Pancake Graph.</caption>
                 <image source="Graphs/pancakesDFS.png" width="80%">
                 <description>The image depicts the result of a depth-first search on a pancake recipe graph. It starts with "3/4 cup milk" at step 1/12, which along with "1 egg" at step 15/16 and "1 Tbl Oil" at step 17/18, feeds into "1 cup mix" at step 2/11. This leads to "heat griddle" at step 13/14, followed by "pour 1/4 cup" at step 3/8. The next action is "turn when bubbly" at step 4/7, and the final steps are "heat syrup" at step 9/10 and "eat" at step 5/6. Each step is represented by an oval, with directed edges showing the sequence of the recipe steps, and numbers indicating the search progression.</description>
                 </image>
@@ -62,7 +62,7 @@
             removed and we know exactly the order in which to perform the pancake
             making steps.</p>
         <figure align="center" xml:id="fig-pancakesTS">
-            <caption> Result of Depth First Search on the Pancake Graph</caption>
+            <caption> Result of Depth First Search on the Pancake Graph.</caption>
                 <image source="Graphs/pancakesTS.png" width="95%">
                 <description>Alt text for Figure 29: This image shows the result of a topological sort on a directed acyclic graph representing the steps for making pancakes. The sequence begins with "1 Tbl Oil" at step 17/18, followed by "1 egg" at step 15/16, "3/4 cup milk" at step 1/12, and "1 cup mix" at step 2/11. The next steps are "heat griddle" at step 13/14, "heat syrup" at step 9/10, "pour 1/4 cup" at step 3/8, and "turn when bubbly" at step 4/7. The final action is "eat" at step 5/6. Each step is depicted as an oval, connected by directed paths that indicate the order of operations, with numbers denoting the order in the topological sort.</description>
                 </image>

--- a/pretext/Graphs/VocabularyandDefinitions.ptx
+++ b/pretext/Graphs/VocabularyandDefinitions.ptx
@@ -55,7 +55,7 @@
              \end{array} \right\}</m>
         
         <figure align="center" xml:id="fig-dgsimple">
-            <caption>A Simple Example of a Directed Graph</caption>
+            <caption>A Simple Example of a Directed Graph.</caption>
                 <image source="Graphs/digraph.png" width="80%">
                 <description>Diagram representing a simple directed graph with vertices labeled V0 to V5. Arrows indicating direction connect the vertices, with weights on each edge. V0 connects to V4 and V1 with weights 1 and 5, respectively. V1 is connected from V0 and to V5 with weights 5 and 4, respectively. V2 connects from V3 and V5 with weights 9 and 1, respectively. V3 connects to V2 and V5 with weights 9 and 3, respectively, and also to V4 with a weight of 7. V4 connects from V0 and V5 with weights 1 and 8, respectively, and to V3 with a weight of 7. V5, at the center, has incoming edges from V1, V3, and V4 with weights 4, 3, and 8, respectively, and outgoing edges to V2 with a weight of 1. </description>
                 </image>


### PR DESCRIPTION
Fixing formatting issues in Chapter 9

# Description
Inconsistency in some of the sentences. Some text needed to be positioned in the correct position on the page. Some had a period after, while others did not. So, I fixed that by putting periods after all sentences. 

## Related Issue
#654  initially, but the issues are within all the chapters. Therefore, I am fixing all of them.

## How Has This Been Tested?
It was tested by rebuilding the book in the local library. 
