### PR TITLE
switch ul/ol entities to use marker=

### DIFF
--- a/pretext/AlgorithmAnalysis/DiscussionQuestions.ptx
+++ b/pretext/AlgorithmAnalysis/DiscussionQuestions.ptx
@@ -1,6 +1,6 @@
 <section xml:id="algorithm-analysis_discussion-questions">
         <title>Discussion Questions</title>
-        <p><ol label="1">
+        <p><ol marker="1">
             <li>
                 <p>Give the Big-O performance of the following code fragment:</p>
             </li>
@@ -11,7 +11,7 @@ for (int i = 0; i &lt; n; i++){
        count = count +1;
    }
 }</pre>
-        <p><ol label="1">
+        <p><ol marker="1">
             <li>
                 <p>Give the Big-O performance of the following code fragment:</p>
             </li>
@@ -20,7 +20,7 @@ for (int i = 0; i &lt; n; i++){
 for (int i = 0; i &lt; n; i++){
    count = count + 1;
 }</pre>
-        <p><ol label="1">
+        <p><ol marker="1">
             <li>
                 <p>Give the Big-O performance of the following code fragment:</p>
             </li>
@@ -31,7 +31,7 @@ while (i &gt; 0){
     count = count + 1;
     i = i / 2; //Note: integer division
 }</pre>
-        <p><ol label="1">
+        <p><ol marker="1">
             <li>
                 <p>Give the Big-O performance of the following code fragment:</p>
             </li>
@@ -44,7 +44,7 @@ for (int i = 0; i &lt; n; i++){
         }
     }
 }</pre>
-        <p><ol label="1">
+        <p><ol marker="1">
             <li>
                 <p>Give the Big-O performance of the following code fragment:</p>
             </li>

--- a/pretext/AlgorithmAnalysis/ProgrammingExercises.ptx
+++ b/pretext/AlgorithmAnalysis/ProgrammingExercises.ptx
@@ -1,6 +1,6 @@
 <section xml:id="algorithm-analysis_programming-exercises">
         <title>Programming Exercises</title>
-        <p><ol label="1">
+        <p><ol marker="1">
             <li>
                 <p>Devise an experiment to verify that the vector index operator is
                     <m>O(1)</m></p>

--- a/pretext/Graphs/DiscussionQuestions.ptx
+++ b/pretext/Graphs/DiscussionQuestions.ptx
@@ -1,6 +1,6 @@
 <section xml:id="graphs_discussion-questions">
         <title>Discussion Questions</title>
-        <p><ol label="1">
+        <p><ol marker="1">
             <li>
                 <p>Draw the graph corresponding to the following adjacency matrix.</p>
             </li>
@@ -11,7 +11,7 @@
                 <description>Adjacency matrix with weighted edges between nodes A to F. A connects to B with 7, to E with 5, and to F with 1. B connects to A with 2, to D with 7, and to E with 3. C connects to B with 2 and to F with 8. D connects to A with 1, to C with 2, and to E with 4. E connects to A with 6 and to C with 5. F connects to A with 1 and to C with 8.</description>
                 </image>
             </figure>
-        <p><ol label="1">
+        <p><ol marker="1">
             <li>
                 <p>Draw the graph corresponding to the following list of edges.</p>
                 <table><tabular>

--- a/pretext/Graphs/ImplementingBreadthFirstSearch.ptx
+++ b/pretext/Graphs/ImplementingBreadthFirstSearch.ptx
@@ -42,7 +42,7 @@
             iterating over its adjacency list. As each node on the adjacency list is
             examined its color is checked. If it is white, the vertex is unexplored,
             and four things happen:</p>
-        <p><ol label="1">
+        <p><ol marker="1">
             <li>
                 <p>The new, unexplored vertex <c>nbr</c>, is colored gray.</p>
             </li>

--- a/pretext/Graphs/ProgrammingExercises.ptx
+++ b/pretext/Graphs/ProgrammingExercises.ptx
@@ -1,6 +1,6 @@
 <section xml:id="graphs_programming-exercises">
         <title>Programming Exercises</title>
-        <p><ol label="1">
+        <p><ol marker="1">
             <li>
                 <p>Modify the depth first search function to produce a topological sort.</p>
             </li>

--- a/pretext/Graphs/StronglyConnectedComponents.ptx
+++ b/pretext/Graphs/StronglyConnectedComponents.ptx
@@ -84,7 +84,7 @@
             components.</p>
         <p>We can now describe the algorithm to compute the strongly connected
             components for a graph.</p>
-        <p><ol label="1">
+        <p><ol marker="1">
             <li>
                 <p>Call <c>dfs</c> for the graph <m>G</m> to compute the finish times
                     for each vertex.</p>

--- a/pretext/Graphs/TopologicalSorting.ptx
+++ b/pretext/Graphs/TopologicalSorting.ptx
@@ -35,7 +35,7 @@
             matrices.</p>
         <p>The topological sort is a simple but useful adaptation of a depth first
             search. The algorithm for the topological sort is as follows:</p>
-        <p><ol label="1">
+        <p><ol marker="1">
             <li>
                 <p>Call <c>dfs(g)</c> for some graph <c>g</c>. The main reason we want to call
                     depth first search is to compute the finish times for each of the

--- a/pretext/Introduction/CollectionData.ptx
+++ b/pretext/Introduction/CollectionData.ptx
@@ -16,7 +16,7 @@
                 located at equally spaced addresses in contiguous computer memory.</p>
             <p>NOTE: A C++ <term>array</term> is always stored in contiguous memory. C++ arrays can be allocated in two different ways:</p>
             <blockquote>
-                <p><ol label="1">
+                <p><ol marker="1">
                     <li>
                         <p><em>statically allocated</em> in which the array size is fixed at compile-time and cannot change</p>
                     </li>

--- a/pretext/Introduction/DiscussionQuestions.ptx
+++ b/pretext/Introduction/DiscussionQuestions.ptx
@@ -1,6 +1,6 @@
 <section xml:id="introduction_discussion-questions">
         <title>Discussion Questions</title>
-        <p><ol label="1">
+        <p><ol marker="1">
             <li>
                 <p>Construct a class hierarchy for people on a college campus. Include
                     faculty, staff, and students. What do they have in common? What

--- a/pretext/Introduction/ObjectOrientedProgrammingDefiningClasses.ptx
+++ b/pretext/Introduction/ObjectOrientedProgrammingDefiningClasses.ptx
@@ -23,7 +23,7 @@
             all of the objects of that type.</p>
         <p>Four key principles are associated with object-oriented programming:</p>
         <blockquote>
-            <p><ol label="1">
+            <p><ol marker="1">
                 <li>
                     <p>abstraction</p>
                 </li>

--- a/pretext/Introduction/ProgrammingExercises.ptx
+++ b/pretext/Introduction/ProgrammingExercises.ptx
@@ -1,6 +1,6 @@
 <section xml:id="introduction_programming-exercises">
         <title>Programming Exercises</title>
-        <p><ol label="1">
+        <p><ol marker="1">
             <li>
                 <p>Implement the simple methods <c>getNum</c> and <c>getDen</c> that will
                     return the numerator and denominator of a fraction.</p>

--- a/pretext/LinearBasic/DiscussionQuestions.ptx
+++ b/pretext/LinearBasic/DiscussionQuestions.ptx
@@ -1,6 +1,6 @@
 <section xml:id="linear-basic_discussion-questions">
         <title>Discussion Questions</title>
-        <p><ol label="1">
+        <p><ol marker="1">
             <li>
                 <p>Convert the following values to binary using <q>divide by 2.</q> Show the
                     stack of remainders.</p>

--- a/pretext/LinearBasic/InfixPrefixandPostfixExpressions.ptx
+++ b/pretext/LinearBasic/InfixPrefixandPostfixExpressions.ptx
@@ -349,7 +349,7 @@
                 parentheses, ( and ). The operand tokens are the single-character
                 identifiers A, B, C, and so on. The following steps will produce a
                 string of tokens in postfix order.</p>
-            <p><ol label="1">
+            <p><ol marker="1">
                 <li>
                     <p>Create an empty stack called <c>opstack</c> for keeping operators.
                         Create an empty vector for output.</p>
@@ -580,7 +580,7 @@ main()
             <p>Assume the postfix expression is a string of tokens delimited by spaces.
                 The operators are *, /, +, and - and the operands are assumed to be
                 single-digit integer values. The output will be an integer result.</p>
-            <p><ol label="1">
+            <p><ol marker="1">
                 <li>
                     <p>Create an empty stack called <c>operandStack</c>.</p>
                 </li>

--- a/pretext/LinearBasic/ProgrammingExercises.ptx
+++ b/pretext/LinearBasic/ProgrammingExercises.ptx
@@ -1,6 +1,6 @@
 <section xml:id="linear-basic_programming-exercises">
         <title>Programming Exercises</title>
-        <p><ol label="1">
+        <p><ol marker="1">
             <li>
                 <p>Modify the infix-to-postfix algorithm so that it can handle errors.</p>
             </li>

--- a/pretext/LinearBasic/SimulationPrintingTasks.ptx
+++ b/pretext/LinearBasic/SimulationPrintingTasks.ptx
@@ -48,7 +48,7 @@
         <subsection xml:id="linear-basic_main-simulation-steps">
             <title>Main Simulation Steps</title>
             <p>Here is the main simulation.</p>
-            <p><ol label="1">
+            <p><ol marker="1">
                 <li>
                     <p>Create a queue of print tasks. Each task will be given a timestamp
                         upon its arrival. The queue is empty to start.</p>

--- a/pretext/LinearLinked/DiscussionQuestions.ptx
+++ b/pretext/LinearLinked/DiscussionQuestions.ptx
@@ -1,6 +1,6 @@
 <section xml:id="linear-linked_discussion-questions">
         <title>Discussion Questions</title>
-        <p><ol label="1">
+        <p><ol marker="1">
             <li>
                 <p>Convert the following values to binary using <q>divide by 2.</q> Show the
                     stack of remainders.</p>

--- a/pretext/LinearLinked/ProgrammingExercises.ptx
+++ b/pretext/LinearLinked/ProgrammingExercises.ptx
@@ -1,6 +1,6 @@
 <section xml:id="linear-linked_programming-exercises">
         <title>Programming Exercises</title>
-        <p><ol label="1">
+        <p><ol marker="1">
             <li>
                 <p>Implement the <c>Queue</c> ADT, using a list such that the rear of the
                     queue is at the end of the list.</p>

--- a/pretext/Recursion/DiscussionQuestions.ptx
+++ b/pretext/Recursion/DiscussionQuestions.ptx
@@ -1,6 +1,6 @@
 <section xml:id="recursion_discussion-questions">
         <title>Discussion Questions</title>
-        <p><ol label="1">
+        <p><ol marker="1">
             <li>
                 <p>Draw a call stack for the Tower of Hanoi problem. Assume that you
                     start with a stack of three disks.</p>

--- a/pretext/Recursion/DynamicProgramming.ptx
+++ b/pretext/Recursion/DynamicProgramming.ptx
@@ -271,7 +271,7 @@ main()
             the minimum of one and five is one we store 1 in the table. Fast forward
             again to the end of the table and consider 11 cents. <xref ref="fig-elevencpp"/>
             shows the three options that we have to consider:</p>
-        <p><ol label="1">
+        <p><ol marker="1">
             <li>
                 <p>A penny plus the minimum number of coins to make change for
                     <m>11-1 = 10</m> cents (1)</p>

--- a/pretext/Recursion/ExploringaMaze.ptx
+++ b/pretext/Recursion/ExploringaMaze.ptx
@@ -87,7 +87,7 @@
             of them you may already have guessed based on the description in the
             previous paragraph. In this algorithm, there are four base cases to
             consider:</p>
-        <p><ol label="1">
+        <p><ol marker="1">
             <li>
                 <p>We have run into a wall. Since the square is occupied by a
                     wall no further exploration can take place.</p>

--- a/pretext/Recursion/TheThreeLawsofRecursion.ptx
+++ b/pretext/Recursion/TheThreeLawsofRecursion.ptx
@@ -3,7 +3,7 @@
         <p>Like the robots of Asimov, all recursive algorithms must obey three
             important laws:</p>
         <blockquote>
-            <p><ol label="1">
+            <p><ol marker="1">
                 <li>
                     <p>A recursive algorithm must have a <term>base case</term>.</p>
                 </li>

--- a/pretext/Recursion/TowerofHanoi.ptx
+++ b/pretext/Recursion/TowerofHanoi.ptx
@@ -48,7 +48,7 @@
             trivial you might even say. This sounds like a base case in the making.</p>
         <p>Here is a high-level outline of how to move a tower from the starting
             pole, to the goal pole, using an intermediate pole:</p>
-        <p><ol label="1">
+        <p><ol marker="1">
             <li>
                 <p>Move a tower of height-1 to an intermediate pole, using the final
                     pole.</p>

--- a/pretext/Recursion/pythondsConvertinganIntegertoaStringinAnyBase.ptx
+++ b/pretext/Recursion/pythondsConvertinganIntegertoaStringinAnyBase.ptx
@@ -18,7 +18,7 @@
         <p>Knowing what our base is suggests that the overall algorithm will
             involve three components:</p>
         <blockquote>
-            <p><ol label="1">
+            <p><ol marker="1">
                 <li>
                     <p>Reduce the original number to a series of single-digit numbers.</p>
                 </li>

--- a/pretext/Recursion/pythondsProgrammingExercises.ptx
+++ b/pretext/Recursion/pythondsProgrammingExercises.ptx
@@ -1,6 +1,6 @@
 <section xml:id="recursion_programming-exercises">
         <title>Programming Exercises</title>
-        <p><ol label="1">
+        <p><ol marker="1">
             <li>
                 <p>Write a recursive function to compute the factorial of a number.</p>
             </li>

--- a/pretext/SearchHash/DiscussionQuestions.ptx
+++ b/pretext/SearchHash/DiscussionQuestions.ptx
@@ -1,6 +1,6 @@
 <section xml:id="search-hash_discussion-questions">
         <title>Discussion Questions</title>
-        <p><ol label="1">
+        <p><ol marker="1">
             <li>
                 <p>Using the hash table performance formulas given in the chapter,
                     compute the average number of comparisons necessary when the table is</p>

--- a/pretext/SearchHash/ProgrammingExercises.ptx
+++ b/pretext/SearchHash/ProgrammingExercises.ptx
@@ -1,6 +1,6 @@
 <section xml:id="search-hash_programming-exercises">
         <title>Programming Exercises</title>
-        <p><ol label="1">
+        <p><ol marker="1">
             <li>
                 <p>Set up a random experiment to test the difference between a
                     sequential search and a binary search on a list of integers.</p>

--- a/pretext/SearchHash/TheSequentialSearch.ptx
+++ b/pretext/SearchHash/TheSequentialSearch.ptx
@@ -31,7 +31,7 @@
         
         
 
-    <program xml:id="lst-seqsearchcpp" interactive="activecode" language="cpp">
+    <program xml:id="search1_cpp" interactive="activecode" language="cpp">
         <input>
 #include &lt;iostream&gt;
 #include &lt;vector&gt;

--- a/pretext/SearchHash/TheSequentialSearch.ptx
+++ b/pretext/SearchHash/TheSequentialSearch.ptx
@@ -31,7 +31,7 @@
         
         
 
-    <program xml:id="search1_cpp" interactive="activecode" language="cpp">
+    <program xml:id="lst-seqsearchcpp" interactive="activecode" language="cpp">
         <input>
 #include &lt;iostream&gt;
 #include &lt;vector&gt;

--- a/pretext/Sort/DiscussionQuestions.ptx
+++ b/pretext/Sort/DiscussionQuestions.ptx
@@ -1,6 +1,6 @@
 <section xml:id="sort_discussion-questions">
         <title>Discussion Questions</title>
-        <p><ol label="1">
+        <p><ol marker="1">
             <li>
                 <p>Generate a random list of integers. Show how this list is sorted by
                     the following algorithms:</p>

--- a/pretext/Sort/ProgrammingExercises.ptx
+++ b/pretext/Sort/ProgrammingExercises.ptx
@@ -1,6 +1,6 @@
 <section xml:id="sort_programming-exercises">
         <title>Programming Exercises</title>
-        <p><ol label="1">
+        <p><ol marker="1">
             <li>
                 <p>Using a random number generator, create a list of 500 integers.
                     Perform a benchmark analysis using some of the sorting algorithms

--- a/pretext/Trees/DiscussionQuestions.ptx
+++ b/pretext/Trees/DiscussionQuestions.ptx
@@ -1,6 +1,6 @@
 <section xml:id="trees_discussion-questions">
         <title>Discussion Questions</title>
-        <p><ol label="1">
+        <p><ol marker="1">
             <li>
                 <p>Draw the tree structure resulting from the following set of tree
                     function calls:</p>
@@ -63,19 +63,19 @@
                     implementing as a function?</p>
             </li>
         </ol></p>
-        <p><ol label="1">
+        <p><ol marker="1">
             <li>
                 <p>Show the function calls needed to build the following binary tree.</p>
             </li>
         </ol></p>
         <figure align="center" ><image source="Trees/exerTree.png" width="50%"/></figure>
-        <p><ol label="1">
+        <p><ol marker="1">
             <li>
                 <p>Given the following tree, perform the appropriate rotations to bring it back into balance.</p>
             </li>
         </ol></p>
         <figure align="center" ><image source="Trees/rotexer1.png" width="20%"/></figure>
-        <p><ol label="1">
+        <p><ol marker="1">
             <li>
                 <p>Using the following as a starting point, derive the equation that gives the updated balance factor for node D.</p>
             </li>

--- a/pretext/Trees/ParseTree.ptx
+++ b/pretext/Trees/ParseTree.ptx
@@ -73,7 +73,7 @@
             are going to be leaf nodes and children of their operators. Finally, we
             know that every operator is going to have both a left and a right child.</p>
         <p>Using the information from above we can define four rules as follows:</p>
-        <p><ol label="1">
+        <p><ol marker="1">
             <li>
                 <p>If the current token is a <c>'('</c>, add a new node as the left child
                     of the current node, and descend to the left child.</p>
@@ -119,7 +119,7 @@
 
         <p>Using <xref ref="fig-bldexpstep"/>, let's walk through the example step by
             step:</p>
-        <p><ol label="a">
+        <p><ol marker="a">
             <li>
                 <p>Create an empty tree.</p>
             </li>

--- a/pretext/Trees/ProgrammingExercises.ptx
+++ b/pretext/Trees/ProgrammingExercises.ptx
@@ -1,6 +1,6 @@
 <section xml:id="trees_programming-exercises">
         <title>Programming Exercises</title>
-        <p><ol label="1">
+        <p><ol marker="1">
             <li>
                 <p>Extend the <c>buildParseTree</c> function to handle mathematical
                     expressions that do not have spaces between every character.</p>

--- a/pretext/Trees/SearchTreeImplementation.ptx
+++ b/pretext/Trees/SearchTreeImplementation.ptx
@@ -293,7 +293,7 @@ TreeNode  *_get(int key, TreeNode *currentNode){
 }</pre>
         <p>Once we've found the node containing the key we want to delete, there
             are three cases that we must consider:</p>
-        <p><ol label="1">
+        <p><ol marker="1">
             <li>
                 <p>The node to be deleted has no children (see <xref ref="fig-bstdel1"/>).</p>
             </li>
@@ -326,7 +326,7 @@ TreeNode  *_get(int key, TreeNode *currentNode){
             Since the cases are symmetric with respect to either having a left or
             right child we will just discuss the case where the current node has a
             left child. The decision proceeds as follows:</p>
-        <p><ol label="1">
+        <p><ol marker="1">
             <li>
                 <p>If the current node is a left child then we only need to update the
                     parent reference of the left child to point to the parent of the
@@ -419,7 +419,7 @@ TreeNode  *_get(int key, TreeNode *currentNode){
             of the same properties of binary search trees that cause an inorder
             traversal to print out the nodes in the tree from smallest to largest.
             There are three cases to consider when looking for the successor:</p>
-        <p><ol label="1">
+        <p><ol marker="1">
             <li>
                 <p>If the node has a right child, then the successor is the smallest key
                     in the right subtree.</p>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description
for ul/ol elements, the label= attribute has been deprecated in favor of marker. It means the same thing.

This touches a bunch of files but makes a very tiny change to each.

## Related Issue
standalone

## How Has This Been Tested?
local build
