### PR TITLE
m tags use label attributes for something else these days

### DIFF
--- a/pretext/AlgorithmAnalysis/AnAnagramDetectionExample.ptx
+++ b/pretext/AlgorithmAnalysis/AnAnagramDetectionExample.ptx
@@ -120,7 +120,7 @@ main()
                 array will be visited once to match a character from <c>s1</c>. The number
                 of visits then becomes the sum of the integers from 1 to <em>n</em>. We stated
                 earlier that this can be written as</p>
-            <m docname="AlgorithmAnalysis/AnAnagramDetectionExample" label="True" nowrap="False" number="True" xml:space="preserve">
+            <m docname="AlgorithmAnalysis/AnAnagramDetectionExample" nowrap="False" number="True" xml:space="preserve">
             \begin{eqnarray}\sum_{i=1}^{n} i &amp;=&amp; \frac {n(n+1)}{2} \\
                  &amp; = &amp; \frac {1}{2}n^{2} + \frac {1}{2}n\end{eqnarray}</m>
             <p>As <m>n</m> gets large, the <m>n^{2}</m> term will dominate the

--- a/pretext/Graphs/VocabularyandDefinitions.ptx
+++ b/pretext/Graphs/VocabularyandDefinitions.ptx
@@ -48,9 +48,9 @@
         <p><xref ref="fig-dgsimple"/> shows another example of a simple weighted
             digraph. Formally we can represent this graph as the set of six
             vertices:</p>
-        <m docname="Graphs/VocabularyandDefinitions" label="True" nowrap="False" number="True" xml:space="preserve">V = \left\{ V0,V1,V2,V3,V4,V5 \right\}</m>
+        <m docname="Graphs/VocabularyandDefinitions" nowrap="False" number="True" xml:space="preserve">V = \left\{ V0,V1,V2,V3,V4,V5 \right\}</m>
         <p>and the set of nine edges:</p>
-        <m docname="Graphs/VocabularyandDefinitions" label="True" nowrap="False" number="True" xml:space="preserve">E = \left\{ \begin{array}{l}(v0,v1,5), (v1,v2,4), (v2,v3,9), (v3,v4,7), (v4,v0,1), \\
+        <m docname="Graphs/VocabularyandDefinitions" nowrap="False" number="True" xml:space="preserve">E = \left\{ \begin{array}{l}(v0,v1,5), (v1,v2,4), (v2,v3,9), (v3,v4,7), (v4,v0,1), \\
              (v0,v5,2),(v5,v4,8),(v3,v5,3),(v5,v2,1)
              \end{array} \right\}</m>
         

--- a/pretext/Recursion/DynamicProgramming.ptx
+++ b/pretext/Recursion/DynamicProgramming.ptx
@@ -46,7 +46,7 @@
             amount minus ten cents, and so on. So the number of coins needed to make
             change for the original amount can be computed according to the
             following:</p>
-        <m docname="Recursion/DynamicProgramming" label="True" nowrap="False" number="True" xml:space="preserve">numCoins =
+        <m docname="Recursion/DynamicProgramming" nowrap="False" number="True" xml:space="preserve">numCoins =
  min
  \begin{cases}
  1 + numCoins(original amount - 1) \\

--- a/pretext/Recursion/pythondsCalculatingtheSumofaListofNumbers.ptx
+++ b/pretext/Recursion/pythondsCalculatingtheSumofaListofNumbers.ptx
@@ -60,15 +60,15 @@ main()
             problem from adding a vector to adding pairs of numbers, we could rewrite
             the vector as a fully parenthesized expression. Such an expression looks
             like this:</p>
-        <m docname="Recursion/pythondsCalculatingtheSumofaListofNumbers" label="True" nowrap="False" number="True" xml:space="preserve">((((1 + 3) + 5) + 7) + 9)</m>
+        <m docname="Recursion/pythondsCalculatingtheSumofaListofNumbers" nowrap="False" number="True" xml:space="preserve">((((1 + 3) + 5) + 7) + 9)</m>
         <p>We can also parenthesize
             the expression the other way around,</p>
-        <m docname="Recursion/pythondsCalculatingtheSumofaListofNumbers" label="True" nowrap="False" number="True" xml:space="preserve">(1 + (3 + (5 + (7 + 9))))</m>
+        <m docname="Recursion/pythondsCalculatingtheSumofaListofNumbers" nowrap="False" number="True" xml:space="preserve">(1 + (3 + (5 + (7 + 9))))</m>
         <p>Notice that the innermost set of
             parentheses, <m>(7 + 9)</m>, is a problem that we can solve without a
             loop or any special constructs. In fact, we can use the following
             sequence of simplifications to compute a final sum.</p>
-        <m docname="Recursion/pythondsCalculatingtheSumofaListofNumbers" label="True" nowrap="False" number="True" xml:space="preserve">total = \  (1 + (3 + (5 + (7 + 9)))) \\
+        <m docname="Recursion/pythondsCalculatingtheSumofaListofNumbers" nowrap="False" number="True" xml:space="preserve">total = \  (1 + (3 + (5 + (7 + 9)))) \\
 total = \  (1 + (3 + (5 + 16))) \\
 total = \  (1 + (3 + 21)) \\
 total = \  (1 + 24) \\

--- a/pretext/Recursion/pythondsProgrammingExercises.ptx
+++ b/pretext/Recursion/pythondsProgrammingExercises.ptx
@@ -83,7 +83,7 @@
             <li>
                 <p>Pascal's triangle is a number triangle with numbers arranged in
                     staggered rows such that</p>
-                <m docname="Recursion/pythondsProgrammingExercises" label="True" nowrap="False" number="True" xml:space="preserve">a_{nr} = {n! \over{r! (n-r)!}}
+                <m docname="Recursion/pythondsProgrammingExercises" nowrap="False" number="True" xml:space="preserve">a_{nr} = {n! \over{r! (n-r)!}}
 
 </m>
                 <p>This equation is the equation for a binomial coefficient. You can

--- a/pretext/Trees/AVLTreeImplementation.ptx
+++ b/pretext/Trees/AVLTreeImplementation.ptx
@@ -201,7 +201,7 @@ void rotateLeft(TreeNode *rotRoot){
             nodes and A, C, E are their subtrees. Let <m>h_x</m> denote the
             height of a particular subtree rooted at node <m>x</m>. By definition
             we know the following:</p>
-        <m docname="Trees/AVLTreeImplementation" label="True" nowrap="False" number="True" xml:space="preserve">newBal(B) = h_A - h_C \\
+        <m docname="Trees/AVLTreeImplementation" nowrap="False" number="True" xml:space="preserve">newBal(B) = h_A - h_C \\
 oldBal(B) = h_A - h_D</m>
         <p>But we know that the old height of D can also be given by <m>1 +
                 max(h_C,h_E)</m>, that is, the height of D is one more than the maximum
@@ -212,19 +212,19 @@ oldBal(B) = h_A - h_D</m>
         <p>and then subtract the two equations. The following steps
             do the subtraction and use some algebra to simplify the equation for
             <m>newBal(B)</m>.</p>
-        <m docname="Trees/AVLTreeImplementation" label="True" nowrap="False" number="True" xml:space="preserve">newBal(B) - oldBal(B) = h_A - h_C - (h_A - (1 + max(h_C,h_E))) \\
+        <m docname="Trees/AVLTreeImplementation" nowrap="False" number="True" xml:space="preserve">newBal(B) - oldBal(B) = h_A - h_C - (h_A - (1 + max(h_C,h_E))) \\
 newBal(B) - oldBal(B) = h_A - h_C - h_A + (1 + max(h_C,h_E)) \\
 newBal(B) - oldBal(B) = h_A  - h_A + 1 + max(h_C,h_E) - h_C  \\
 newBal(B) - oldBal(B) =  1 + max(h_C,h_E) - h_C</m>
         <p>Next we will move <m>oldBal(B)</m> to the right hand side of the
             equation and make use of the fact that
             <m>max(a,b)-c = max(a-c, b-c)</m>.</p>
-        <m docname="Trees/AVLTreeImplementation" label="True" nowrap="False" number="True" xml:space="preserve">newBal(B) = oldBal(B) + 1 + max(h_C - h_C ,h_E - h_C) \\</m>
+        <m docname="Trees/AVLTreeImplementation" nowrap="False" number="True" xml:space="preserve">newBal(B) = oldBal(B) + 1 + max(h_C - h_C ,h_E - h_C) \\</m>
         <p>But, <m>h_E - h_C</m> is the same as <m>-oldBal(D)</m>. So we can
             use another identity that says <m>max(-a,-b) = -min(a,b)</m>. So we
             can finish our derivation of <m>newBal(B)</m> with the following
             steps:</p>
-        <m docname="Trees/AVLTreeImplementation" label="True" nowrap="False" number="True" xml:space="preserve">newBal(B) = oldBal(B) + 1 + max(0 , -oldBal(D)) \\
+        <m docname="Trees/AVLTreeImplementation" nowrap="False" number="True" xml:space="preserve">newBal(B) = oldBal(B) + 1 + max(0 , -oldBal(D)) \\
 newBal(B) = oldBal(B) + 1 - min(0 , oldBal(D)) \\</m>
         <p>Now we have all of the parts in terms that we readily know. If we
             remember that B is <c>rotRoot</c> and D is <c>newRoot</c> then we can see this

--- a/pretext/Trees/AVLTreePerformance.ptx
+++ b/pretext/Trees/AVLTreePerformance.ptx
@@ -17,13 +17,13 @@
             for a tree of height 3 there are <m>1 + 2 + 4 = 7</m>. More generally
             the pattern we see for the number of nodes in a tree of height h
             (<m>N_h</m>) is:</p>
-        <m docname="Trees/AVLTreePerformance" label="True" nowrap="False" number="True" xml:space="preserve">N_h = 1 + N_{h-1} + N_{h-2}</m>
+        <m docname="Trees/AVLTreePerformance" nowrap="False" number="True" xml:space="preserve">N_h = 1 + N_{h-1} + N_{h-2}</m>
         <p>This recurrence may look familiar to you because it is very similar to
             the Fibonacci sequence. We can use this fact to derive a formula for the
             height of an AVL tree given the number of nodes in the tree. Recall that
             for the Fibonacci sequence the <m>i_{th}</m> Fibonacci number is
             given by:</p>
-        <m docname="Trees/AVLTreePerformance" label="True" nowrap="False" number="True" xml:space="preserve">F_0 = 0 \\
+        <m docname="Trees/AVLTreePerformance" nowrap="False" number="True" xml:space="preserve">F_0 = 0 \\
 F_1 = 1 \\
 F_i = F_{i-1} + F_{i-2}  \text{ for all } i \ge 2</m>
         <p>An important mathematical result is that as the numbers of the Fibonacci
@@ -35,13 +35,13 @@ F_i = F_{i-1} + F_{i-2}  \text{ for all } i \ge 2</m>
             use this equation to approximate <m>F_i</m> as <m>F_i =
                 \Phi^i/\sqrt{5}</m>. If we make use of this approximation we can rewrite
             the equation for <m>N_h</m> as:</p>
-        <m docname="Trees/AVLTreePerformance" label="True" nowrap="False" number="True" xml:space="preserve">N_h = F_{h+1} - 1, h \ge 1</m>
+        <m docname="Trees/AVLTreePerformance" nowrap="False" number="True" xml:space="preserve">N_h = F_{h+1} - 1, h \ge 1</m>
         <p>By replacing the Fibonacci reference with its golden ratio approximation
             we get:</p>
-        <m docname="Trees/AVLTreePerformance" label="True" nowrap="False" number="True" xml:space="preserve">N_h = \frac{\Phi^{h+2}}{\sqrt{5}} - 1</m>
+        <m docname="Trees/AVLTreePerformance" nowrap="False" number="True" xml:space="preserve">N_h = \frac{\Phi^{h+2}}{\sqrt{5}} - 1</m>
         <p>If we rearrange the terms, and take the base 2 log of both sides and
             then solve for <m>h</m> we get the following derivation:</p>
-        <m docname="Trees/AVLTreePerformance" label="True" nowrap="False" number="True" xml:space="preserve">\log{N_h+1} = (h+2)\log{\Phi} - \frac{1}{2} \log{5} \\
+        <m docname="Trees/AVLTreePerformance" nowrap="False" number="True" xml:space="preserve">\log{N_h+1} = (h+2)\log{\Phi} - \frac{1}{2} \log{5} \\
 h = \frac{\log{N_h+1} - 2 \log{\Phi} + \frac{1}{2} \log{5}}{\log{\Phi}} \\
 h = 1.44 \log{N_h}</m>
         <p>This derivation shows us that at any time the height of our AVL tree is

--- a/pretext/Trees/BalancedBinarySearchTrees.ptx
+++ b/pretext/Trees/BalancedBinarySearchTrees.ptx
@@ -14,7 +14,7 @@
             and right subtrees for each node. More formally, we define the balance
             factor for a node as the difference between the height of the left
             subtree and the height of the right subtree.</p>
-        <m docname="Trees/BalancedBinarySearchTrees" label="True" nowrap="False" number="True" xml:space="preserve">balanceFactor = height(leftSubTree) - height(rightSubTree)</m>
+        <m docname="Trees/BalancedBinarySearchTrees" nowrap="False" number="True" xml:space="preserve">balanceFactor = height(leftSubTree) - height(rightSubTree)</m>
         <p>Using the definition for balance factor given above we say that a
             subtree is left-heavy if the balance factor is greater than zero. If the
             balance factor is less than zero then the subtree is right heavy. If the


### PR DESCRIPTION
# Description
It would appear that m entities can be the target of xrefs these days. Whatever label="True" used to mean, it doesn't mean that any more. Deleting the attribute does not appear to change the output and it gets rid of yet another PTX:ERROR

easy fix: delete ' label="True"' everywhere

## Related Issue
standalone

## How Has This Been Tested?
local build