### PR TITLE
listings get captions not ttitles

### DIFF
--- a/pretext/Introduction/ObjectOrientedProgrammingDefiningClasses.ptx
+++ b/pretext/Introduction/ObjectOrientedProgrammingDefiningClasses.ptx
@@ -633,7 +633,7 @@ print(gcd(20,10))
                 <xref ref="introduction_lst-newaddmethod"/>).</p>
             
     <listing xml:id="introduction_lst-newaddmethod">
-        <title>New addition implementation using <c>gcd</c></title>
+        <caption>New addition implementation using <c>gcd</c></caption>
         <program xml:id="gcdadd" label="gcdadd" interactive="activecode" language="cpp"><input>
 #include &lt;iostream&gt;
 using namespace std;

--- a/pretext/LinearBasic/SimulationPrintingTasks.ptx
+++ b/pretext/LinearBasic/SimulationPrintingTasks.ptx
@@ -115,7 +115,7 @@
                 the printer to idle (line 11) if the task is completed.</p>
 
             <listing xml:id="linear-basic_lst-printer">
-                <title>The <c>Printer</c> class</title>
+                <caption>The <c>Printer</c> class</caption>
                 <program language="cpp"><input>
 class Printer {
 public:
@@ -173,7 +173,7 @@ private:
                 printing begins.</p>
             
             <listing xml:id="linear-basic_lst-task">
-                <title>The <c>Task</c> class</title>
+                <caption>The <c>Task</c> class</caption>
                 <program language="cpp"><input>
 class Task {
 public:
@@ -211,7 +211,7 @@ private:
                 printer.</p>
             
             <listing xml:id="linear-basic_lst-qumainsim">
-                <title>The main simulation function</title>
+                <caption>The main simulation function</caption>
                 <program language="cpp"><input>
 void simulation(int numSeconds, int pagesPerMinute) {
     Printer labprinter(pagesPerMinute);

--- a/pretext/LinearLinked/ImplementinganOrderedList.ptx
+++ b/pretext/LinearLinked/ImplementinganOrderedList.ptx
@@ -29,7 +29,7 @@
             <xref ref="linear-linked_lst-orderlist"/>).</p>
         
         <listing xml:id="linear-linked_lst-orderlist">
-            <title><c>OrderedList</c> Member Variable</title>
+            <caption><c>OrderedList</c> Member Variable</caption>
             <program language="cpp"><input>
 class OrderedList {
     Node* head;
@@ -79,7 +79,7 @@ class OrderedList {
             the unordered linked list search.</p>
         
         <listing xml:id="linear-linked_lst-ordersearch">
-            <title><c>search</c> Method</title>
+            <caption><c>search</c> Method</caption>
             <program language="cpp"><input>
 bool search(int item) {
     Node *current = head;
@@ -141,7 +141,7 @@ bool search(int item) {
             <c>previous == NULL</c> (line 13) can be used to provide the answer.</p>
         
         <listing xml:id="linear-linked_lst-orderadd">
-            <title><c>add</c> Method</title>
+            <caption><c>add</c> Method</caption>
             <program language="cpp"><input>
 void add(int item) {
     if (head == NULL) {

--- a/pretext/LinearLinked/TheNodeClass.ptx
+++ b/pretext/LinearLinked/TheNodeClass.ptx
@@ -14,7 +14,7 @@
             to access and modify the data and the next reference.</p>
 
   <listing xml:id="linear-linked_lst-nodeclass" names="lst_nodeclass">
-    <title><c>Node</c> Class</title>
+    <caption><c>Node</c> Class</caption>
     <program language="cpp"><input>
 #include &lt;iostream&gt;
 using namespace std;

--- a/verifier.py
+++ b/verifier.py
@@ -32,7 +32,7 @@ class CppsXmlTest:
 
 class TagsNeedsCaption(CppsXmlTest):
     """The tags below should have a <caption> elements as a child"""
-    captioned_things = ('figure',)
+    captioned_things = ('figure', 'listing', 'table')
     @classmethod
     def test_file(cls, fname, doc):
         ret = True


### PR DESCRIPTION
# Description
Originally I believed that title was the correct tag for listings.. it isn't, it's caption. Easy/mechanical fix.

## Related Issue
standalone

## How Has This Been Tested?
local build