### PR TITLE
enable numbers, make linenos match text

### DIFF
--- a/_sources/Trees/AVLTreeImplementation.rst
+++ b/_sources/Trees/AVLTreeImplementation.rst
@@ -192,6 +192,9 @@ it to you to study the code for ``rotateRight``.
 
 **C++ Implementation**
 
+.. highlight:: cpp
+    :linenothreshold: 5
+
 ::
 
     void rotateLeft(TreeNode *rotRoot){
@@ -219,9 +222,11 @@ it to you to study the code for ``rotateRight``.
     }
 
 
+.. highlight:: cpp
+    :linenothreshold: 500
 
 
-Finally, lines 16-17 require some explanation. In
+Finally, lines 21-22 require some explanation. In
 these two lines we update the balance factors of the old and the new
 root. Since all the other moves are moving entire subtrees around the
 balance factors of all other nodes are unaffected by the rotation. But
@@ -290,7 +295,7 @@ steps:
 
 Now we have all of the parts in terms that we readily know. If we
 remember that B is ``rotRoot`` and D is ``newRoot`` then we can see this
-corresponds exactly to the statement on line 16, or:
+corresponds exactly to the statement on line 21, or:
 
 ::
 
@@ -354,8 +359,8 @@ the left rotation around A brings the entire subtree back into balance.
 The code that implements these rules can be found in our ``rebalance``
 method, which is shown in :ref:`Listing 3 <lst_rebalance>`. Rule number 1 from
 above is implemented by the ``if`` statement starting on line 2.
-Rule number 2 is implemented by the ``elif`` statement starting on
-line 8.
+Rule number 2 is implemented by the ``else if`` statement starting on
+line 11.
 
 .. _lst_rebalance:
 

--- a/pretext/Trees/AVLTreeImplementation.ptx
+++ b/pretext/Trees/AVLTreeImplementation.ptx
@@ -195,7 +195,7 @@ void rotateLeft(TreeNode *rotRoot){
             </input></program>
         </listing>
 
-        <p>Finally, lines&#160;16-17 require some explanation. In
+        <p>Finally, lines&#160;21-22 require some explanation. In
             these two lines we update the balance factors of the old and the new
             root. Since all the other moves are moving entire subtrees around the
             balance factors of all other nodes are unaffected by the rotation. But
@@ -238,7 +238,7 @@ newBal(B) - oldBal(B) =  1 + max(h_C,h_E) - h_C</m>
 newBal(B) = oldBal(B) + 1 - min(0 , oldBal(D)) \\</m>
         <p>Now we have all of the parts in terms that we readily know. If we
             remember that B is <c>rotRoot</c> and D is <c>newRoot</c> then we can see this
-            corresponds exactly to the statement on line&#160;16, or:</p>
+            corresponds exactly to the statement on line&#160;21, or:</p>
         <program language="cpp"><input>
 rotRoot.balanceFactor = rotRoot.balanceFactor + 1 - min(0,newRoot.balanceFactor)
 </input></program>
@@ -290,12 +290,12 @@ rotRoot.balanceFactor = rotRoot.balanceFactor + 1 - min(0,newRoot.balanceFactor)
         <p>The code that implements these rules can be found in our <c>rebalance</c>
             method, which is shown in <xref ref="avlimpl_lst-rebalance"/>. Rule number 1 from
             above is implemented by the <c>if</c> statement starting on line&#160;2.
-            Rule number 2 is implemented by the <c>elif</c> statement starting on
-            line 8.</p>
+            Rule number 2 is implemented by the <c>else if</c> statement starting on
+            line 11.</p>
         
         <listing xml:id="avlimpl_lst-rebalance">
             <caption>Implementation of <c>rebalance</c></caption>
-            <program language="cpp"><input>
+            <program language="cpp" line-numbers="yes"><input>
 void rebalance(TreeNode *node){
     if (node-&gt;balanceFactor &lt; 0){
         if (node-&gt;rightChild-&gt;balanceFactor &gt; 0){


### PR DESCRIPTION
# Description
avl implementation section was missing line numbers in rst. Also update the line numbers to match the listings.

## Related Issue
closes #194 

## How Has This Been Tested?
local build
