### PR TITLE
add captions, tabs, etc. to fixup various listings

### DIFF
--- a/pretext/AlgorithmAnalysis/BigONotation.ptx
+++ b/pretext/AlgorithmAnalysis/BigONotation.ptx
@@ -173,9 +173,11 @@
         anything, it is instructive to see how we can take actual code and
         analyze performance.</p>
     
-<listing xml:id="algo_analysis_dummycode_1">
-    <p><term>C++ Implementation</term></p>
-    <program language="cpp"><input>
+    <exploration xml:id="expl-dummycode_1">
+        <title>Analysis Example</title>
+        <task label="algo_analysis_dummycode_1" xml:id="algo_analysis_dummycode_1">
+            <title>C++ Implementation</title>
+            <statement><program language="cpp"><input>
 #include &lt;iostream&gt;
 using namespace std;
 
@@ -197,9 +199,12 @@ int main(){
     }
     int d = 33;
     return 0;
-}</input></program>
-<p><term>Python Implementation</term></p>
-<program language="python"><input>
+}
+            </input></program></statement>
+        </task>
+        <task xml:id="algo_analysis_dummycode_1_py" label="algo_analysis_dummycode_1_py">
+            <title>Python Implementation</title>
+            <statement><program language="python"><input>
 def main():
     a=5
     b=6
@@ -214,8 +219,9 @@ def main():
         v = b*b
     d = 33
 main()
-</input></program>
-</listing>
+            </input></program></statement>
+        </task>
+    </exploration>
     <p>The number of assignment operations is the sum of four terms. The first
         term is the constant 3, representing the three assignment statements at
         the start of the fragment. The second term is <m>3n^{2}</m>, since

--- a/pretext/Graphs/BuildingtheWordLadderGraph.ptx
+++ b/pretext/Graphs/BuildingtheWordLadderGraph.ptx
@@ -53,6 +53,7 @@
             same key in the map. <xref ref="graphs_wordbucket_cpp"/> shows the C++
             code required to build the graph.</p>
 <listing xml:id="graphs_wordbucket_cpp">
+    <caption>Building the Word Bucket Graph</caption>
     <program xml:id="wordbucket_cpp" interactive="activecode" language="cpp">
         <input>
 #include &lt;fstream&gt;

--- a/pretext/Graphs/KnightsTourAnalysis.ptx
+++ b/pretext/Graphs/KnightsTourAnalysis.ptx
@@ -114,10 +114,10 @@
             <caption>Knights tour visualization</caption>
             <video label="graphs_knighttour-video" source="Graphs/knights_tour_vis.webm" width="80%" preview="Graphs/kt_vis_thumb.png" />
         </figure>
-        
-<term>Listing 4</term>
-<listing xml:id="graphs_lst-avail" names="lst_avail"><term>Listing 4</term>
-        <program language="python"><input>
+
+        <listing xml:id="graphs_lst-avail" names="lst_avail">
+            <caption>Implementation of <c>orderByAvail</c></caption>
+            <program language="python"><input>
 def orderByAvail(n):
     resList = []
     for v in n.getConnections():
@@ -129,8 +129,8 @@ def orderByAvail(n):
             resList.append((c,v))
     resList.sort(key=lambda x: x[0])
     return [y[1] for y in resList]
-</input></program>
-</listing>
+            </input></program>
+        </listing>
         <reading-questions xml:id="rq-knights-tour-impl">
            <title>Reading Question</title>
            

--- a/pretext/Introduction/WhatIsComputerScience.ptx
+++ b/pretext/Introduction/WhatIsComputerScience.ptx
@@ -76,10 +76,11 @@
             consider the C++ <c>cmath</c> module. Once we import the module, we can
             perform computations as in the following example:</p>
 
-        <TabNode tabname="C++" tabnode_options="{'subchapter': 'WhatIsComputerScience', 'chapter': 'Introduction', 'basecourse': 'cppds', 'optional': '', 'optclass': '', 'tabname': 'C++'}">
-
-    <program xml:id="cPlusPlus" interactive="activecode" language="cpp">
-        <input>
+        <exploration xml:id="expl-cplusplus">
+            <title>Example using <c>&lt;cmath&gt;</c></title>
+            <task label="cPlusPlus" xml:id="cPlusPlus">
+                <title>C++ Implementation</title>
+                <statement><program interactive="activecode" language="cpp"><input>
 //Outputs the square root of a given number.
 #include &lt;iostream&gt;
 #include &lt;cmath&gt;
@@ -88,19 +89,18 @@ using namespace std;
 int main() {
     cout &lt;&lt; sqrt(16);
 }
-        </input>
-    </program>
-            </TabNode><TabNode tabname="Python" tabnode_options="{'subchapter': 'WhatIsComputerScience', 'chapter': 'Introduction', 'basecourse': 'cppds', 'optional': '', 'optclass': '', 'tabname': 'Python'}">
-
-    <program xml:id="Python" interactive="activecode" language="python">
-        <input>
+                </input></program></statement>
+            </task>
+            <task label="mathpy" xml:id="mathpy">
+                <title>Python Implementation</title>
+                <statement><program interactive="activecode" language="python"><input>
 #Outputs the square root of a given number.
 import math
 
 print(math.sqrt(16))
-        </input>
-    </program>
-            </TabNode>
+                </input></program></statement>
+            </task>
+        </exploration>
         <p> <idx>procedural abstraction</idx>
             This is an example of <term>procedural abstraction</term>. We do not necessarily
             know how the square root is being calculated, but we know what the

--- a/pretext/LinearBasic/ImplementingaStackCpp.ptx
+++ b/pretext/LinearBasic/ImplementingaStackCpp.ptx
@@ -13,10 +13,12 @@
             the end of the array will hold the top element of the stack. As the stack
             grows (as <c>push</c> operations occur), new items will be added on the end
             of the array. <c>pop</c> operations will manipulate that same end.</p>
-        
-    <listing xml:id="stack-code1">
-        <p><term>C++ Implementation</term></p>
-        <program xml:id="stack_1ac_cpp" interactive="activecode" language="cpp"><input>
+
+        <exploration xml:id="expl-stack-code1">
+            <title>Stack Implementation</title>
+            <task xml:id="stack-code1" label="stack-code1">
+                <title>C++ Implementation</title>
+                <statement><program interactive="activecode" language="cpp"><input>
 //Tests the push, empty, size, pop, and top methods of the stack library.
 
 #include &lt;iostream&gt;
@@ -49,9 +51,11 @@ int main() {
 
     return 0;
 }
-    </input></program>
-    <p><term>Python Implementation</term></p>
-    <program xml:id="stack_1ac_py" interactive="activecode" language="python"><input>
+                </input></program></statement>
+            </task>
+            <task xml:id="stack_1ac_py" label="stack_1ac_py">
+                <title>Python Implementation</title>
+                <statement><program interactive="activecode" language="python"><input>
 #Tests the push, empty, size, pop, and top methods of the stack library.
 
 class Stack:
@@ -89,7 +93,9 @@ def main():
 
     print("Top Element of the Stack: ", newStack.top())
 main()
-    </input></program></listing>
+                </input></program></statement>
+            </task>
+        </exploration>
 
 <reading-questions xml:id="rq-stack-implementation">
                 <title>Reading Questions</title>


### PR DESCRIPTION
# Description
add the tabbing interface, captions, etc to various listings. Some unreferenced manual numbering also disappears with this (yea!)

## Related Issue
standalone

## How Has This Been Tested?
local build