### PR TITLE
require iostream reference to be returned

### DIFF
--- a/_sources/Introduction/ObjectOrientedProgrammingDefiningClasses.rst
+++ b/_sources/Introduction/ObjectOrientedProgrammingDefiningClasses.rst
@@ -411,7 +411,7 @@ stream is changed by the stream operator.
 
             int main() {
                 Fraction myfraction(3, 5);
-                cout << myfraction;
+                cout << myfraction << " is my fraction" << endl;
 
                 return 0;
             }

--- a/pretext/Introduction/ObjectOrientedProgrammingDefiningClasses.ptx
+++ b/pretext/Introduction/ObjectOrientedProgrammingDefiningClasses.ptx
@@ -225,7 +225,7 @@ Fraction (){
     Fraction myfraction(3, 5);
 
     // Throws an error
-    cout &lt;&lt; myfraction &lt;&lt; " is my fraction" &lt;&lt; endl;
+    cout &lt;&lt; myfraction &lt;&lt; endl;
 
     return 0;
 }</pre>

--- a/pretext/Introduction/ObjectOrientedProgrammingDefiningClasses.ptx
+++ b/pretext/Introduction/ObjectOrientedProgrammingDefiningClasses.ptx
@@ -225,7 +225,7 @@ Fraction (){
     Fraction myfraction(3, 5);
 
     // Throws an error
-    cout &lt;&lt; myfraction &lt;&lt; endl;
+    cout &lt;&lt; myfraction &lt;&lt; " is my fraction" &lt;&lt; endl;
 
     return 0;
 }</pre>
@@ -345,7 +345,7 @@ ostream &amp;operator &lt;&lt; (ostream &amp;stream, const Fraction &amp;frac) {
 
 int main() {
     Fraction myfraction(3, 5);
-    cout &lt;&lt; myfraction;
+    cout &lt;&lt; myfraction &lt;&lt; " is my fraction" &lt;&lt; endl;
 
     return 0;
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description
Just printing the object doesn't require that the `operator<<` function return the iostream reference. However, printing a string forces the issue.

## Related Issue
closes #208 
closes #656 

## How Has This Been Tested?
local build