### PR TITLE
C++ uses / for integer and floating point division

### DIFF
--- a/pretext/AlgorithmAnalysis/AnAnagramDetectionExample.ptx
+++ b/pretext/AlgorithmAnalysis/AnAnagramDetectionExample.ptx
@@ -480,7 +480,7 @@ main()
         int count = 0;
         while (i &gt; 0){
             count = count + 1;
-            i = i // 2;
+            i = i / 2;
         }
         return 0;
     }


### PR DESCRIPTION
# Description
Use C++ division operator. This bug doesn't appear in the RST version.

## Related Issue
none

## How Has This Been Tested?
standalone
