### PR TITLE
get rid of xhtml numbered entities

### DIFF
--- a/pretext/Introduction/BuiltInAtomicDataTypes.ptx
+++ b/pretext/Introduction/BuiltInAtomicDataTypes.ptx
@@ -439,7 +439,7 @@ int main(){
                 <q>assigned</q> to the variable named on the left-hand side.
                 Here the type of the variable is integer.</p>
     <p>In C++, the data type cannot change.
-                This is a characteristic of C++&#x2019;s static typing. A
+                This is a characteristic of C++<rsq/>s static typing. A
                 variable can hold ever only one type of data.
                 Pitfall: C++ will often simply try to do the assignment you
                 requested without
@@ -696,11 +696,10 @@ ptrN = &amp;varN;</pre>
                     goes to that address, effectively <em>dereferencing</em> the pointer,
                     meaning that it will find the location of the value stored where the pointer was
                     pointing.</p>
-      <p>In other words, varN and *ptrN (note the asterisk in front!) reference the same
+      <p>In other words, <c>varN</c> and <c>*ptrN</c> (note the asterisk in front!) reference the same
                     value in the code above.</p>
-      <p>Let&#x2019;s extend the example above to output the value of a variable and its address
-                    in memory:</p>
-      <p>&#x2026; _dereferencing:</p>
+      <p>Let<rsq/>s extend the example above to output the value of a variable and its address
+                    in memory: <ellipsis/> _dereferencing.</p>
       <blockquote>
         <program xml:id="firstptr" interactive="activecode" language="cpp">
           <input>
@@ -818,7 +817,7 @@ int main() {
       <p>The second <c>cout</c> instruction is a disaster because</p>
       <ol marker="1">
         <li>
-          <p>You don&#x2019;t know what is stored in location 100 in memory, and</p>
+          <p>You don<rsq/>t know what is stored in location 100 in memory, and</p>
         </li>
         <li>
           <p>that location is outside of your segment (area in memory reserved for your program), so the operating system will jump in with a message about a <q>segmentation fault</q>. Although such an error message looks bad,
@@ -925,7 +924,7 @@ int main( ) {
             </condition>
             <condition string="^\s*reference\s*$">
               <feedback>
-                <p>That&#x2019;s a general description of what it is, not a C++ term!</p>
+                <p>That<rsq/>s a general description of what it is, not a C++ term!</p>
               </feedback>
             </condition>
             <condition string="^\s*default\s*$">
@@ -938,7 +937,7 @@ int main( ) {
       </exercise>
       <exercise label="mc_memory">
         <statement>
-          <p>How may one reference a variable&#x2019;s memory address in C++?</p>
+          <p>How may one reference a variable<rsq/>s memory address in C++?</p>
         </statement>
         <choices>
           <choice correct="yes">

--- a/pretext/Introduction/DefiningFunctions.ptx
+++ b/pretext/Introduction/DefiningFunctions.ptx
@@ -193,7 +193,7 @@ int main( ) {
 }
         </input>
     </program></listing>
-            <p>For the program in <xref ref="activepassrefcpp"/> to reverse the order of the integers the users types in, the function <c>swap_values(...)</c> must be able to change the values of the arguments. Try removing one or both of the <q>&amp;</q> &#8216;s in this code to see what happens.</p>
+            <p>For the program in <xref ref="activepassrefcpp"/> to reverse the order of the integers the users types in, the function <c>swap_values(...)</c> must be able to change the values of the arguments. Try removing one or both of the <c>&amp;</c><rsq/>s in this code to see what happens.</p>
         </subsection>
         <transition/>
         <subsection xml:id="introduction_arrays-as-parameters-in-functions">
@@ -440,7 +440,7 @@ int main() {
         <title>Self Check Challenge</title>
         <p>See if you can improve upon the program in the self check by keeping letters
             that are correct and only modifying one character in the best string so far.
-            This is a type of algorithm in the class of &#8216;hill climbing' algorithms, that
+            This is a type of algorithm in the class of <q>hill climbing</q> algorithms, that
             is we only keep the result if it is better than the previous one.</p>
     </note>       
                 

--- a/pretext/Introduction/Glossary.ptx
+++ b/pretext/Introduction/Glossary.ptx
@@ -17,7 +17,7 @@
                 <gi>
                     <title>access keywords</title>
                     
-                        <p>Keywords such as &#8216;'public'', private'', and &#8216;'protected'' that indicates what class properties/behaviors a user can change.</p>
+                        <p>Keywords such as <c>public</c>, <c>private</c>, and <c>protected</c> that indicate what class properties/behaviors a user can change.</p>
                     
                 </gi>
                 <gi>

--- a/pretext/Introduction/ObjectOrientedProgrammingDefiningClasses.ptx
+++ b/pretext/Introduction/ObjectOrientedProgrammingDefiningClasses.ptx
@@ -178,7 +178,7 @@ myfraction = Fraction(3, 5)
                 It is typical in C++ to make all data attributes <c>private</c> and most methods <c>public</c>.
                 All attribute variables under the <c>private</c>
                 keyword will only be able to be accessed by the object's class methods, not by the user.
-                Only C++'s &#8216;<c>public</c> methods can be accessed and used by the user. Because we
+                Only C++<rsq/>s <c>public</c> methods can be accessed and used by the user. Because we
                 want our user to be able to call every constructor directly, we always place the
                 constructor under <c>public</c>. A third access keyword, <c>protected</c> will be discussed later.</p>
 
@@ -372,7 +372,7 @@ Fraction f1(1, 4);
 Fraction f2(1, 2);
 Fraction f3 = f1 + f2;
 
-// &gt;&gt; error: no match for &#8216;operator+' (operand types are &#8216;Fraction' and &#8216;Fraction'))
+// &gt;&gt; error: no match for `operator+' (operand types are `Fraction' and `Fraction'))
 </input></program>
                     <p>An error received before overloading</p>
                 </TabNode><TabNode tabname="Python" tabnode_options="{'subchapter': 'ObjectOrientedProgrammingDefiningClasses', 'chapter': 'Introduction', 'basecourse': 'cppds', 'optional': '', 'optclass': '', 'tabname': 'Python'}">

--- a/pretext/Recursion/Glossary.ptx
+++ b/pretext/Recursion/Glossary.ptx
@@ -73,8 +73,8 @@
                     <title>recursive call</title>
                     
                         <p>The statement that calls an already executing function.  Recursion can
-                            even be indirect &#8212; function <title_reference>f</title_reference> can call <title_reference>g</title_reference> which calls <title_reference>h</title_reference>,
-                            and <title_reference>h</title_reference> could make a call back to <title_reference>f</title_reference>.</p>
+                            even be indirect <mdash/> function <em>f</em> can call <em>g</em> which calls <em>h</em>,
+                            and <em>h</em> could make a call back to <em>f</em>.</p>
                     
                 </gi>
                 <gi>

--- a/pretext/Sort/TheQuickSort.ptx
+++ b/pretext/Sort/TheQuickSort.ptx
@@ -26,8 +26,8 @@
             </figure>
 
 
-        <p>Partitioning begins by locating two position markers&#8212;let's call them
-            <c>leftmark</c> and <c>rightmark</c>&#8212;at the beginning and end of the remaining
+        <p>Partitioning begins by locating two position markers <mdash/> let's call them
+            <c>leftmark</c> and <c>rightmark</c> <mdash/> at the beginning and end of the remaining
             items in the list (positions 1 and 8 in <xref ref="fig-partitiona"/>). The goal
             of the partition process is to move items that are on the wrong side
             with respect to the pivot value while also converging on the split

--- a/pretext/Trees/ProgrammingExercises.ptx
+++ b/pretext/Trees/ProgrammingExercises.ptx
@@ -34,7 +34,7 @@
             </li>
             <li>
                 <p>Clean up the <c>printexp</c> function so that it does not include an
-                    &#8216;extra' set of parentheses around each number.</p>
+                    <q>extra</q> set of parentheses around each number.</p>
             </li>
             <li>
                 <p>Using the <c>buildHeap</c> method, write a sorting function that can


### PR DESCRIPTION
# Description
This is the last of the xhtml numbered entities. These required a little more than simple substitutions in some cases.

Having done this, the PDF and other transforms should look better since LaTeX will get proper kerning hints, etc.

## Related Issue
standalone

## How Has This Been Tested?
local build