### PR TITLE
a bundle of "easy" xref fixes

### DIFF
--- a/pretext/LinearBasic/InfixPrefixandPostfixExpressions.ptx
+++ b/pretext/LinearBasic/InfixPrefixandPostfixExpressions.ptx
@@ -58,7 +58,7 @@
             Prefix expression notation requires that all operators precede the two
             operands that they work on. Postfix, on the other hand, requires that
             its operators come after the corresponding operands. A few more examples
-            should help to make this a bit clearer (see <xref ref="linear-basic_tbl-example1"/>).</p>
+            should help to make this a bit clearer (see <xref ref="linear-basic_xfix_examples"/>).</p>
         <p>In prefix, A + B * C would be written as + A * B C . The multiplication
             operator comes immediately before the operands B and C, denoting that *
             has precedence over +. The addition operator then appears before the A
@@ -134,8 +134,8 @@
             determined by the position of the operator and nothing else. In many
             ways, this makes infix the least desirable notation to use.</p>
         
-        <table xml:id="linear-basic_id2"><tabular>
-            <title><term>Table 3: An Expression with Parentheses</term></title>
+        <table xml:id="linear-basic_tbl-parexample"><tabular>
+            <title>An Expression with Parentheses</title>
             
                 
                 
@@ -173,8 +173,8 @@
             understand how they are equivalent in terms of the order of the
             operations being performed.</p>
         
-        <table xml:id="linear-basic_id3"><tabular>
-            <title><term>Table 4: Additional Examples of Infix, Prefix, and Postfix</term></title>
+        <table xml:id="linear-basic_tbl-example3"><tabular>
+            <title>Additional Examples of Infix, Prefix, and Postfix</title>
             
                 
                 

--- a/pretext/LinearBasic/SimulationPrintingTasks.ptx
+++ b/pretext/LinearBasic/SimulationPrintingTasks.ptx
@@ -104,7 +104,7 @@
             <p>To design this simulation we will create classes for the three
                 real-world objects described above: <c>Printer</c>, <c>Task</c>, and
                 <c>PrintQueue</c>.</p>
-            <p>The <c>Printer</c> class (<xref ref="lst-printer"/>) will need to track whether
+            <p>The <c>Printer</c> class (<xref ref="linear-basic_lst-printer"/>) will need to track whether
                 it has a current task. If it does, then it is busy (lines 13&#8211;17) and the
                 amount of time needed can be computed from the number of pages in the
                 task. The constructor will also allow the pages-per-minute setting to be
@@ -148,7 +148,7 @@ private:
     int timeRemaining; // Time remaining, in "seconds".
 };
 </input></program>
-            <p>The Task class (<xref ref="lst-task"/>) will represent a single printing
+            <p>The Task class (<xref ref="linear-basic_lst-task"/>) will represent a single printing
                 task. When the task is created, a random number generator will provide a
                 length from 1 to 20 pages. We have chosen to use the <c>rand()</c>
                 function to provide the random number using the format below. <c>srand()</c> is used
@@ -192,7 +192,7 @@ private:
     int pages;
 };
 </input></program>
-            <p>The main simulation (<xref ref="lst-qumainsim"/>) implements the algorithm
+            <p>The main simulation (<xref ref="linear-basic_lst-qumainsim"/>) implements the algorithm
                 described above. The <c>printQueue</c> object is an instance of our
                 existing queue ADT. A boolean helper function, <c>newPrintTask</c>, decides
                 whether a new printing task has been created. We have again chosen to

--- a/pretext/LinearBasic/TheDequeAbstractDataType.ptx
+++ b/pretext/LinearBasic/TheDequeAbstractDataType.ptx
@@ -40,8 +40,8 @@
             the rear as you move items in and out of the collection as things can
             get a bit confusing.</p>
         
-        <table xml:id="linear-basic_dequeue-examples"><tabular>
-            <title><term>Table 1: Examples of Deque Operations</term></title>
+        <table xml:id="linear-basic_tbl-dequeoperations"><tabular>
+            <title>Examples of Deque Operations</title>
             
                 
                 

--- a/pretext/LinearBasic/TheQueueAbstractDataType.ptx
+++ b/pretext/LinearBasic/TheQueueAbstractDataType.ptx
@@ -40,8 +40,8 @@
             such that the front is on the right. 4 was the first item pushed so it
             is the first item returned by dequeue.</p>
         
-        <table xml:id="linear-basic_queue-examples"><tabular>
-            <title><term>Table 1: Example Queue Operations</term></title>
+        <table xml:id="linear-basic_tbl-queueoperations"><tabular>
+            <title>Example Queue Operations</title>
             
                 
                 

--- a/pretext/LinearLinked/ImplementinganOrderedList.ptx
+++ b/pretext/LinearLinked/ImplementinganOrderedList.ptx
@@ -26,7 +26,7 @@
         <p>To implement the <c>OrderedList</c> class, we will use the same technique
             as seen previously with unordered linked lists. Once again, an empty linked list will
             be denoted by a <c>head</c> reference to <c>NULL</c> (see
-            <xref ref="lst-orderlist"/>).</p>
+            <xref ref="linear-linked_lst-orderlist"/>).</p>
         
         <p xml:id="linear-linked_lst-orderlist" names="lst_orderlist"><term>Listing 8</term></p>
         <pre>class OrderedList {
@@ -65,7 +65,7 @@
                 </image>
             </figure>
 
-        <p><xref ref="lst-ordersearch"/> shows the complete <c>search</c> method. It is
+        <p><xref ref="linear-linked_lst-ordersearch"/> shows the complete <c>search</c> method. It is
             easy to incorporate the new condition discussed above by adding another
             boolean variable, <c>stop</c>, and initializing it to <c>False</c> (line 4).
             While <c>stop</c> is <c>False</c> (in other words, while the search is still ongoing) we can continue to look
@@ -118,7 +118,7 @@
 
         <p>As we saw with unordered linked lists, it is necessary to have an additional
             reference, again called <c>previous</c>, since <c>current</c> will not provide
-            access to the node that must be modified. <xref ref="lst-orderadd"/> shows
+            access to the node that must be modified. <xref ref="linear-linked_lst-orderadd"/> shows
             the complete <c>add</c> method. Lines 2&#8211;3 set up the two external
             references and lines 9&#8211;10 again allow <c>previous</c> to follow one node
             behind <c>current</c> every time through the iteration. The condition (line

--- a/pretext/LinearLinked/TheNodeClass.ptx
+++ b/pretext/LinearLinked/TheNodeClass.ptx
@@ -5,12 +5,12 @@
             <term>node</term>. Each node object must hold at least two pieces of information.
             First, the node must contain the list item itself. We will call this the
             <term>data field</term> of the node. In addition, each node must hold a reference
-            to the next node. <xref ref="lst-nodeclass"/> shows the C++
+            to the next node. <xref ref="linear-linked_lst-nodeclass"/> shows the C++
             implementation. To construct a node, you need to supply the initial data
             value for the node. Evaluating the assignment statement below will yield
-            a node object containing the value 93 (see <xref ref="fig-node"/>). You
+            a node object containing the value 93 (see <xref ref="id1-fig-node"/>). You
             should note that we will typically represent a node object as shown in
-            <xref ref="fig-node2"/>. The <c>Node</c> class also includes the usual methods
+            <xref ref="id2-fig-node2"/>. The <c>Node</c> class also includes the usual methods
             to access and modify the data and the next reference.</p>
   <p xml:id="linear-linked_lst-nodeclass" names="lst_nodeclass">
     <term>Listing 1</term>
@@ -63,11 +63,11 @@ class Node {
                 referring to <c>NULL</c>.</p>
   </blockquote>
   <figure align="center" xml:id="id1-fig-node">
-    <caption xmlns:c="https://www.sphinx-doc.org/" xmlns:changeset="https://www.sphinx-doc.org/" xmlns:citation="https://www.sphinx-doc.org/" xmlns:cpp="https://www.sphinx-doc.org/" xmlns:index="https://www.sphinx-doc.org/" xmlns:js="https://www.sphinx-doc.org/" xmlns:math="https://www.sphinx-doc.org/" xmlns:py="https://www.sphinx-doc.org/" xmlns:rst="https://www.sphinx-doc.org/" xmlns:std="https://www.sphinx-doc.org/">Figure 3: A Node Object Contains the Item and a Reference to the Next Node</caption>
+    <caption>A Node Object Contains the Item and a Reference to the Next Node</caption>
     <image source="LinearLinked/node.png" width="50%"/>
   </figure>
   <figure align="center" xml:id="id2-fig-node2">
-    <caption xmlns:c="https://www.sphinx-doc.org/" xmlns:changeset="https://www.sphinx-doc.org/" xmlns:citation="https://www.sphinx-doc.org/" xmlns:cpp="https://www.sphinx-doc.org/" xmlns:index="https://www.sphinx-doc.org/" xmlns:js="https://www.sphinx-doc.org/" xmlns:math="https://www.sphinx-doc.org/" xmlns:py="https://www.sphinx-doc.org/" xmlns:rst="https://www.sphinx-doc.org/" xmlns:std="https://www.sphinx-doc.org/">Figure 4: A Typical Representation for a Node</caption>
+    <caption>A Typical Representation for a Node</caption>
     <image source="LinearLinked/node2.png" width="50%"/>
   </figure>
   <p>


### PR DESCRIPTION
# Description
These xrefs fixes are "easy", meaning they point to an object which is "referenceable" (paragraph, figure, table, etc.). Many of the remaining xref errors point at `program` tags and those require more thought than I can muster right now.

<!--- Describe your changes in detail -->

## Related Issue
There are probably related issues, but the easy way to go through these right now is by reading the ptx error log.

## How Has This Been Tested?
local build
