### PR TITLE
fix image links in linear linked chapter 4

### DIFF
--- a/pretext/LinearLinked/TheNodeClass.ptx
+++ b/pretext/LinearLinked/TheNodeClass.ptx
@@ -64,10 +64,10 @@ class Node {
   </blockquote>
   <figure align="center" xml:id="id1-fig-node">
     <caption xmlns:c="https://www.sphinx-doc.org/" xmlns:changeset="https://www.sphinx-doc.org/" xmlns:citation="https://www.sphinx-doc.org/" xmlns:cpp="https://www.sphinx-doc.org/" xmlns:index="https://www.sphinx-doc.org/" xmlns:js="https://www.sphinx-doc.org/" xmlns:math="https://www.sphinx-doc.org/" xmlns:py="https://www.sphinx-doc.org/" xmlns:rst="https://www.sphinx-doc.org/" xmlns:std="https://www.sphinx-doc.org/">Figure 3: A Node Object Contains the Item and a Reference to the Next Node</caption>
-    <image source="LinearLinked/Figures/node.png" width="50%"/>
+    <image source="LinearLinked/node.png" width="50%"/>
   </figure>
   <figure align="center" xml:id="id2-fig-node2">
     <caption xmlns:c="https://www.sphinx-doc.org/" xmlns:changeset="https://www.sphinx-doc.org/" xmlns:citation="https://www.sphinx-doc.org/" xmlns:cpp="https://www.sphinx-doc.org/" xmlns:index="https://www.sphinx-doc.org/" xmlns:js="https://www.sphinx-doc.org/" xmlns:math="https://www.sphinx-doc.org/" xmlns:py="https://www.sphinx-doc.org/" xmlns:rst="https://www.sphinx-doc.org/" xmlns:std="https://www.sphinx-doc.org/">Figure 4: A Typical Representation for a Node</caption>
-    <image source="LinearLinked/Figures/node2.png" width="50%"/>
+    <image source="LinearLinked/node2.png" width="50%"/>
   </figure>
 </section>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description
remove Figures/ from the image url: fixes images in chapter 4

## Related Issue
standalone

## How Has This Been Tested?
local build with 404 checking