### PR TITLE
remove extra period (no other entries have them)

### DIFF
--- a/pretext/LinearLinked/Glossary.ptx
+++ b/pretext/LinearLinked/Glossary.ptx
@@ -42,7 +42,7 @@
                 <gi>
                     <title>node</title>
                     
-                        <p>the element of a linked list.</p>
+                        <p>the element of a linked list</p>
                     
                 </gi>
                 <gi>


### PR DESCRIPTION
# Description
linked list glossary: removed extra period for consistency with all other entries

## Related Issue
none (trivial diff)

## How Has This Been Tested?
local build