### PR TITLE
make repeated id3 point to correct refs

### DIFF
--- a/pretext/LinearBasic/WhatisaStack.ptx
+++ b/pretext/LinearBasic/WhatisaStack.ptx
@@ -34,11 +34,11 @@
             reverse of the order that they were placed. Stacks are fundamentally
             important, as they can be used to reverse the order of items. The order
             of insertion is the reverse of the order of removal.
-            <xref ref="fig-reversal"/> shows the stack object as it was
+            <xref ref="linear-basic-stack-fig-reversal"/> shows the stack object as it was
             created and then again as items are removed. Note the order of the
             objects.</p>
         
-        <figure align="center" xml:id="id3"><caption xmlns:c="https://www.sphinx-doc.org/" xmlns:changeset="https://www.sphinx-doc.org/" xmlns:citation="https://www.sphinx-doc.org/" xmlns:cpp="https://www.sphinx-doc.org/" xmlns:index="https://www.sphinx-doc.org/" xmlns:js="https://www.sphinx-doc.org/" xmlns:math="https://www.sphinx-doc.org/" xmlns:py="https://www.sphinx-doc.org/" xmlns:rst="https://www.sphinx-doc.org/" xmlns:std="https://www.sphinx-doc.org/">Figure 3: The Reversal Property of Stacks</caption><image source="LinearBasic/simplereversal.png" width="50%"/></figure>
+        <figure align="center" xml:id="linear-basic-stack-fig-reversal"><caption xmlns:c="https://www.sphinx-doc.org/" xmlns:changeset="https://www.sphinx-doc.org/" xmlns:citation="https://www.sphinx-doc.org/" xmlns:cpp="https://www.sphinx-doc.org/" xmlns:index="https://www.sphinx-doc.org/" xmlns:js="https://www.sphinx-doc.org/" xmlns:math="https://www.sphinx-doc.org/" xmlns:py="https://www.sphinx-doc.org/" xmlns:rst="https://www.sphinx-doc.org/" xmlns:std="https://www.sphinx-doc.org/">Figure 3: The Reversal Property of Stacks</caption><image source="LinearBasic/simplereversal.png" width="50%"/></figure>
     <p>Considering this reversal property, you can perhaps think of examples of
             stacks that occur as you use your computer. For example, every web
             browser has a Back button. As you navigate from web page to web page,

--- a/pretext/Trees/AVLTreeImplementation.ptx
+++ b/pretext/Trees/AVLTreeImplementation.ptx
@@ -196,8 +196,8 @@ void rotateLeft(TreeNode *rotRoot){
             the heights of the new subtrees? The following derivation should
             convince you that these lines are correct.</p>
         
-        <figure align="center" xml:id="id3"><caption xmlns:c="https://www.sphinx-doc.org/" xmlns:changeset="https://www.sphinx-doc.org/" xmlns:citation="https://www.sphinx-doc.org/" xmlns:cpp="https://www.sphinx-doc.org/" xmlns:index="https://www.sphinx-doc.org/" xmlns:js="https://www.sphinx-doc.org/" xmlns:math="https://www.sphinx-doc.org/" xmlns:py="https://www.sphinx-doc.org/" xmlns:rst="https://www.sphinx-doc.org/" xmlns:std="https://www.sphinx-doc.org/">A Left Rotation.</caption><image source="Trees/bfderive.png" width="70%"/></figure>
-        <p><xref ref="fig-bfderive"/> shows a left rotation. B and D are the pivotal
+        <figure align="center" xml:id="trees-avl-fig-bfderive"><caption xmlns:c="https://www.sphinx-doc.org/" xmlns:changeset="https://www.sphinx-doc.org/" xmlns:citation="https://www.sphinx-doc.org/" xmlns:cpp="https://www.sphinx-doc.org/" xmlns:index="https://www.sphinx-doc.org/" xmlns:js="https://www.sphinx-doc.org/" xmlns:math="https://www.sphinx-doc.org/" xmlns:py="https://www.sphinx-doc.org/" xmlns:rst="https://www.sphinx-doc.org/" xmlns:std="https://www.sphinx-doc.org/">A Left Rotation.</caption><image source="Trees/bfderive.png" width="70%"/></figure>
+        <p><xref ref="trees-avl-fig-bfderive"/> shows a left rotation. B and D are the pivotal
             nodes and A, C, E are their subtrees. Let <m>h_x</m> denote the
             height of a particular subtree rooted at node <m>x</m>. By definition
             we know the following:</p>

--- a/pretext/Trees/BinaryHeapImplementation.ptx
+++ b/pretext/Trees/BinaryHeapImplementation.ptx
@@ -83,11 +83,11 @@
                 property. However, it is possible to write a method that will allow us
                 to regain the heap structure property by comparing the newly added item
                 with its parent. If the newly added item is less than its parent, then
-                we can swap the item with its parent. <xref ref="fig-percup"/> shows the
+                we can swap the item with its parent. <xref ref="trees-binheap-fig-percup"/> shows the
                 series of swaps needed to percolate the newly added item up to its
                 proper position in the tree.</p>
             
-            <figure align="center" xml:id="id3"><caption xmlns:c="https://www.sphinx-doc.org/" xmlns:changeset="https://www.sphinx-doc.org/" xmlns:citation="https://www.sphinx-doc.org/" xmlns:cpp="https://www.sphinx-doc.org/" xmlns:index="https://www.sphinx-doc.org/" xmlns:js="https://www.sphinx-doc.org/" xmlns:math="https://www.sphinx-doc.org/" xmlns:py="https://www.sphinx-doc.org/" xmlns:rst="https://www.sphinx-doc.org/" xmlns:std="https://www.sphinx-doc.org/">Percolate the New Node up to Its Proper Position.</caption><image source="Trees/percUp.png" width="50%" alt="image"/></figure>
+            <figure align="center" xml:id="trees-binheap-fig-percup"><caption xmlns:c="https://www.sphinx-doc.org/" xmlns:changeset="https://www.sphinx-doc.org/" xmlns:citation="https://www.sphinx-doc.org/" xmlns:cpp="https://www.sphinx-doc.org/" xmlns:index="https://www.sphinx-doc.org/" xmlns:js="https://www.sphinx-doc.org/" xmlns:math="https://www.sphinx-doc.org/" xmlns:py="https://www.sphinx-doc.org/" xmlns:rst="https://www.sphinx-doc.org/" xmlns:std="https://www.sphinx-doc.org/">Percolate the New Node up to Its Proper Position.</caption><image source="Trees/percUp.png" width="50%" alt="image"/></figure>
             
             <p>Notice that when we percolate an item up, we are restoring the heap
                 property between the newly added item and the parent. We are also

--- a/pretext/Trees/SearchTreeImplementation.ptx
+++ b/pretext/Trees/SearchTreeImplementation.ptx
@@ -318,8 +318,8 @@ TreeNode  *_get(int key, TreeNode *currentNode){
     }
 }</pre>
         
-        <figure align="center" xml:id="id3"><caption xmlns:c="https://www.sphinx-doc.org/" xmlns:changeset="https://www.sphinx-doc.org/" xmlns:citation="https://www.sphinx-doc.org/" xmlns:cpp="https://www.sphinx-doc.org/" xmlns:index="https://www.sphinx-doc.org/" xmlns:js="https://www.sphinx-doc.org/" xmlns:math="https://www.sphinx-doc.org/" xmlns:py="https://www.sphinx-doc.org/" xmlns:rst="https://www.sphinx-doc.org/" xmlns:std="https://www.sphinx-doc.org/">Deleting Node 16, a Node without Children.</caption><image source="Trees/bstdel1.png" width="50%"/></figure>
-        <p>The second case is only slightly more complicated (see <xref ref="lst-bst7"/>). If a node has only a
+        <figure align="center" xml:id="trees-search-lst-bst7"><caption xmlns:c="https://www.sphinx-doc.org/" xmlns:changeset="https://www.sphinx-doc.org/" xmlns:citation="https://www.sphinx-doc.org/" xmlns:cpp="https://www.sphinx-doc.org/" xmlns:index="https://www.sphinx-doc.org/" xmlns:js="https://www.sphinx-doc.org/" xmlns:math="https://www.sphinx-doc.org/" xmlns:py="https://www.sphinx-doc.org/" xmlns:rst="https://www.sphinx-doc.org/" xmlns:std="https://www.sphinx-doc.org/">Deleting Node 16, a Node without Children.</caption><image source="Trees/bstdel1.png" width="50%"/></figure>
+        <p>The second case is only slightly more complicated (see <xref ref="trees-search-lst-bst7"/>). If a node has only a
             single child, then we can simply promote the child to take the place of
             its parent. The code for this case is shown in the next listing. As
             you look at this code you will see that there are six cases to consider.


### PR DESCRIPTION
# Description
fix duplicate `id3` ref
fix missing refs: `lst-bst`, `fig-percup`, `fig-bfderive`, and `fig-reversal`

## Related Issue
<!--- This project prefers pull requests related to open issues -->
<!--- If suggesting a change, please discuss it in an issue first -->
<!--- Please link to the issue here: -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
