### PR TITLE
require ios reference return

### DIFF
--- a/_sources/Introduction/ObjectOrientedProgrammingDefiningClasses.rst
+++ b/_sources/Introduction/ObjectOrientedProgrammingDefiningClasses.rst
@@ -411,7 +411,7 @@ stream is changed by the stream operator.
 
             int main() {
                 Fraction myfraction(3, 5);
-                cout << myfraction;
+                cout << myfraction << " is my fraction" << endl;
 
                 return 0;
             }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description
Just printing the fraction doesn't require the iostream reference to be returned. However, printing a string afterwards DOES require the ios reference to be returned.

## Related Issue
closes #208
closes #656

## How Has This Been Tested?
local build