### PR TITLE
Clarify location 4 operator overloading

### DIFF
--- a/_sources/Introduction/ObjectOrientedProgrammingDefiningClasses.rst
+++ b/_sources/Introduction/ObjectOrientedProgrammingDefiningClasses.rst
@@ -583,9 +583,9 @@ like more symmetry.
 Binary operators can either be members of their
 left-hand argument's class or friend functions.
 Since the stream operators' left-hand argument is a stream,
-stream operators (like << and >>) must be either member functions of the stream class
+stream operators (such as &lt;&lt; and &gt;&gt;) must be either member functions of the stream class
 or friend functions of the class they are used with.
-However, that is not true for ``+``.
+However, that is not true for the ``+`` operator.
 Let's rewrite the addition operator as a friend function.
 
 **Listing 6**

--- a/_sources/Introduction/ObjectOrientedProgrammingDefiningClasses.rst
+++ b/_sources/Introduction/ObjectOrientedProgrammingDefiningClasses.rst
@@ -583,8 +583,8 @@ like more symmetry.
 Binary operators can either be members of their
 left-hand argument's class or friend functions.
 Since the stream operators' left-hand argument is a stream,
-stream operators either have to be members of the stream class
-or friend functions.
+stream operators (like << and >>) must be either member functions of the stream class
+or friend functions of the class they are used with.
 However, that is not true for ``+``.
 Let's rewrite the addition operator as a friend function.
 

--- a/pretext/Introduction/ObjectOrientedProgrammingDefiningClasses.ptx
+++ b/pretext/Introduction/ObjectOrientedProgrammingDefiningClasses.ptx
@@ -492,9 +492,9 @@ print(f3)
                 Binary operators can either be members of their
                 left-hand argument's class or friend functions.
                 Since the stream operators' left-hand argument is a stream,
-                stream operators either have to be members of the stream class
-                or friend functions.
-                However, that is not true for <c>+</c>.
+                stream operators (such as &lt;&lt; and &gt;&gt;) must be either member functions of the stream class
+                or friend functions of the class they are used with.
+                However, that is not true for the <c>+</c> operator.
                 Let's rewrite the addition operator as a friend function.</p>
             <p><term>Listing 6</term></p>
             <TabNode tabname="C++" tabnode_options="{'subchapter': 'ObjectOrientedProgrammingDefiningClasses', 'chapter': 'Introduction', 'basecourse': 'cppds', 'optional': '', 'optclass': '', 'tabname': 'C++'}">


### PR DESCRIPTION
Provides clarification of where operator overloading definitions must reside for stream operators.

## Related Issue
cherry-picks commit 0295ea914b81df841e63b6411c8ae56cbfd89e16
