### PR TITLE
Captions not titles

### DIFF
--- a/pretext/LinearBasic/TheDequeAbstractDataType.ptx
+++ b/pretext/LinearBasic/TheDequeAbstractDataType.ptx
@@ -40,131 +40,124 @@
             the rear as you move items in and out of the collection as things can
             get a bit confusing.</p>
         
-        <table xml:id="linear-basic_tbl-dequeoperations"><tabular>
-            <title>Examples of Deque Operations</title>
-            
-                
-                
-                
-                
-                    <row header="yes">
-                        <cell>
-                            <term>Deque Operation</term>
-                        </cell>
-                        <cell>
-                            <term>Deque Contents</term>
-                        </cell>
-                        <cell>
-                            <term>Return Value</term>
-                        </cell>
-                    </row>
-                
-                
-                    <row>
-                        <cell>
-                            <c>d.empty()</c>
-                        </cell>
-                        <cell>
-                            <c>[]</c>
-                        </cell>
-                        <cell>
-                            <c>True</c>
-                        </cell>
-                    </row>
-                    <row>
-                        <cell>
-                            <c>d.push_back(4)</c>
-                        </cell>
-                        <cell>
-                            <c>[4]</c>
-                        </cell>
-                        <cell>
-                        </cell>
-                    </row>
-                    <row>
-                        <cell>
-                            <c>d.push_back(17)</c>
-                        </cell>
-                        <cell>
-                            <c>[17,4]</c>
-                        </cell>
-                        <cell>
-                        </cell>
-                    </row>
-                    <row>
-                        <cell>
-                            <c>d.push_front(93)</c>
-                        </cell>
-                        <cell>
-                            <c>[17,4,93]</c>
-                        </cell>
-                        <cell>
-                        </cell>
-                    </row>
-                    <row>
-                        <cell>
-                            <c>d.push_front(65)</c>
-                        </cell>
-                        <cell>
-                            <c>[17,4,93,65]</c>
-                        </cell>
-                        <cell>
-                        </cell>
-                    </row>
-                    <row>
-                        <cell>
-                            <c>d.size()</c>
-                        </cell>
-                        <cell>
-                            <c>[17,4,93,65]</c>
-                        </cell>
-                        <cell>
-                            <c>4</c>
-                        </cell>
-                    </row>
-                    <row>
-                        <cell>
-                            <c>d.empty()</c>
-                        </cell>
-                        <cell>
-                            <c>[17,4,93,65]</c>
-                        </cell>
-                        <cell>
-                            <c>False</c>
-                        </cell>
-                    </row>
-                    <row>
-                        <cell>
-                            <c>d.push_back(25)</c>
-                        </cell>
-                        <cell>
-                            <c>[25,17,4,93,65]</c>
-                        </cell>
-                        <cell>
-                        </cell>
-                    </row>
-                    <row>
-                        <cell>
-                            <c>d.pop_back()</c>
-                        </cell>
-                        <cell>
-                            <c>[17,4,93,65]</c>
-                        </cell>
-                        <cell>
-                        </cell>
-                    </row>
-                    <row>
-                        <cell>
-                            <c>d.pop_front()</c>
-                        </cell>
-                        <cell>
-                            <c>[17,4,93]</c>
-                        </cell>
-                        <cell>
-                        </cell>
-                    </row>
-                
-            
+        <table xml:id="linear-basic_tbl-dequeoperations">
+            <caption>Examples of Deque Operations</caption>
+            <tabular>
+                <row header="yes">
+                    <cell>
+                        <term>Deque Operation</term>
+                    </cell>
+                    <cell>
+                        <term>Deque Contents</term>
+                    </cell>
+                    <cell>
+                        <term>Return Value</term>
+                    </cell>
+                </row>
+
+                <row>
+                    <cell>
+                        <c>d.empty()</c>
+                    </cell>
+                    <cell>
+                        <c>[]</c>
+                    </cell>
+                    <cell>
+                        <c>True</c>
+                    </cell>
+                </row>
+                <row>
+                    <cell>
+                        <c>d.push_back(4)</c>
+                    </cell>
+                    <cell>
+                        <c>[4]</c>
+                    </cell>
+                    <cell>
+                    </cell>
+                </row>
+                <row>
+                    <cell>
+                        <c>d.push_back(17)</c>
+                    </cell>
+                    <cell>
+                        <c>[17,4]</c>
+                    </cell>
+                    <cell>
+                    </cell>
+                </row>
+                <row>
+                    <cell>
+                        <c>d.push_front(93)</c>
+                    </cell>
+                    <cell>
+                        <c>[17,4,93]</c>
+                    </cell>
+                    <cell>
+                    </cell>
+                </row>
+                <row>
+                    <cell>
+                        <c>d.push_front(65)</c>
+                    </cell>
+                    <cell>
+                        <c>[17,4,93,65]</c>
+                    </cell>
+                    <cell>
+                    </cell>
+                </row>
+                <row>
+                    <cell>
+                        <c>d.size()</c>
+                    </cell>
+                    <cell>
+                        <c>[17,4,93,65]</c>
+                    </cell>
+                    <cell>
+                        <c>4</c>
+                    </cell>
+                </row>
+                <row>
+                    <cell>
+                        <c>d.empty()</c>
+                    </cell>
+                    <cell>
+                        <c>[17,4,93,65]</c>
+                    </cell>
+                    <cell>
+                        <c>False</c>
+                    </cell>
+                </row>
+                <row>
+                    <cell>
+                        <c>d.push_back(25)</c>
+                    </cell>
+                    <cell>
+                        <c>[25,17,4,93,65]</c>
+                    </cell>
+                    <cell>
+                    </cell>
+                </row>
+                <row>
+                    <cell>
+                        <c>d.pop_back()</c>
+                    </cell>
+                    <cell>
+                        <c>[17,4,93,65]</c>
+                    </cell>
+                    <cell>
+                    </cell>
+                </row>
+                <row>
+                    <cell>
+                        <c>d.pop_front()</c>
+                    </cell>
+                    <cell>
+                        <c>[17,4,93]</c>
+                    </cell>
+                    <cell>
+                    </cell>
+                </row>
         </tabular></table>
         <p>
             <!-- extra space before the progress bar -->

--- a/pretext/LinearBasic/TheDequeAbstractDataType.ptx
+++ b/pretext/LinearBasic/TheDequeAbstractDataType.ptx
@@ -41,7 +41,7 @@
             get a bit confusing.</p>
         
         <table xml:id="linear-basic_tbl-dequeoperations">
-            <caption>Examples of Deque Operations</caption>
+            <title>Examples of Deque Operations</title>
             <tabular>
                 <row header="yes">
                     <cell>

--- a/pretext/LinearBasic/TheQueueAbstractDataType.ptx
+++ b/pretext/LinearBasic/TheQueueAbstractDataType.ptx
@@ -41,7 +41,7 @@
             is the first item returned by dequeue.</p>
         
         <table xml:id="linear-basic_tbl-queueoperations">
-            <caption>Example Queue Operations</caption>
+            <title>Example Queue Operations</title>
             <tabular>
                     <row header="yes">
                         <cell>

--- a/pretext/LinearBasic/TheQueueAbstractDataType.ptx
+++ b/pretext/LinearBasic/TheQueueAbstractDataType.ptx
@@ -40,13 +40,9 @@
             such that the front is on the right. 4 was the first item pushed so it
             is the first item returned by dequeue.</p>
         
-        <table xml:id="linear-basic_tbl-queueoperations"><tabular>
-            <title>Example Queue Operations</title>
-            
-                
-                
-                
-                
+        <table xml:id="linear-basic_tbl-queueoperations">
+            <caption>Example Queue Operations</caption>
+            <tabular>
                     <row header="yes">
                         <cell>
                             <term>Queue Operation</term>

--- a/pretext/LinearBasic/TheStackAbstractDataType.ptx
+++ b/pretext/LinearBasic/TheStackAbstractDataType.ptx
@@ -37,8 +37,9 @@
             stack operations. Under stack contents, the top item is listed at the
             far right.</p>
         
-        <table xml:id="linear-basic_tbl-stackops"><tabular>
-            <title>Sample Stack Operations</title>
+        <table xml:id="linear-basic_tbl-stackops">
+            <caption>Sample Stack Operations</caption>
+            <tabular>
                     <row header="yes">
                         <cell>
                             <term>Stack Operation</term>

--- a/pretext/LinearBasic/TheStackAbstractDataType.ptx
+++ b/pretext/LinearBasic/TheStackAbstractDataType.ptx
@@ -38,7 +38,7 @@
             far right.</p>
         
         <table xml:id="linear-basic_tbl-stackops">
-            <caption>Sample Stack Operations</caption>
+            <title>Sample Stack Operations</title>
             <tabular>
                     <row header="yes">
                         <cell>

--- a/pretext/Sort/TheBubbleSort.ptx
+++ b/pretext/Sort/TheBubbleSort.ptx
@@ -194,8 +194,9 @@ main()
             comparison will cause an exchange. On average, we exchange half of the
             time.</p>
         
-        <table xml:id="sort_tbl-bubbleanalysis"><tabular>
-            <title>Comparisons for Each Pass of Bubble Sort</title>
+        <table xml:id="sort_tbl-bubbleanalysis">
+            <caption>Comparisons for Each Pass of Bubble Sort</caption>
+            <tabular>
                     <row header="yes">
                         <cell>
                             <term>Pass</term>

--- a/pretext/Sort/TheBubbleSort.ptx
+++ b/pretext/Sort/TheBubbleSort.ptx
@@ -195,7 +195,7 @@ main()
             time.</p>
         
         <table xml:id="sort_tbl-bubbleanalysis">
-            <caption>Comparisons for Each Pass of Bubble Sort</caption>
+            <title>Comparisons for Each Pass of Bubble Sort</title>
             <tabular>
                     <row header="yes">
                         <cell>

--- a/verifier.py
+++ b/verifier.py
@@ -30,9 +30,22 @@ class CppsXmlTest:
         return True
 
 
+class TabNodeIsNotAThing(CppsXmlTest):
+    """TabNode is something the automatic conversion tools emitted.
+    PreTeXt doesn't actually have the concept of a TabNode per se,
+    so everywhere this tag occurs we have to do some manual work.
+    """
+    @classmethod
+    def test_file(cls, fname, doc):
+        n = len(doc.getElementsByTagName("TabNode"))
+        if n > 0:
+            print(f"{fname} has {n} TabNode tags")
+        return n == 0
+
+
 class TagsNeedsCaption(CppsXmlTest):
     """The tags below should have a <caption> elements as a child"""
-    captioned_things = ('figure', 'listing', 'table')
+    captioned_things = ('figure', 'listing')
     @classmethod
     def test_file(cls, fname, doc):
         ret = True
@@ -43,6 +56,25 @@ class TagsNeedsCaption(CppsXmlTest):
                     if child.nodeType != xml.dom.Node.ELEMENT_NODE:
                         continue
                     if child.nodeName == "caption":
+                        found = True
+                if not found:
+                    ret = False
+                    print(f'{fname}: {captioned_thing} is missing caption')
+
+
+class TagsNeedsTitle(CppsXmlTest):
+    """The tags below should have a <title> elements as a child"""
+    captioned_things = ('table', 'exploration', 'task')
+    @classmethod
+    def test_file(cls, fname, doc):
+        ret = True
+        for captioned_thing in cls.captioned_things:
+            for fig in doc.getElementsByTagName(captioned_thing):
+                found = False
+                for child in fig.childNodes:
+                    if child.nodeType != xml.dom.Node.ELEMENT_NODE:
+                        continue
+                    if child.nodeName == "title":
                         found = True
                 if not found:
                     ret = False


### PR DESCRIPTION
# Description
tables have titles (not captions), and they must be direct children of table tags (not tabular)

## Related Issue
standalone

## How Has This Been Tested?
local build