### PR TITLE
Changed links to relevant topics on linked lists Fixes Issue #1026

### DIFF
--- a/pretext/LinearLinked/WhatAreLinkedStructures.ptx
+++ b/pretext/LinearLinked/WhatAreLinkedStructures.ptx
@@ -19,9 +19,9 @@
     
     <video xml:id="uUqCsOcDjVQ" youtube="uUqCsOcDjVQ" width="auto"/>
     
-    <video xml:id="OCYZTg3jahU" youtube="OCYZTg3jahU" width="auto"/>
+    <video xml:id="N6dOwBde7-M" youtube="N6dOwBde7-M" width="auto"/>
     
-    <video xml:id="fiveY-dkurZfgk" youtube="5Y-dkurZfgk" width="auto"/>
+    <video xml:id="R9PTBwOzceo" youtube="R9PTBwOzceo" width="auto"/>
             <p>You can hear and see all of these videos simultaneously, but only because your
             computer switches from one task to another so fast that it appears seamless. Just
             like you, your computer gives each task some time to use its resources and cycles


### PR DESCRIPTION
There are two links that were used in 4.2 as examples for processes switching back and forth to imitate seamless simultaneous playing, however, those two links were to unavailable/private videos, so I changed them to relevant topics.

# Description
Changed the two "dead" links to active, relevant videos on the Linked lists.

## Related Issue
#1026

## How Has This Been Tested?
Built on local host, played videos all at the same time, they all work. Reviewed by @flasheb @coco3427
