### PR TITLE
fix up code listings

### DIFF
--- a/pretext/Graphs/BuildingtheKnightsTourGraph.ptx
+++ b/pretext/Graphs/BuildingtheKnightsTourGraph.ptx
@@ -23,9 +23,10 @@
             column into a linear vertex number similar to the vertex numbers shown
             in <xref ref="fig-knightmoves"/>.</p>
         
-        <term>Listing 1</term>
-        <listing xml:id="graphs_lst-knighttour1" names="lst_knighttour1"><term>Listing 1</term>
-        <pre>Graph knightGraph(int bdSize) {
+        <listing xml:id="graphs_lst-knighttour1" names="lst_knighttour1">
+            <caption>Building The Full Knights Tour Graph.</caption>
+            <program language="cpp"><input>
+Graph knightGraph(int bdSize) {
     Graph ktGraph(false);
 
     for (int row = 0; row &lt; bdSize; row++) {
@@ -40,16 +41,18 @@
     }
 
     return ktGraph;
-}</pre>
-</listing>
+}
+            </input></program>
+        </listing>
         <p>The <c>genLegalMoves</c> function (<xref ref="graphs_lst-knighttour2"/>) takes the position of the knight on the
             board and generates each of the eight possible moves. The <c>legalCoord</c>
             helper function (<xref ref="graphs_lst-knighttour2"/>) makes sure that a particular move that is generated is
             still on the board.</p>
     
-            <term>Listing 2</term>
-        <listing xml:id="graphs_lst-knighttour2" names="lst_knighttour2"><term>Listing 2</term>
-        <pre>int coordToNum(int x, int y, int bdSize) {
+        <listing xml:id="graphs_lst-knighttour2" names="lst_knighttour2">
+            <caption>Generating Legal Moves</caption>
+            <program language="cpp"><input>
+int coordToNum(int x, int y, int bdSize) {
     // Takes the x y position and returns the id from 0 to (bdSize*2)-1
     int id = 0;
     id += y * bdSize;
@@ -92,8 +95,9 @@ vector&lt;int&gt; genLegalMoves(int id, int bdSize) {
     }
 
     return newMoves;
-}</pre>
-</listing>
+}
+            </input></program>
+        </listing>
         <p><xref ref="fig-bigknight"/> shows the complete graph of possible moves on an
             eight-by-eight board. There are exactly 336 edges in the graph. Notice
             that the vertices corresponding to the edges of the board have fewer
@@ -108,12 +112,15 @@ vector&lt;int&gt; genLegalMoves(int id, int bdSize) {
                 <description>Complex graph showing all legal moves for a knight on an 8 x 8 chessboard, visualized as a network. The nodes are arranged in a grid pattern, numbered from 0 to 63, corresponding to the squares of a chessboard. The lines connecting the nodes represent the knight's potential moves, with each node being connected to others that a knight could reach in a single move based on the rules of chess. The myriad of crisscrossing lines create an intricate web, illustrating the complexity of the knight's movement possibilities across the entire board. </description>
                 </image>
             </figure>
-        <p>The full implementation of this is shown below, however the code must be ran in C++11
-            due to differences in Vector Initialization between C++ versions. In the below code,
-            in the main function, we traverse using our previously created breadth-first search between
+        <p>The full implementation of this is shown in <xref ref="knight-full"/>.
+            In the main function, we traverse using our previously created breadth-first search between
             two locations. In the next chapter, we will implement a different algorithm called a
             <c>depth first search (DFS)</c> to solve our knight's tour problem.</p>
-<pre>#include &lt;fstream&gt;
+
+        <listing xml:id="knight-full">
+            <caption>Full Implementation of Generating the Knight Moves</caption>
+            <program interactive="activecode" language="cpp"><input>
+#include &lt;fstream&gt;
 #include &lt;iostream&gt;
 #include &lt;map&gt;
 #include &lt;queue&gt;
@@ -359,6 +366,8 @@ int main() {
     traverse(kt.getVertex(0));
 
     return 0;
-}</pre>
-    </section>
+}
+            </input></program>
+        </listing>
+</section>
 

--- a/pretext/Introduction/DefiningFunctions.ptx
+++ b/pretext/Introduction/DefiningFunctions.ptx
@@ -4,13 +4,12 @@
         <p>In general, we can hide the details of any computation by defining
             a function. A function definition requires a name, a group of
             parameters, a return type, and a body. It may either return a variable, value, or nothing (specified by the keyword void). For
-            example, the simple function defined below returns an integer which is the double of the
+            example, the simple function defined in <xref ref="timesTwo"/> returns an integer which is the double of the
             value you pass into it.</p>
         
-        <blockquote>
-
-    <program xml:id="timesTwo" interactive="activecode" language="cpp">
-        <input>
+        <listing xml:id="timesTwo">
+            <caption><c>timesTwo</c> Function</caption>
+            <program interactive="activecode" language="cpp"><input>
 #include &lt;iostream&gt;
 using namespace std;
 
@@ -27,9 +26,9 @@ int main() {
 
     return 0;
 }
-        </input>
-    </program>
-        </blockquote>
+            </input></program>
+        </listing>
+
         <p>The syntax for this function definition includes the name, <c>timesTwo</c>,
             and a parenthesized list of formal parameters and their types. For this function an <c>int</c> named <c>num</c>
             is the only formal parameter, which suggests that <c>timesTwo</c> needs only
@@ -39,12 +38,11 @@ int main() {
             evaluate it, passing an actual parameter value, in this case, <c>3</c>.
             Note that the call to <c>timesTwo</c> returns an integer that can in turn be
             passed to another invocation.</p>
-        <p>Let us look at a similar function.</p>
-        
-        <blockquote>
+        <p>Let us look at a similar function in <xref ref="timesTwoVoid"/>.</p>
 
-    <program xml:id="timesTwoVoid" interactive="activecode" language="cpp">
-        <input>
+        <listing xml:id="timesTwoVoid">
+            <caption><c>timesTwoVoid</c> Function Returns Nothing.</caption>
+            <program interactive="activecode" language="cpp"><input>
 #include &lt;iostream&gt;
 using namespace std;
 
@@ -61,10 +59,9 @@ int main() {
 
     return 0;
 }
-        </input>
-    </program>
-        </blockquote>
-        <p><c>timesTwoVoid</c> behave very similarly to <c>timesTwo</c>. However, there is one key
+            </input></program>
+        </listing>
+        <p><c>timesTwoVoid</c> behaves very similarly to <c>timesTwo</c>. However, there is one key
             difference between them. Instead of the <c>int</c> in <c>timesTwo</c>, <c>timesTwoVoid</c> has a
             <c>void</c> in front of its function definition. Unlike <c>timesTwo</c>, <c>timesTwoVoid</c> is a non-fruitful
             function meaning it does not return a value even though it can still print something out.</p>
@@ -85,6 +82,7 @@ int main() {
             marker. Any characters that follow the // on a line are ignored.</p>
         
     <listing xml:id="introduction_lst-root" names="lst_root">
+        <caption>Newton's Method for Calculating Square Roots.</caption>
     <program xml:id="newtonsmethod" interactive="activecode" language="cpp">
         <input>
 #include &lt;iostream&gt;
@@ -164,6 +162,7 @@ void callingFunction() { /*return type int which indicates
                 that calls <c>swap_values(...)</c>.</p>
             
     <listing xml:id="activepassrefcpp">
+        <caption>Pass By Reference Example</caption>
     <program interactive="activecode" language="cpp">
         <input>
 #include &lt;iostream&gt;
@@ -245,22 +244,25 @@ int main( ) {
                 name when they can be distinguished by the parameters.
                 Hence, C++  allows function overloading when either the data types of the parameters differ
                 or the number of parameters differ.</p>
-            <p>Overloading is a nice feature of the C++ language.</p>
-            <TabNode tabname="C++" tabnode_options="{'subchapter': 'DefiningFunctions', 'chapter': 'Introduction', 'basecourse': 'cppds', 'optional': '', 'optclass': '', 'tabname': 'C++'}">
+            <p>Overloading is a nice feature of the C++ language. See <xref ref="expl-overloading"/> for an example
+                of overloading in C++ and Python</p>
 
-    <program xml:id="foverload_cpp" interactive="activecode" language="cpp">
-        <input>
+            <exploration xml:id="expl-overloading">
+                <title>Example of Overloading</title>
+                <task label="foverload_cpp">
+                    <title>C++ Implementation</title>
+                    <statement><program xml:id="foverload_cpp" interactive="activecode" language="cpp"><input>
 //showcases function overloading in C++
 #include &lt;iostream&gt;
 using namespace std;
 
 void myfunct(int n) {
-     cout &lt;&lt; "1 parameter: " &lt;&lt; n &lt;&lt;endl;
+        cout &lt;&lt; "1 parameter: " &lt;&lt; n &lt;&lt;endl;
 }
 
 void myfunct(int n, int m) {
-     cout &lt;&lt; "2 parameters: " &lt;&lt; n;
-     cout &lt;&lt; " and " &lt;&lt; m &lt;&lt;endl;
+        cout &lt;&lt; "2 parameters: " &lt;&lt; n;
+        cout &lt;&lt; " and " &lt;&lt; m &lt;&lt;endl;
 }
 
 int main() {
@@ -271,12 +273,11 @@ int main() {
 
     return 0;
 }
-        </input>
-    </program>
-                </TabNode><TabNode tabname="Python" tabnode_options="{'subchapter': 'DefiningFunctions', 'chapter': 'Introduction', 'basecourse': 'cppds', 'optional': '', 'optclass': '', 'tabname': 'Python'}">
-
-    <program xml:id="foverload_py" interactive="activecode" language="python">
-        <input>
+                    </input></program></statement>
+                </task>
+                <task label="foverload_py">
+                    <title>Python Implementation</title>
+                    <statement><program xml:id="foverload_py" interactive="activecode" language="python"><input>
 #showcases function overloading in Python
 def myfunct(n, m=None):
     if m is None:
@@ -291,12 +292,10 @@ def main():
     myfunct(100);
 
 main()
-        </input>
-    </program>
-                </TabNode>
+                    </input></program></statement>
+                </task>
+            </exploration>
 
-    
-            
             <reading-questions xml:id="rq-defining-function">
                 <title>
                     Reading Questions


### PR DESCRIPTION
# Description
Fixing up code listings so they aren't manually numbered and have captions, etc. In some cases adding the tabbing stuff. Also, we can depend on C++11 at this point.

Btw, verifier now only reports 22 errors that are NOT missing image descriptions.

## Related Issue
standalone

## How Has This Been Tested?
local build