### PR TITLE
deque's are O(1) on both ends in the STL

### DIFF
--- a/_sources/LinearBasic/ImplementingaDequeCpp.rst
+++ b/_sources/LinearBasic/ImplementingaDequeCpp.rst
@@ -148,9 +148,11 @@ the front of the deque is at position 0 in the array.
        main()
 
 You can see many similarities to C++ code already used for
-stacks and queues. You are also likely to observe that in this
-implementation adding and removing items from the back is O(1) whereas
+stacks and queues. In the STL, the deque gives O(1) performance for
+adding and removing items from both the front and back of the queue. In the
+Python implementation,
+adding and removing items from the back is O(1) whereas
 adding and removing from the front is O(n). This is to be expected given
-the common operations that appear for adding and removing items. Again,
+the common operations that appear for adding and removing items to lists. Again,
 the important thing is to be certain that we know where the front and
 rear are assigned in the implementation.

--- a/_sources/LinearBasic/ImplementingaDequeCpp.rst
+++ b/_sources/LinearBasic/ImplementingaDequeCpp.rst
@@ -152,7 +152,7 @@ stacks and queues. In the STL, the deque gives O(1) performance for
 adding and removing items from both the front and back of the queue. In the
 Python implementation,
 adding and removing items from the back is O(1) whereas
-adding and removing from the front is O(n). This is to be expected given
+adding and removing from the front depends on the implementation and could be O(n). This is to be expected given
 the common operations that appear for adding and removing items to lists. Again,
 the important thing is to be certain that we know where the front and
 rear are assigned in the implementation.

--- a/pretext/LinearBasic/ImplementingaDequeCpp.ptx
+++ b/pretext/LinearBasic/ImplementingaDequeCpp.ptx
@@ -138,10 +138,12 @@ main()
             </task>
         </exploration>
         <p>You can see many similarities to C++ code already used for
-            stacks and queues. You are also likely to observe that in this
-            implementation adding and removing items from the back is O(1) whereas
-            adding and removing from the front is O(n). This is to be expected given
-            the common operations that appear for adding and removing items. Again,
+            stacks and queues. In the STL, the deque gives <m>O(1)</m> performance for
+            adding and removing items from both the front and back of the queue. In the
+            Python implementation in <xref ref="lst-dequecode-py"/>,
+            adding and removing items from the back is <m>O(1)</m> whereas
+            adding and removing from the front is <m>O(n)</m>. This is to be expected given
+            the common operations that appear for adding and removing items to lists. Again,
             the important thing is to be certain that we know where the front and
             rear are assigned in the implementation.</p>
     <p>


### PR DESCRIPTION
# Description
In the C++ STL, deque is required to be O(1) for insert and remove on both ends. That's not true for the python implementation give, though.

## Related Issue
standalone

## How Has This Been Tested?
local build