### PR TITLE
let's change the default book initials to... DS?

### DIFF
--- a/pretext/bookinfo.ptx
+++ b/pretext/bookinfo.ptx
@@ -52,7 +52,7 @@ along with MathBook XML. If not, see <http://www.gnu.org/licenses/>.
 
 <!-- Prefix to enhance Sage notebook contents -->
 
-<initialism>SB</initialism>
+<initialism>DS</initialism>
 
 <!-- Math-related macros from "macros.tex" in previous LaTeX version -->
 


### PR DESCRIPTION
# Description
I finally figured out where the SB in the titlebar was coming from... how about we change it from SB -> DS.

## Related Issue
standalone

## How Has This Been Tested?
local build
