### PR TITLE
fix ref to stack code, switch to listing

### DIFF
--- a/pretext/LinearBasic/ImplementingaStackCpp.ptx
+++ b/pretext/LinearBasic/ImplementingaStackCpp.ptx
@@ -9,15 +9,14 @@
             type such as a stack is the creation of a new class. The stack
             operations are implemented as methods. However, the STL already has a well
             written implementation of the Stack class.</p>
-        <p>The following stack implementation (<xref ref="lst-stackcode1"/>) assumes that
+        <p>The following stack implementation (<xref ref="stack-code1"/>) assumes that
             the end of the array will hold the top element of the stack. As the stack
             grows (as <c>push</c> operations occur), new items will be added on the end
             of the array. <c>pop</c> operations will manipulate that same end.</p>
         
-        <TabNode tabname="C++" tabnode_options="{'subchapter': 'ImplementingaStackCpp', 'chapter': 'LinearBasic', 'basecourse': 'cppds', 'optional': '', 'optclass': '', 'tabname': 'C++'}">
-
-    <program xml:id="stack_1ac_cpp" interactive="activecode" language="cpp">
-        <input>
+    <listing xml:id="stack-code1">
+        <p><term>C++ Implementation</term></p>
+        <program xml:id="stack_1ac_cpp" interactive="activecode" language="cpp"><input>
 //Tests the push, empty, size, pop, and top methods of the stack library.
 
 #include &lt;iostream&gt;
@@ -50,12 +49,9 @@ int main() {
 
     return 0;
 }
-        </input>
-    </program>
-            </TabNode><TabNode tabname="Python" tabnode_options="{'subchapter': 'ImplementingaStackCpp', 'chapter': 'LinearBasic', 'basecourse': 'cppds', 'optional': '', 'optclass': '', 'tabname': 'Python'}">
-
-    <program xml:id="stack_1ac_py" interactive="activecode" language="python">
-        <input>
+    </input></program>
+    <p><term>Python Implementation</term></p>
+    <program xml:id="stack_1ac_py" interactive="activecode" language="python"><input>
 #Tests the push, empty, size, pop, and top methods of the stack library.
 
 class Stack:
@@ -93,9 +89,7 @@ def main():
 
     print("Top Element of the Stack: ", newStack.top())
 main()
-        </input>
-    </program>
-            </TabNode>
+    </input></program></listing>
 
 <reading-questions xml:id="rq-stack-implementation">
                 <title>Reading Questions</title>


### PR DESCRIPTION

# Description
fixes the xref to the stack code, and removes tabnode in favor of dual-listing.

## Related Issue
this uses the same idea as proposed in #770 (dual listing like the bigO section). Let me know if it is acceptable in that bug report.

## How Has This Been Tested?
local build
