### PR TITLE
delete order of magnitude from the match

### DIFF
--- a/_sources/AlgorithmAnalysis/Glossary.rst
+++ b/_sources/AlgorithmAnalysis/Glossary.rst
@@ -77,7 +77,7 @@ Matching
     :match_4: worst case|||When an algorithm performs especially poorly given a certain data set or circumstance.
     :match_5: quadratic|||Function describing a relationship who's highest order is a number squared
     :match_6: best case|||When an algorithm performs especially good given a certain data set or circumstance
-    :match_7: Big-O notation|||another term for order of magnitude
+    :match_7: Big-O notation|||a function describing an algorithm's steps as the size of the problem increases
     :match_8: brute force|||Technique that tries to exhaust all possibilities of a problem
     :match_9: contiguous|||Adjacent 
     :match_10: dynamic size|||Able to change size automatically
@@ -85,6 +85,5 @@ Matching
     :match_12: hash table|||A collection consisting of key-value pairs with an associated hash function that maps the key to the associated value.
     :match_13: linear|||Function that grows in a one to one relationship with its input.
     :match_14: logarithmic|||functions that are the inverse of exponential functions
-    :match_15: order of magnitude|||a function describing an algorithm's steps as the size of the problem increases. 
 
     Drag the word on the left to its corresponding definition

--- a/pretext/AlgorithmAnalysis/Matching.ptx
+++ b/pretext/AlgorithmAnalysis/Matching.ptx
@@ -33,10 +33,6 @@
         <premise>logarithmic</premise>
         <response>functions that are the inverse of exponential functions</response>
       </match>
-      <match order="15">
-        <premise>order of magnitude</premise>
-        <response>a function describing an algorithm's steps as the size of the problem increases.</response>
-      </match>
       <match order="2">
         <premise>average case</premise>
         <response>When an algorithm performs between its worst and best case given a certain data set or circumstance.</response>
@@ -59,7 +55,7 @@
       </match>
       <match order="7">
         <premise>Big-O notation</premise>
-        <response>another term for order of magnitude</response>
+        <response>a function describing an algorithm's steps as the size of the problem increases.</response>
       </match>
       <match order="8">
         <premise>brute force</premise>


### PR DESCRIPTION

# Description
Having both order of magntitude and Big-O in the match is confusing since they're synonyms

## Related Issue
closes #272

## How Has This Been Tested?
local build