### PR TITLE
titles for tables (not tabulars)

### DIFF
--- a/pretext/Graphs/DiscussionQuestions.ptx
+++ b/pretext/Graphs/DiscussionQuestions.ptx
@@ -14,12 +14,9 @@
         <p><ol marker="1">
             <li>
                 <p>Draw the graph corresponding to the following list of edges.</p>
-                <table><tabular>
-                    
-                        
-                        
-                        
-                        
+                <table>
+                    <title>Weighted Graph</title>
+                    <tabular>
                             <row header="yes">
                                 <cell>
                                     from

--- a/pretext/Introduction/BuiltInAtomicDataTypes.ptx
+++ b/pretext/Introduction/BuiltInAtomicDataTypes.ptx
@@ -258,8 +258,8 @@ main()
                 form complex logical questions. <xref ref="introduction_tab-relational"/> shows the relational
                 and logical operators with examples shown in the session that follows.</p>
     <table xml:id="introduction_tab-relational">
+      <title>C++ Relational and Logical Operators</title>
       <tabular>
-        <title>C++ Relational and Logical Operators</title>
         <row header="yes">
           <cell>
             <term>Operation Name</term>

--- a/pretext/Introduction/CollectionData.ptx
+++ b/pretext/Introduction/CollectionData.ptx
@@ -218,8 +218,9 @@ main()
                 needs to include the vector library.</p>
             <pre>#include &lt;vector&gt;</pre>
             
-            <table xml:id="introduction_id4"><tabular>
-                <title><term>Common C++ Vector Operators</term></title>
+            <table xml:id="introduction_id4">
+                <title>Common C++ Vector Operators</title>
+                <tabular>
                 
                     
                     
@@ -488,13 +489,9 @@ char cstring[] = {"Hello World!"};    // C-string or char array uses double quot
 
     
             
-            <table xml:id="introduction_tab-stringmethods"><tabular>
+            <table xml:id="introduction_tab-stringmethods">
                 <title>String Methods Provided in C++</title>
-                
-                    
-                    
-                    
-                    
+                <tabular>
                         <row header="yes">
                             <cell>
                                 <term>Method Name</term>
@@ -789,13 +786,9 @@ main()
             <p>Hash Tables have both methods and operators. <xref ref="introduction_tab-hashopers"/>
                 describes them, and the session shows them in action.</p>
             
-            <table xml:id="introduction_tab-hashopers"><tabular>
+            <table xml:id="introduction_tab-hashopers">
                 <title>Important Hash Table Operators Provided in C++</title>
-                
-                    
-                    
-                    
-                    
+                <tabular>
                         <row header="yes">
                             <cell>
                                 <term>Operator</term>
@@ -886,13 +879,9 @@ main()
                 have worked with sets in a mathematics setting. <xref ref="introduction_tab-setmethods"/>
                 provides a summary. Examples of their use follow.</p>
             
-            <table xml:id="introduction_tab-setmethods"><tabular>
+            <table xml:id="introduction_tab-setmethods">
                 <title>Methods Provided by Sets in C++</title>
-                
-                    
-                    
-                    
-                    
+                <tabular>
                         <row header="yes">
                             <cell>
                                 <term>Method Name</term>

--- a/pretext/LinearBasic/InfixPrefixandPostfixExpressions.ptx
+++ b/pretext/LinearBasic/InfixPrefixandPostfixExpressions.ptx
@@ -70,13 +70,9 @@
             respective operands, the order of the operands stayed exactly the same
             relative to one another.</p>
         
-        <table xml:id="linear-basic_xfix_examples"><tabular>
+        <table xml:id="linear-basic_xfix_examples">
             <title>Examples of Infix, Prefix, and Postfix</title>
-            
-                
-                
-                
-                
+            <tabular>
                     <row header="yes">
                         <cell>
                             <term>Infix Expression</term>
@@ -134,13 +130,9 @@
             determined by the position of the operator and nothing else. In many
             ways, this makes infix the least desirable notation to use.</p>
         
-        <table xml:id="linear-basic_tbl-parexample"><tabular>
+        <table xml:id="linear-basic_tbl-parexample">
             <title>An Expression with Parentheses</title>
-            
-                
-                
-                
-                
+            <tabular>
                     <row header="yes">
                         <cell>
                             <term>Infix Expression</term>
@@ -173,8 +165,9 @@
             understand how they are equivalent in terms of the order of the
             operations being performed.</p>
         
-        <table xml:id="linear-basic_tbl-example3"><tabular>
+        <table xml:id="linear-basic_tbl-example3">
             <title>Additional Examples of Infix, Prefix, and Postfix</title>
+            <tabular>
             
                 
                 

--- a/pretext/Trees/SummaryofMapADTImplementations.ptx
+++ b/pretext/Trees/SummaryofMapADTImplementations.ptx
@@ -7,15 +7,9 @@
             performance of each data structure for the key operations defined by the
             map ADT (see <xref ref="trees_tab-compare"/>).</p>
         
-        <table xml:id="trees_tab-compare"><tabular>
+        <table xml:id="trees_tab-compare">
             <title>Comparing the Performance of Different Map Implementations</title>
-            
-                
-                
-                
-                
-                
-                
+            <tabular>
                     <row header="yes">
                         <cell>
                             operation


### PR DESCRIPTION
# Description
I think the automated tool is responsible for these... `<title>` elements should be children of `<table>` elements not `<tabular>`. This diff is a little long, but it's rather mechanical.

## Related Issue
standalone

## How Has This Been Tested?
local build