### PR TITLE
fix issue #949

### DIFF
--- a/pretext/LinearBasic/ConvertingDecimalNumberstoBinaryNumbers.ptx
+++ b/pretext/LinearBasic/ConvertingDecimalNumberstoBinaryNumbers.ptx
@@ -242,14 +242,64 @@ main()
                 Reading Questions
             </title>
         <exercise label="convert-base-1">
+    <statement>
+        <p>What is value of 25 expressed as an octal (base 8) number? <var/></p>
+    </statement>
+    <setup>
+        <var>
+            <condition number="[31]">
+                <feedback>
+                    <p>Correct because 25 = 3×8 + 1.</p>
+                </feedback>
+            </condition>
+            <condition string="^\s*.*\s*$">
+                <feedback>
+                    <p>That is not correct, please try again.</p>
+                </feedback>
+            </condition>
+        </var>
+    </setup>
+</exercise>
+
+     <exercise label="convert-base-2">
             <statement>
-    <p>What is value of 25 expressed as an octal (base 8) number? <var/>  </p></statement><setup><var><p><BlankNode/></p><condition number="[31, 31]"><feedback><p>Correct because 25 = 3x8 + 1.</p></feedback></condition></var></setup></exercise>
-        <exercise label="convert-base-2">
-            <statement>
-    <p>What is value of 256 expressed as a hexadecimal (base 16) number? <var/>  </p></statement><setup><var><p><BlankNode/></p><condition number="[100, 100]"><feedback><p>Correct because 256 = 1x16^2.</p></feedback></condition></var></setup></exercise>
+                <p>What is value of 256 expressed as a hexadecimal (base 16) number? <var/>  </p>
+            </statement>
+            <setup>
+                <var>
+                    <condition number="[100]">
+                        <feedback>
+                            <p>Correct because 256 = 1x16^2.</p>
+                        </feedback>
+                    </condition>
+                    <condition string="^\s*.*\s*$">
+                        <feedback>
+                            <p>That is not correct, please try again.</p>
+                        </feedback>
+                    </condition>
+                </var>
+            </setup>
+    </exercise>
+
         <exercise label="convert-base-3">
             <statement>
-    <p>What is value of 26 expressed in base 26? <var/>  </p></statement><setup><var><p><BlankNode/></p><condition number="[10, 10]"><feedback><p>Correct because 26 = 1x26^1.</p></feedback></condition></var></setup></exercise>  
+                <p>What is value of 26 expressed in base 26? <var/>  </p>
+            </statement>
+            <setup>
+                <var>
+                    <condition number="[10]">
+                        <feedback>
+                            <p>Correct because 26 = 1x26^1.</p>
+                        </feedback>
+                    </condition>
+                    <condition string="^\s*.*\s*$">
+                        <feedback>
+                            <p>That is not correct, please try again.</p>
+                        </feedback>
+                    </condition>
+                </var>
+            </setup>
+        </exercise>  
 </reading-questions>   
 <p>
     <!-- extra space before the progress bar -->


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
The issue was that the displayed feedback for the correct answer was wrong. 
# Description
<!--- Describe your changes in detail -->
First, I fixed the condition for the correct answer by setting `number="[31]"` instead of `number="[31, 31]"`.  Second, I added a condition for any other answers that are not [31] by adding the condition` string="^\s*.*\s*$">` .  Last, I adjusted the code indentation to make it easy to read.
## Related Issue
<!--- This project prefers pull requests related to open issues -->
<!--- If suggesting a change, please discuss it in an issue first -->
<!--- Please link to the issue here: -->

## How Has This Been Tested?
I made necessary changes, saved them and rebuilt the book on the local host. 
<!--- Please describe in detail how you tested your changes. -->
