### PR TITLE
check for labels on activecode programs

### DIFF
--- a/verifier.py
+++ b/verifier.py
@@ -159,6 +159,22 @@ class TagsNeedLabels(CppsXmlTest):
                     ret = False
         return ret
 
+class ActivecodeProgramsNeedLabels(CppsXmlTest):
+    """program elements which are activecode should have labels"""
+    labeled_items = ('exercise', 'task')
+
+    @classmethod
+    def test_file(cls, fname, doc):
+        ret = True
+
+        for prog in doc.getElementsByTagName("program"):
+            attr = prog.getAttribute("interactive")
+            if attr == "activecode":
+                label = prog.getAttribute("label")
+                if len(label) == 0:
+                    print(f'{fname}: program does not have label')
+                    ret = False
+        return ret
 
 ALL_TESTS = CppsXmlTest.__subclasses__()
 


### PR DESCRIPTION
# Description
program elements need to have labels if they are user edittable (activecode). Otherwise things written by the user are not saved correctly. This adds a verifier check for that condition.

## Related Issue
standalone

## How Has This Been Tested?
local build