### PR TITLE
split really long dragndrop question

### DIFF
--- a/_sources/LinearBasic/Glossary.rst
+++ b/_sources/LinearBasic/Glossary.rst
@@ -66,14 +66,23 @@ Matching
     :match_4: first-in first-out (FIFO)|||First item added is also the first removed
     :match_5: linear data structure|||Data structure with elements that have positions relative to each other
     :match_6: palindrome|||String that reads the same forward and backward
-    :match_7: postfix|||Expression notation in which all operators come after the two operands that they work on
+    :match_7: simulation|||Replica of a process or operations 
     :match_8: precedence|||Hierarchy on the order things occur
-    :match_9: prefix|||Expression notation in which all operators precede the two operands that they work on
-    :match_10: queue|||Ordered collection of items where the addition of new items happens at one end and the removal of existing items occurs at the other end
-    :match_11: last-in first-out (LIFO)|||Last item added is also the first removed
-    :match_12: simulation|||Replica of a process or operations
-    :match_13: stack|||Ordered collection of items where the addition of new items and the removal of existing items always takes place at the same end
-    :match_14: fully parenthesized|||Usage of one pair of parentheses for each operator
-    :match_15: infix|||Expression notation in which the operator is in between the two operands that it is working on
+    
+    Match the term with their corresponding definition 
+
+
+Matching
+--------
+
+.. dragndrop:: Matchchap3
+    :feedback: Incorrect
+    :match_1: postfix|||Expression notation in which all operators come after the two operands that they work on
+    :match_2: prefix|||Expression notation in which all operators precede the two operands that they work on
+    :match_3: queue|||Ordered collection of items where the addition of new items happens at one end and the removal of existing items occurs at the other end
+    :match_4: last-in first-out (LIFO)|||Last item added is also the first removed
+    :match_5: stack|||Ordered collection of items where the addition of new items and the removal of existing items always takes place at the same end
+    :match_6: fully parenthesized|||Usage of one pair of parentheses for each operator
+    :match_7: infix|||Expression notation in which the operator is in between the two operands that it is working on
 
     Match the term with their corresponding definition 

--- a/pretext/LinearBasic/Matching.ptx
+++ b/pretext/LinearBasic/Matching.ptx
@@ -13,30 +13,6 @@
         <premise>algorithm</premise>
         <response>Generic step-by-step list of instructions for solving a problem</response>
       </match>
-      <match order="10">
-        <premise>queue</premise>
-        <response>Ordered collection of items where the addition of new items happens at one end and the removal of existing items occurs at the other end</response>
-      </match>
-      <match order="11">
-        <premise>last-in first-out (LIFO)</premise>
-        <response>Last item added is also the first removed</response>
-      </match>
-      <match order="12">
-        <premise>simulation</premise>
-        <response>Replica of a process or operations</response>
-      </match>
-      <match order="13">
-        <premise>stack</premise>
-        <response>Ordered collection of items where the addition of new items and the removal of existing items always takes place at the same end</response>
-      </match>
-      <match order="14">
-        <premise>fully parenthesized</premise>
-        <response>Usage of one pair of parentheses for each operator</response>
-      </match>
-      <match order="15">
-        <premise>infix</premise>
-        <response>Expression notation in which the operator is in between the two operands that it is working on</response>
-      </match>
       <match order="2">
         <premise>balanced parentheses</premise>
         <response>Each opening symbol has a corresponding closing symbol and the pairs of parentheses are properly nested</response>
@@ -58,16 +34,51 @@
         <response>String that reads the same forward and backward</response>
       </match>
       <match order="7">
-        <premise>postfix</premise>
-        <response>Expression notation in which all operators come after the two operands that they work on</response>
+        <premise>simulation</premise>
+        <response>Replica of a process or operations</response>
       </match>
       <match order="8">
         <premise>precedence</premise>
         <response>Hierarchy on the order things occur</response>
       </match>
-      <match order="9">
+    </matches>
+  </exercise>
+
+  <exercise label="Match_chap3_2">
+    <statement>
+      <p>Match the term with their corresponding definition</p>
+    </statement>
+    <feedback>
+      <p>Incorrect</p>
+    </feedback>
+    <matches>
+      <match order="1">
+        <premise>postfix</premise>
+        <response>Expression notation in which all operators come after the two operands that they work on</response>
+      </match>
+      <match order="2">
         <premise>prefix</premise>
         <response>Expression notation in which all operators precede the two operands that they work on</response>
+      </match>
+      <match order="3">
+        <premise>queue</premise>
+        <response>Ordered collection of items where the addition of new items happens at one end and the removal of existing items occurs at the other end</response>
+      </match>
+      <match order="4">
+        <premise>last-in first-out (LIFO)</premise>
+        <response>Last item added is also the first removed</response>
+      </match>
+      <match order="5">
+        <premise>stack</premise>
+        <response>Ordered collection of items where the addition of new items and the removal of existing items always takes place at the same end</response>
+      </match>
+      <match order="6">
+        <premise>fully parenthesized</premise>
+        <response>Usage of one pair of parentheses for each operator</response>
+      </match>
+      <match order="7">
+        <premise>infix</premise>
+        <response>Expression notation in which the operator is in between the two operands that it is working on</response>
       </match>
     </matches>
   </exercise>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description
the dragndrop was 15 entries long, split it into a 7 and 8 entry DND.

## Related Issue
I cherry-picked from @kwizeras #659 for the diff to rst and made a corresponding entry for ptx.

closes #659
closes #329

## How Has This Been Tested?
local build