### PR TITLE
Moved Inheritence question from 1.12 to 1.13 Self-Check to fix issue …

### DIFF
--- a/_sources/Introduction/ObjectOrientedProgrammingDefiningClasses.rst
+++ b/_sources/Introduction/ObjectOrientedProgrammingDefiningClasses.rst
@@ -993,50 +993,6 @@ Self Check
           :click-incorrect:int den; // den attribute:endclick:
     :click-correct:}:endclick:
 
-.. OOP class example:
-
-**Question example**
-
-.. highlight:: cpp
-    :linenothreshold: 5
-
-::
-
-    #include<iostream>
-    using namespace std;
-
-    class Vehicle
-    {
-
-        protected:
-            int wheels;
-            int windows;
-            int engine;
-    };
-
-    class Airplane: public Vehicle
-    {
-        protected:
-            // wheels
-            // windows
-            // engine
-            int wings;
-    };
-
-.. mchoice:: OOPclassquestion
-    :answer_a: Inheritance
-    :answer_b: Encapsulation
-    :answer_c: Polymorphism
-    :answer_d: Abstraction
-    :correct: a
-    :feedback_a: Correct! Airplane inherits many things from Vehicle
-    :feedback_b: Encapsulation is the principle of hiding the contents of a class except when absolutely necessary. Wings is not hidden from Vehicle, it simply does not exist in the Vehicle class.
-    :feedback_c: Polymorphism is the ability to process objects or methods differently depending on their data type, class, number of arguments, etc. A subclass using parts of a pre-existing class is not an example of polymorphism because they are used in the same way.
-    :feedback_d: Abstraction is the principle of focusing on desired behaviors and properties while disregarding what is irrelevant/unimportant. Take another look at what the two classes have in common.
-
-    Which OOP principle is the above code an example of?
-
-
 
 .. dragndrop:: elements_of_OOP
     :feedback: Review the elements of object oriented programming

--- a/_sources/Introduction/ObjectOrientedProgrammingDerivedClasses.rst
+++ b/_sources/Introduction/ObjectOrientedProgrammingDerivedClasses.rst
@@ -586,7 +586,50 @@ connection.
 	:feedback_e: Correct!
 	
 	What is the difference between HAS-A and IS-A relationships? Select all that apply. 
-   
+.. OOP class example:
+
+**Question example**
+
+.. highlight:: cpp
+    :linenothreshold: 5
+
+::
+
+    #include<iostream>
+    using namespace std;
+
+    class Vehicle
+    {
+
+        protected:
+            int wheels;
+            int windows;
+            int engine;
+    };
+
+    class Airplane: public Vehicle
+    {
+        protected:
+            // wheels
+            // windows
+            // engine
+            int wings;
+    };
+
+.. mchoice:: OOPclassquestion
+    :answer_a: Inheritance
+    :answer_b: Encapsulation
+    :answer_c: Polymorphism
+    :answer_d: Abstraction
+    :correct: a
+    :feedback_a: Correct! Airplane inherits many things from Vehicle
+    :feedback_b: Encapsulation is the principle of hiding the contents of a class except when absolutely necessary. Wings is not hidden from Vehicle, it simply does not exist in the Vehicle class.
+    :feedback_c: Polymorphism is the ability to process objects or methods differently depending on their data type, class, number of arguments, etc. A subclass using parts of a pre-existing class is not an example of polymorphism because they are used in the same way.
+    :feedback_d: Abstraction is the principle of focusing on desired behaviors and properties while disregarding what is irrelevant/unimportant. Take another look at what the two classes have in common.
+
+    Which OOP principle is the above code an example of?
+
+
 .. _lst_Connectorclass:
 
 **Listing 12**

--- a/pretext/Introduction/ObjectOrientedProgrammingDefiningClasses.ptx
+++ b/pretext/Introduction/ObjectOrientedProgrammingDefiningClasses.ptx
@@ -885,30 +885,7 @@ print(x == y)
         </exploration>>
         </subsection>
         <subsection xml:id="introduction_self-check">
-            <!--OOP class example:-->
-            <p><term>Question example</term></p>
-            <program language="cpp"><input>
-#include&lt;iostream&gt;
-using namespace std;
-
-class Vehicle
-{
-
-    protected:
-        int wheels;
-        int windows;
-        int engine;
-};
-
-class Airplane: public Vehicle
-{
-    protected:
-        // wheels
-        // windows
-        // engine
-        int wings;
-};
-</input></program>
+            <title>Self-Check</title>
             <p>To make sure you understand how operators are implemented in C++ classes, and how to properly write methods, write some methods to implement
                 <c>*</c>, <c>/</c>, and <c>-</c>.  Also implement comparison operators <c>&gt;</c> and <c>&lt;</c>.</p>
 
@@ -1006,52 +983,6 @@ int main(){
     <cline>      <area>int den; // den attribute</area>:</cline>
     <cline><area correct="yes">}</area>:</cline>
     </areas></exercise>
-    <exercise label="OOPclassquestion">
-        <statement>
-
-            <p>Which OOP principle is the above code an example of?</p>
-
-        </statement>
-<choices>
-
-            <choice correct="yes">
-                <statement>
-                    <p>Inheritance</p>
-                </statement>
-                <feedback>
-                    <p>Correct! Airplane inherits many things from Vehicle</p>
-                </feedback>
-            </choice>
-
-            <choice>
-                <statement>
-                    <p>Encapsulation</p>
-                </statement>
-                <feedback>
-                    <p>Encapsulation is the principle of hiding the contents of a class except when absolutely necessary. Wings is not hidden from Vehicle, it simply does not exist in the Vehicle class.</p>
-                </feedback>
-            </choice>
-
-            <choice>
-                <statement>
-                    <p>Polymorphism</p>
-                </statement>
-                <feedback>
-                    <p>Polymorphism is the ability to process objects or methods differently depending on their data type, class, number of arguments, etc. A subclass using parts of a pre-existing class is not an example of polymorphism because they are used in the same way.</p>
-                </feedback>
-            </choice>
-
-            <choice>
-                <statement>
-                    <p>Abstraction</p>
-                </statement>
-                <feedback>
-                    <p>Abstraction is the principle of focusing on desired behaviors and properties while disregarding what is irrelevant/unimportant. Take another look at what the two classes have in common.</p>
-                </feedback>
-            </choice>
-</choices>
-
-    </exercise>
 
     
 

--- a/pretext/Introduction/ObjectOrientedProgrammingDerivedClasses.ptx
+++ b/pretext/Introduction/ObjectOrientedProgrammingDerivedClasses.ptx
@@ -756,6 +756,77 @@ int main() {
         </choices>
         
             </exercise>
+
+ <exercise label="OOPclassquestion">
+ 
+        <statement>
+
+            <!--OOP class example:-->
+            <p><term>Question example</term></p>
+            <program language="cpp"><input>
+#include&lt;iostream&gt;
+using namespace std;
+
+class Vehicle
+{
+
+    protected:
+        int wheels;
+        int windows;
+        int engine;
+};
+
+class Airplane: public Vehicle
+{
+    protected:
+        // wheels
+        // windows
+        // engine
+        int wings;
+};
+</input></program>
+            <p>Which OOP principle is the above code an example of?</p>
+
+        </statement>
+<choices>
+
+            <choice>
+                <statement>
+                    <p>Encapsulation</p>
+                </statement>
+                <feedback>
+                    <p>Encapsulation is the principle of hiding the contents of a class except when absolutely necessary. Wings is not hidden from Vehicle, it simply does not exist in the Vehicle class.</p>
+                </feedback>
+            </choice>
+
+            <choice>
+                <statement>
+                    <p>Polymorphism</p>
+                </statement>
+                <feedback>
+                    <p>Polymorphism is the ability to process objects or methods differently depending on their data type, class, number of arguments, etc. A subclass using parts of a pre-existing class is not an example of polymorphism because they are used in the same way.</p>
+                </feedback>
+            </choice>
+
+                <choice correct="yes">
+                <statement>
+                    <p>Inheritance</p>
+                </statement>
+                <feedback>
+                    <p>Correct! Airplane inherits many things from Vehicle</p>
+                </feedback>
+            </choice>
+            <choice>
+                <statement>
+                    <p>Abstraction</p>
+                </statement>
+                <feedback>
+                    <p>Abstraction is the principle of focusing on desired behaviors and properties while disregarding what is irrelevant/unimportant. Take another look at what the two classes have in common.</p>
+                </feedback>
+            </choice>
+</choices>
+
+    </exercise>
             <note>
                 <title>Self  Check Challenge</title>
                 <p>One of the fundamental building blocks of a computer is something called a flip flop.  It's not something that computer science professors wear on their feet, but rather a kind of circuit that is stable and stores the last piece of data that was put on it.  A simple flip-flop can be made from two <term>NOR</term> gates (a combination <term>OR</term> and <term>NOT</term>) that are tied together as in the following diagram. Create a new gate class, called NorGate. NorGates work like OrGates that have a Not attached to the output. See if you can use your new class to implement this.</p>


### PR DESCRIPTION
…#261
Move a question on Inheritance from the wrong section (1.12) to the right one (1.13) after Inheritance has been explained.
<!--- Provide a general summary of your changes in the Title above -->
I removed the question in the self-check section of 1.12, moved it to 1.13, and added the code that the question was based one, which was initially missing in the pretext version.
# Description
<!--- Describe your changes in detail -->
I moved the question in both pretext (cppds2) and rst version of the book. 
## Related Issue
<!--- This project prefers pull requests related to open issues -->
Issue #261 
<!--- If suggesting a change, please discuss it in an issue first -->
N/A
<!--- Please link to the issue here: -->
#261 
## How Has This Been Tested?
I built it in both pretext-cli only and Runestone environments
<!--- Please describe in detail how you tested your changes. -->
I did a normal build and deploy.