### PR TITLE
add missing less-than tag

### DIFF
--- a/pretext/Introduction/CollectionData.ptx
+++ b/pretext/Introduction/CollectionData.ptx
@@ -1312,7 +1312,7 @@ int main(){
 
         <choice correct="yes">
             <statement>
-                <p>An array of characters that ends with a terminating null character. For instance, "\0"./p>
+                <p>An array of characters that ends with a terminating null character. For instance, "\0".</p>
             </statement>
             <feedback>
                 <p>Correct! a c-string is different from a string.</p>


### PR DESCRIPTION
# Description
Missing &lt; in xml tag... I didn't notice this when I was reviewing ebfca10f52f3aae84346ab2baca120059130fb1b

## Related Issue
standalone

## How Has This Been Tested?
localbuild
