### PR TITLE
Figures missing captions descr

### DIFF
--- a/pretext/Introduction/ObjectOrientedProgrammingDerivedClasses.ptx
+++ b/pretext/Introduction/ObjectOrientedProgrammingDerivedClasses.ptx
@@ -143,7 +143,13 @@ int main() {
                 two families, those that have one input line and those that have two.
                 Below that, the specific logic functions of each appear.</p>
             <figure align="center" xml:id="ooderive_fig-circuit0">
-                <image source="Introduction/logicquestion.png" width="50%"/>
+                <caption>Example Logic Circuit</caption>
+                <image source="Introduction/logicquestion.png" width="50%">
+                        <description>
+                                Circuit diagram showing a two-input AND gate and a two-input OR gate.
+                                The output of these two gates are the inputs to another two-input AND gate
+                        </description>
+                </image>
             </figure>
 
          

--- a/pretext/Trees/DiscussionQuestions.ptx
+++ b/pretext/Trees/DiscussionQuestions.ptx
@@ -62,24 +62,37 @@
                     implementing as a method, whereas we could check inside the call when
                     implementing as a function?</p>
             </li>
-        </ol></p>
-        <p><ol marker="1">
             <li>
-                <p>Show the function calls needed to build the following binary tree.</p>
+                <p>Show the function calls needed to build the binary tree in <xref ref="exertree"/>.</p>
+                <figure align="center" xml:id="exertree">
+                    <caption>Tree of Programming Languages</caption>
+                    <image source="Trees/exerTree.png" width="50%">
+                        <description>A tree whose root node is language. The language node has two children: compiled and interpreted.
+                            The compiled node has two children: C and Java. The interpreted node has two children: Python and Scheme.
+                        </description>
+                    </image>
+                </figure>
+            </li>
+            <li>
+                <p>Given the tree in <xref ref="rotexer1"/>, perform the appropriate rotations to bring it back into balance.</p>
+                <figure align="center" xml:id="rotexer1">
+                    <caption>Out of Balance Tree</caption>
+                    <image source="Trees/rotexer1.png" width="20%">
+                        <description>
+                            A tree whose root node is B with a balance factor of -2. B has two children: A with a balance factor of 0 and
+                            E with a balanace factor of 1. A has no children. E has two children: D with a balance factor of 1 and F with
+                            a balance factor of 0. D has only a left child: C with balance factor 0. F has no children.
+                        </description>
+                    </image>
+                </figure>
+            </li>
+            <li>
+                <p>Using <xref ref="bfderive"/> as a starting point, derive the equation that gives the updated balance factor for node D.</p>
+                <figure align="center" xml:id="bfderive">
+                    <caption>Compute Updated Balance Factor</caption>
+                    <image source="Trees/bfderive.png" width="50%"/>
+                </figure>
             </li>
         </ol></p>
-        <figure align="center" ><image source="Trees/exerTree.png" width="50%"/></figure>
-        <p><ol marker="1">
-            <li>
-                <p>Given the following tree, perform the appropriate rotations to bring it back into balance.</p>
-            </li>
-        </ol></p>
-        <figure align="center" ><image source="Trees/rotexer1.png" width="20%"/></figure>
-        <p><ol marker="1">
-            <li>
-                <p>Using the following as a starting point, derive the equation that gives the updated balance factor for node D.</p>
-            </li>
-        </ol></p>
-        <figure align="center" ><image source="Trees/bfderive.png" width="50%"/></figure>
     </section>
 


### PR DESCRIPTION
# Description
figures should have captions and be referenced

also, I added descriptions for some of the images (the last AVL tree example eludes me for the moment)

## Related Issue
standalone

## How Has This Been Tested?
local build
