### PR TITLE
ensure xml:id's are unique: linear-basic-id1

### DIFF
--- a/pretext/LinearBasic/InfixPrefixandPostfixExpressions.ptx
+++ b/pretext/LinearBasic/InfixPrefixandPostfixExpressions.ptx
@@ -70,7 +70,7 @@
             respective operands, the order of the operands stayed exactly the same
             relative to one another.</p>
         
-        <table xml:id="linear-basic_id1"><tabular>
+        <table xml:id="linear-basic_xfix_examples"><tabular>
             <title><term>Table 2: Examples of Infix, Prefix, and Postfix</term></title>
             
                 

--- a/pretext/LinearBasic/TheDequeAbstractDataType.ptx
+++ b/pretext/LinearBasic/TheDequeAbstractDataType.ptx
@@ -40,7 +40,7 @@
             the rear as you move items in and out of the collection as things can
             get a bit confusing.</p>
         
-        <table xml:id="linear-basic_id1"><tabular>
+        <table xml:id="linear-basic_dequeue-examples"><tabular>
             <title><term>Table 1: Examples of Deque Operations</term></title>
             
                 

--- a/pretext/LinearBasic/TheQueueAbstractDataType.ptx
+++ b/pretext/LinearBasic/TheQueueAbstractDataType.ptx
@@ -40,7 +40,7 @@
             such that the front is on the right. 4 was the first item pushed so it
             is the first item returned by dequeue.</p>
         
-        <table xml:id="linear-basic_id1"><tabular>
+        <table xml:id="linear-basic_queue-examples"><tabular>
             <title><term>Table 1: Example Queue Operations</term></title>
             
                 


### PR DESCRIPTION
# Description
xml:id's must be unique, fixes error like:

* PTX:ERROR: the @xml:id value "linear-basic_id1" should be unique, but is authored 3 times.

## Related Issue
standalone

## How Has This Been Tested?
local build
