### PR TITLE
Pretext cli changes

### DIFF
--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -26,6 +26,9 @@
     "ghcr.io/devcontainers/features/github-cli:1": {}
   },
 
+  // Respect the project's designated dependencies
+  "postCreateCommand": "pip install -r requirements.txt",
+
   // Port forwarding
   // ---------------
   // This is needed by the CodeChat Server.

--- a/.gitignore
+++ b/.gitignore
@@ -128,3 +128,6 @@ pavement.py
 
 # Don't track codechat config (will be generated automatically)
 codechat_config.yaml
+
+# This temporary: pretext insists on adding stuff here
+.github/workflows


### PR DESCRIPTION
# Description
The pretext cli insists on modifying the devcontainer to include adding the python requirements. The change seems harmless, and it makes the source view a little nicer in vscode.

Question...do @pearcej or @moisedk use the .devcontainer.json? If not, then let's just delete it (it is in `.gitgnore` anyway)

Also, pretext wants to drop `.github/workflows/pretext-cli.yml`. Eventually we'll need to deal with that (when we start using actions to build/reploy). For now, I'd like to ignore it (improving the view in vscode)

## Related Issue
standalone

## How Has This Been Tested?
eyeballs