### PR TITLE
use program/code instead of pre for listing

### DIFF
--- a/pretext/Introduction/DefiningFunctions.ptx
+++ b/pretext/Introduction/DefiningFunctions.ptx
@@ -151,7 +151,7 @@ void callingFunction() { /*return type int which indicates
                 The contents of <em>myVar</em> is <term>still the same</term>, as the location for <em>myVar</em> differs from where <em>inputVar</em>
                 is stored. Thus, <em>myVar</em> still has the value 10, and the <c>cout</c> statement after the function call will
                 produce the output:</p>
-            <program language="cpp"><code>>myVar = 10</code></program>
+            <program language="cpp"><code>myVar = 10</code></program>
             <p>In other words, any changes to the variables are local to the function, which is exactly what we want.</p>
 
             <p>However, there is a problem.</p>

--- a/pretext/Introduction/DefiningFunctions.ptx
+++ b/pretext/Introduction/DefiningFunctions.ptx
@@ -118,8 +118,11 @@ int main() {
                 the values of the parameters, the original contents in the memory referenced
                 by the arguments of the calling function do not change.</p>
             <p>Consider the following two function definitions:</p>
-            <pre>void functionExample( int inputVar ) { /*return type void which indicates that
-                                         nothing is being returned*/
+                
+            <program language="cpp"><code>
+void functionExample( int inputVar ) {
+    /* return type void which indicates that
+       nothing is being returned */
     int nextVar = inputVar * 2;
     inputVar = 4;
 
@@ -132,20 +135,25 @@ void callingFunction() { /*return type int which indicates
 
     functionExample( myVar );
     cout &lt;&lt; &quot;myVar = &quot; &lt;&lt; myVar;
-}</pre>
+}
+            </code></program>
+            
             <p>When the function <c>callingFunction()</c> executes, it calls <c>functionExample(...)</c>
                 with the variable <em>myVar</em> having the value 10. Within <c>functionExample(...)</c>,
                 the value of 10 is copied from <em>myVar</em> to the formal parameter <em>inputVar</em>,
                 so the value of <em>nextVar</em> is 10x2, or 20. The next statement changes the contents of <em>inputVar</em> to 4,
                 so the <c>cout</c> statement within this function produces the output:</p>
-            <pre>nextVar = 20 inputVar = 4</pre>
+            <program language="cpp"><code>
+                nextVar = 20 inputVar = 4
+            </code></program>
+            
             <p>Notice what happens when <c>functionExample(...)</c> ends and execution returns to <c>callingFunction()</c>.
                 The contents of <em>myVar</em> is <term>still the same</term>, as the location for <em>myVar</em> differs from where <em>inputVar</em>
                 is stored. Thus, <em>myVar</em> still has the value 10, and the <c>cout</c> statement after the function call will
                 produce the output:</p>
-            <pre>myVar = 10</pre>
+            <program language="cpp"><code>>myVar = 10</code></program>
             <p>In other words, any changes to the variables are local to the function, which is exactly what we want.</p>
-            <transition/>
+
             <p>However, there is a problem.</p>
             <p><idx>pass-by-reference</idx>We have seen examples of C++ functions that return no value or a single value.
                 How about when we want the function to return <term>more</term> than one value?
@@ -207,31 +215,45 @@ int main( ) {
             <p>The following example function returns the average hours worked over the array of
                 integers (note that we need to also pass in the number of elements in that array
                 because the array parameter <em>list[]</em> does not include that information):</p>
-            <pre>double average( int list[], int length ) {
-     // It is correct syntax to omit the array length on the array itself.
+
+            <program language="cpp"><code>
+double average( int list[], int length ) {
+    // It is correct syntax to omit the array length on the array itself.
     double total = 0;
-     //return type double which indicates that a decimal is being returned
+    //return type double which indicates that a decimal is being returned
     int count;
     for( count = 0; count &lt; length; count++ ) {
         total += double(list[count]);
-        };
+    }
     return (total / length);
-}</pre>
+}
+            </code></program>
+
             <p>Array parameters look like pass by value, but they are effectively similar to pass by reference parameters. When they execute, the functions with these parameters do not make private copies of the arrays. Instead, the reference is passed to reduce the impact on memory. Arrays can therefore always be permanently changed when passed as arguments to functions.</p>
             <p>After a call to the following function, each element in the third array argument is equal to the sum of the corresponding two elements in the first and second arguments:</p>
-            <pre>void add_lists( int first[], int second[], int total[], int length ) {
+            
+            <program language="cpp"><code>
+void add_lists( int first[], int second[], int total[], int length ) {
     //return type void which indicates that nothing is returned
     int count;
     for( count = 0; count &lt; length; count++ ) {
         total[count] = first[count] + second[count];
-};}</pre>
+    }
+}
+            </code></program>
+            
             <p>Upon further examination, we can see that the first two arrays do not change values. To prevent ourselves from accidentally modifying any of these arrays, we can add the modifier <c>const</c> in the function head:</p>
-            <pre>void add_lists( const int first[], const int second[], int total[], int length ) {
+
+            <program language="cpp"><code>
+void add_lists( const int first[], const int second[], int total[], int length ) {
     //return type void which indicates that nothing is returned
     int count;
     for( count = 0; count &lt; length; count++ ) {
         total[count] = first[count] + second[count];
-};}</pre>
+    }
+}
+            </code></program>
+            
             <p>These changes would ensure that the compiler will then not accept any statements within the function's definition that potentially modify the elements of the arrays <em>first</em> or <em>second</em>.</p>
         </subsection>
         <subsection xml:id="introduction_function-overloading">
@@ -301,25 +323,22 @@ main()
                     Reading Questions
                 </title>
                 <p>Take a look at the code below:</p>
-            <pre>#include &lt;iostream&gt;
+                <program language="cpp"><code>
+#include &lt;iostream&gt;
+
 using namespace std;
 
 void dogWalk(int steps){
-
     for (int step = 0; step &lt; steps; step++){
         cout &lt;&lt; &quot;dog walked &quot;&lt;&lt; step &lt;&lt; &quot; steps!&quot;&lt;&lt; endl;
-
     }
-
 }
 
 int main() {
-
     dogWalk(11);
-
     return 0;
-
-}</pre>
+}
+                </code></program>
     <exercise label="dog_walker">
         <statement>
 


### PR DESCRIPTION
# Description
I noticed some formatting issues with the code in the defining functions secton and while I was here I switched from "pre" to "program/code" elements (which gets us syntax highlighting, etc.)

## Related Issue
standalone

## How Has This Been Tested?
local build