### PR TITLE
fix search-hash-id2 xrefs

### DIFF
--- a/pretext/SearchHash/TheBinarySearch.ptx
+++ b/pretext/SearchHash/TheBinarySearch.ptx
@@ -144,7 +144,7 @@ int main() {
                 times can we split the list? <xref ref="search-hash_tbl-binaryanalysis"/> helps us to see the
                 answer.</p>
             
-            <table xml:id="search-hash_id2"><tabular>
+            <table xml:id="search-hash_tbl-binaryanalysis"><tabular>
                 <title><term>Table 3: Tabular Analysis for a Binary Search</term></title>
                 
                     

--- a/pretext/SearchHash/TheSequentialSearch.ptx
+++ b/pretext/SearchHash/TheSequentialSearch.ptx
@@ -121,7 +121,7 @@
                 approximation, so the complexity of the sequential search, is
                 <m>O(n)</m>. <xref ref="search-hash_tbl-seqsearchtable"/> summarizes these results.</p>
             
-            <table xml:id="search-hash_id2"><tabular>
+            <table xml:id="search-hash_tbl-seqsearchtable"><tabular>
                 <title><term>Table 1: Comparisons Used in a Sequential Search of an Unordered List</term></title>
                 
                     


### PR DESCRIPTION
# Description
The right xref was right above these, easy peesy

## Related Issue
standalone

## How Has This Been Tested?
local build