### PR TITLE
we spell literal: c

### DIFF
--- a/pretext/AlgorithmAnalysis/HashTableAnalysis.ptx
+++ b/pretext/AlgorithmAnalysis/HashTableAnalysis.ptx
@@ -171,7 +171,7 @@ print("%d,%10.3f,%10.3f" % (i, lst_time, d_time))
         of 990,000 it also took 0.004 milliseconds.</p>
 
     <figure align="center" xml:id="fig-vectvshash-cpp">
-        <caption>Comparing the <literal>in</literal> Operator for C++ vectors and Hash Tables</caption>
+        <caption>Comparing the <c>in</c> Operator for C++ vectors and Hash Tables</caption>
             <image source="AlgorithmAnalysis/vectvshash.png" width="50%">
                 <description>Figure 3 summarizes the results of running Listing 6. You can see that the hash table is consistently faster. For the smallest vector size of 10,000 elements a hash table is 89.4 times faster than a vector. For the largest vector size of 990,000 elements the hash table is 11,603 times faster! You can also see that the time it takes for the contains operator on the vector grows linearly with the size of the vector. This verifies the assertion that the contains operator on a vector is . It can also be seen that the time for the contains operator on a hash table is constant even as the hash table size grows. In fact for a hash table size of 10,000 the contains operation took 0.004 milliseconds and for the hash table size of 990,000 it also took 0.004 milliseconds.</description>
             </image>

--- a/pretext/Recursion/StackFramesImplementingRecursion.ptx
+++ b/pretext/Recursion/StackFramesImplementingRecursion.ptx
@@ -94,7 +94,7 @@ main()
             call stack after the return statement on line 4.</p>
         
         <figure align="center" xml:id="fig-callstack">
-            <caption>Call Stack Generated from <literal>toStr(10,2).</literal></caption>
+            <caption>Call Stack Generated from <c>toStr(10,2).</c></caption>
                 <image source="Recursion/newcallstack.png" width="50%">
                 <description>Diagram illustrating a call stack generated from the function toStr(10,2), which converts the number 10 into a base 2 string. The bottom of the stack shows 'toStr(10/2, 2) + convertString[10%2]', then above it 'toStr(5,2) n = 5 base = 2' with 'toStr(5/2,2) + convertString[5%2]', followed by 'toStr(2,2) n = 2 base = 2' and at the top 'toStr(2/2,2) + convertString[2%2]'. A single character '1' floats above the stack, indicating the start of the conversion process.</description>
                 </image>

--- a/pretext/Sort/TheInsertionSort.ptx
+++ b/pretext/Sort/TheInsertionSort.ptx
@@ -31,7 +31,7 @@
         
 
         <figure align="center" xml:id="fig-insertionpass">
-            <caption><literal>InsertionSort</literal>: Fifth Pass of the Sort.</caption>
+            <caption><c>InsertionSort</c>: Fifth Pass of the Sort.</caption>
                 <image source="Sort/insertionpass.png" width="50%">
                 <description>An educational illustration depicting the fifth pass of the insertion sort algorithm. The diagram shows a series of rows with numerical values in boxes, each row representing a step in the sorting process. Arrows indicate the shifting of numbers to make space for the correctly positioned value. Descriptive text accompanies each step explaining the movement required, such as '93>31 so shift it to the right' and 'Need to insert 31 back into the sorted list'. The final row shows the number 31 being inserted into its correct position in the sequence.</description>
                 </image>


### PR DESCRIPTION
# Description
`<literal>` is not actually a pretext tag that I can find. I believe in each case here `<c>` is appropriate

There are a couple more of these in the OOdefiningClasses file, but I'm working on a bunch of other stuff there which is not quite ready.

## Related Issue
stand alone

## How Has This Been Tested?
local build