### PR TITLE
Fixed 2.3 Exercises 4 & 5

### DIFF
--- a/pretext/AlgorithmAnalysis/BigONotation.ptx
+++ b/pretext/AlgorithmAnalysis/BigONotation.ptx
@@ -393,7 +393,7 @@ Reading Questions
     
             <choice correct="yes">
                 <statement>
-                    <p>2.53</p>
+                    <p>2.04</p>
                 </statement>
                 <feedback>
                     <p>Correct!</p>
@@ -434,7 +434,7 @@ Reading Questions
     
             <p>The Big O of a particular algorithm is <m>O(\log_{2}n)</m>.
                 Given that it takes 2 seconds to complete the algorithm with 3 million inputs;
-                how long would it take with 10 million inputs?</p>
+                how long would it take with <b>10 million</b> inputs?</p>
     
         </statement>
     <choices>
@@ -448,12 +448,12 @@ Reading Questions
                 </feedback>
             </choice>
     
-            <choice>
+            <choice  correct="yes">
                 <statement>
-                    <p>2.53</p>
+                    <p>2.16</p>
                 </statement>
                 <feedback>
-                    <p>Incorrect. Try again.</p>
+                    <p>Correct!</p>
                 </feedback>
             </choice>
     
@@ -466,12 +466,12 @@ Reading Questions
                 </feedback>
             </choice>
     
-            <choice correct="yes">
+            <choice>
                 <statement>
                     <p>4.2</p>
                 </statement>
                 <feedback>
-                    <p>Right!</p>
+                    <p>Incorrect. Try again</p>
                 </feedback>
             </choice>
     


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description
Exercises 4 and 5 in section 2.3 have incorrect answers.  I computed the following for Exercise 4:

<img width="733" alt="Screenshot 2025-01-16 at 2 01 04 PM" src="https://github.com/user-attachments/assets/80d19cb6-8494-4ea8-9dbc-2a1a04674e2a" />
<img width="663" alt="Screenshot 2025-01-16 at 1 47 22 PM" src="https://github.com/user-attachments/assets/f19b0246-e1fe-4c41-886f-da5e515fea1a" />


Similarly for exercise 5:

<img width="709" alt="Screenshot 2025-01-16 at 1 50 05 PM" src="https://github.com/user-attachments/assets/f2d0fc4f-44bd-45fb-81d9-0fe8a632be93" />


## Related Issue
Just a quick fix

## How Has This Been Tested?
Verified by building and viewing pretext.
<img width="562" alt="Screenshot 2025-01-16 at 1 55 52 PM" src="https://github.com/user-attachments/assets/f20ff76b-3bd0-4359-b7b5-5d40fcddd62b" />

