### PR TITLE
update container/requirements to current pretext

### DIFF
--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -1,5 +1,3 @@
-// <!-- Managed automatically by PreTeXt authoring tools -->
-// (delete the above line to manage this file manually)
 //////////////////////////////////////////////////////////////
 //
 // This file provides configuration options so that a PreTeXt 
@@ -15,11 +13,11 @@
   "name": "PreTeXt-Codespaces",
 
   // This Docker image includes some LaTeX support, but is still not to large.  Note that if you keep your codespace running, it will use up your GitHub free storage quota.  Additional options are listed below.
-  "image": "oscarlevin/pretext:small",
+  //"image": "oscarlevin/pretext:small",
   // If you need to generate more complicated assets (such as sageplots) or use additional fonts when building to PDF, comment out the above line and uncomment the following line.
   // "image": "oscarlevin/pretext:full",
   // If you only intend to build for web and don't have any latex-image generated assets, you can use a smaller image:
-  // "image": "oscarlevin/pretext:lite",
+  "image": "oscarlevin/pretext:lite",
 
   // Add gh cli as a feature (to support codechat)
   "features": {

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
-# <!-- Managed automatically by PreTeXt authoring tools -->
-pretext == 2.7.0
+pretext>=2.7.0
+runestone>=3.0.0b5
+SQLAlchemy>=1.0.8

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
-pretext>=2.7.0
-runestone>=3.0.0b5
-SQLAlchemy>=1.0.8
+# <!-- Managed automatically by PreTeXt authoring tools -->
+pretext == 2.7.0


### PR DESCRIPTION
# Description
- tell pretext to stop trying to update .devcontainer.json
- use the "lite" image for now (we'll want to switch to "small" when we start playing with printable generation

## Related Issue
standalone

## How Has This Been Tested?
codespaces build