### PR TITLE
matches to cardsort, move order to premise ch6,7

### DIFF
--- a/pretext/SearchHash/Matching.ptx
+++ b/pretext/SearchHash/Matching.ptx
@@ -8,84 +8,84 @@
     <feedback>
       <p>Review classes and their properties</p>
     </feedback>
-    <matches>
-      <match order="1">
-        <premise>binary search</premise>
+    <cardsort>
+      <match>
+        <premise order="1">binary search</premise>
         <response>One repeatedly divides a sorted data structure in half and determines if the item is in one half of it until the item is found or deemed not in the data.</response>
       </match>
-      <match order="10">
-        <premise>load factor</premise>
+      <match>
+        <premise order="10">load factor</premise>
         <response>Its the number of items in a hash table divided by the size of the table.</response>
       </match>
-      <match order="11">
-        <premise>map</premise>
+      <match>
+        <premise order="11">map</premise>
         <response>Associate data type that stores key-data pairs</response>
       </match>
-      <match order="12">
-        <premise>mid-square method</premise>
+      <match>
+        <premise order="12">mid-square method</premise>
         <response>Method for constructing a hash function by squaring the item and then using some portion of the result.</response>
       </match>
-      <match order="13">
-        <premise>open addressing</premise>
+      <match>
+        <premise order="13">open addressing</premise>
         <response>Collision resolution that tries to find the next open slot/address in the hash table.</response>
       </match>
-      <match order="14">
-        <premise>perfect hash function</premise>
+      <match>
+        <premise order="14">perfect hash function</premise>
         <response>Hash function that maps each item to a unique hash slot.</response>
       </match>
-      <match order="15">
-        <premise>quadratic probing</premise>
+      <match>
+        <premise order="15">quadratic probing</premise>
         <response>Variation of linear probing in which rehashing is done using successive squared values.</response>
       </match>
-      <match order="16">
-        <premise>rehashing</premise>
+      <match>
+        <premise order="16">rehashing</premise>
         <response>Putting an item into a hash table after a collision.</response>
       </match>
-      <match order="17">
-        <premise>searching</premise>
+      <match>
+        <premise order="17">searching</premise>
         <response>Algorithmic process of finding a particular item in a collection of items.</response>
       </match>
-      <match order="18">
-        <premise>sequential search</premise>
+      <match>
+        <premise order="18">sequential search</premise>
         <response>Search method in which one follows the underlying ordering of items in a collection of data to find a specific item.</response>
       </match>
-      <match order="19">
-        <premise>slot</premise>
+      <match>
+        <premise order="19">slot</premise>
         <response>Position in a hash table.</response>
       </match>
-      <match order="2">
-        <premise>chaining</premise>
+      <match>
+        <premise order="2">chaining</premise>
         <response>Collision resolution method, in which each slot in a hash table holds a reference to a collection of items.</response>
       </match>
-      <match order="3">
-        <premise>collision</premise>
+      <match>
+        <premise order="3">collision</premise>
         <response>Having two or more items sharing the same slot in a hash table.</response>
       </match>
-      <match order="4">
-        <premise>collision resolution</premise>
+      <match>
+        <premise order="4">collision resolution</premise>
         <response>Systematic method for solving hash table collisions.</response>
       </match>
-      <match order="5">
-        <premise>clustering</premise>
+      <match>
+        <premise order="5">clustering</premise>
         <response>Items being mapped in a hash table near each other resulting in items with collisions being put together.</response>
       </match>
-      <match order="6">
-        <premise>folding method</premise>
+      <match>
+        <premise order="6">folding method</premise>
         <response>Constructing a hash function by dividing the item into equally sized pieces, adding the pieces together to get a hash value, dividing by the size of the hash table, and the remainder becomes the slot for that item.</response>
       </match>
-      <match order="7">
-        <premise>hashing</premise>
+      <match>
+        <premise order="7">hashing</premise>
         <response>Creating a value for an input that can be used to find the input by searching for the value.</response>
       </match>
-      <match order="8">
-        <premise>hash function</premise>
+      <match>
+        <premise order="8">hash function</premise>
         <response>Mapping between an item and its slot in a hash table</response>
       </match>
-      <match order="9">
-        <premise>linear probing</premise>
+      <match>
+        <premise order="9">linear probing</premise>
         <response>Open addressing technique in which each slot is visited one at a time systematically.</response>
       </match>
-    </matches>
+    </cardsort>
   </exercise>
   <p>
     <!-- extra space before the progress bar -->

--- a/pretext/SearchHash/SelfCheck.ptx
+++ b/pretext/SearchHash/SelfCheck.ptx
@@ -4,20 +4,20 @@
     <exercise label="bigOSH">
         <statement><p>Match the method of finding data to its corresponding Big O.</p></statement>
         <feedback><p>Review the analysis of each technique</p></feedback>
-        <matches>
-            <match order="1"><premise>Linear Search</premise><response><m>O(n)</m></response></match>
-            <match order="2"><premise>Binary Search</premise><response><m>O(\log n)</m></response></match>
-            <match order="3"><premise>Hashing</premise><response><m>O(1)</m></response></match>
-        </matches>
+        <cardsort>
+            <match><premise order="1">Linear Search</premise><response><m>O(n)</m></response></match>
+            <match><premise order="2">Binary Search</premise><response><m>O(\log n)</m></response></match>
+            <match><premise order="3">Hashing</premise><response><m>O(1)</m></response></match>
+        </cardsort>
     </exercise>
     
     <exercise label="searchBests">
         <statement><p>Drag the search method to the type of data that it is more efficient for compared to the other search method.</p></statement>
         <feedback><p>This is feedback.</p></feedback>
-        <matches>
-            <match order="1"><premise>Binary Search</premise><response>ordered data</response></match>
-            <match order="2"><premise>Linear Search</premise><response>unordered data</response></match>
-        </matches>
+        <cardsort>
+            <match><premise order="1">Binary Search</premise><response>ordered data</response></match>
+            <match><premise order="2">Linear Search</premise><response>unordered data</response></match>
+        </cardsort>
     </exercise>
     
     <exercise label="hashcollisions">

--- a/pretext/Sort/Matching.ptx
+++ b/pretext/Sort/Matching.ptx
@@ -8,63 +8,63 @@
     <feedback>
       <p>Review classes and their properties</p>
     </feedback>
-    <matches>
-      <match order="1">
-        <premise>bubble sort</premise>
+    <cardsort>
+      <match>
+        <premise order="1">bubble sort</premise>
         <response>Makes multiple passes through a collection, comparing adjacent items, and swaps items that are out of order</response>
       </match>
-      <match order="10">
-        <premise>short bubble</premise>
+      <match>
+        <premise order="10">short bubble</premise>
         <response>Stops if there are no exchanges to do</response>
       </match>
-      <match order="11">
-        <premise>shell sort</premise>
+      <match>
+        <premise order="11">shell sort</premise>
         <response>Divides the collection into subsets, sorts the subsets individually using insertion sort, then also sorts the combination of the sorted subsets using insertion sort</response>
       </match>
-      <match order="12">
-        <premise>sorting</premise>
+      <match>
+        <premise order="12">sorting</premise>
         <response>Process of placing elements from a collection in some kind of order</response>
       </match>
-      <match order="13">
-        <premise>split point</premise>
+      <match>
+        <premise order="13">split point</premise>
         <response>Position of the pivot value in the sorted collection; used to divide the collection for subsequent calls to quick sort</response>
       </match>
-      <match order="14">
-        <premise>quick sort</premise>
+      <match>
+        <premise order="14">quick sort</premise>
         <response>Uses recursion to split a collection in half and places elements on the proper side of the split point</response>
       </match>
-      <match order="2">
-        <premise>gap</premise>
+      <match>
+        <premise order="2">gap</premise>
         <response>Used to divide a collection into subsets without breaking apart the collection during a shell sort</response>
       </match>
-      <match order="3">
-        <premise>insertion sort</premise>
+      <match>
+        <premise order="3">insertion sort</premise>
         <response>Maintains a sorted and unsorted subset of a collection and inserts elements from the unsorted subset into the sorted subset</response>
       </match>
-      <match order="4">
-        <premise>median of three</premise>
+      <match>
+        <premise order="4">median of three</premise>
         <response>Method of choosing the pivot value for a quick sort by taking the median of the first, middle, and last element of a collection</response>
       </match>
-      <match order="5">
-        <premise>merge</premise>
+      <match>
+        <premise order="5">merge</premise>
         <response>Takes two smaller sorted subsets and combines them</response>
       </match>
-      <match order="6">
-        <premise>merge sort</premise>
+      <match>
+        <premise order="6">merge sort</premise>
         <response>Uses recursion to split a collection in half until there is one item and then combines the smaller subsets back into larger sorted subsets</response>
       </match>
-      <match order="7">
-        <premise>partition</premise>
+      <match>
+        <premise order="7">partition</premise>
         <response>Finds the split point and moves items to the appropriate side of the collection, either less than or greater than the pivot value</response>
       </match>
-      <match order="8">
-        <premise>pivot value</premise>
+      <match>
+        <premise order="8">pivot value</premise>
         <response>Value selected in a collection during quick sort in order to split a collection</response>
       </match>
-      <match order="9">
-        <premise>selection sort</premise>
+      <match>
+        <premise order="9">selection sort</premise>
         <response>Makes multiple passes through a collection, taking the largest or lowest unsorted element and places it into its correct place by swapping places with the next largest or lowest element</response>
       </match>
-    </matches>
+    </cardsort>
   </exercise>
 </section>

--- a/pretext/Sort/SelfCheck.ptx
+++ b/pretext/Sort/SelfCheck.ptx
@@ -26,12 +26,12 @@
     <exercise label="question_sort_10">
         <statement><p>Match each sorting method with its appropriate estimated comparisons.</p></statement>
         <feedback><p>Refer to previous sections of the chapter</p></feedback>
-        <matches>
-            <match order="1"><premise>Quick Sort</premise><response><m>O(n \log n)</m> or <m>O(n^2)</m></response></match>
-            <match order="2"><premise>Insertion/Bubble/Merge</premise><response><m>O(n^2)</m></response></match>
-            <match order="3"><premise>Merge Sort</premise><response><m>O(n \log n)</m></response></match>
-            <match order="4"><premise>Shell Sort</premise><response>between <m>O(n)</m> and <m>O(n^2)</m></response></match>
-        </matches>
+        <cardsort>
+            <match><premise order="1">Quick Sort</premise><response><m>O(n \log n)</m> or <m>O(n^2)</m></response></match>
+            <match><premise order="2">Insertion/Bubble/Merge</premise><response><m>O(n^2)</m></response></match>
+            <match><premise order="3">Merge Sort</premise><response><m>O(n \log n)</m></response></match>
+            <match><premise order="4">Shell Sort</premise><response>between <m>O(n)</m> and <m>O(n^2)</m></response></match>
+        </cardsort>
     </exercise>
 
     <exercise label="sortefficiencyrandom">


### PR DESCRIPTION
# Description
- update matches tag -> cardsort
- move order from match to premise

# Related Issue

working on #1047 and #1048

## How Has This Been Tested?

local build