### PR TITLE
fix AVL math

### DIFF
--- a/pretext/Trees/AVLTreePerformance.ptx
+++ b/pretext/Trees/AVLTreePerformance.ptx
@@ -51,25 +51,34 @@
             F_i &amp;= F_{i-1} + F_{i-2}  \text{ for all } i \ge 2
             \end{split}
         </me>
-        <p>An important mathematical result is that as the numbers of the Fibonacci
-            sequence get larger and larger the ratio of <m>F_i / F_{i-1}</m>
-            becomes closer and closer to approximating the golden ratio
-            <m>\Phi</m> which is defined as
-            <m>\Phi = \frac{1 + \sqrt{5}}{2}</m>. You can consult a math text if
-            you want to see a derivation of the previous equation. We will simply
-            use this equation to approximate <m>F_i</m> as <m>F_i =
-                \Phi^i/\sqrt{5}</m>. If we make use of this approximation we can rewrite
-            the equation for <m>N_h</m> as:</p>
-        <me>N_h = F_{h+1} - 1, h \ge 1</me>
+        <p>We can express the value of the number of nodes in a tree of height <m>h</m>
+            in terms of its position in the Fibonacci sequence:</p>
+        <me>N_h = F_{h+3} - 1, h \ge 0</me>
+        
+        <p>An important mathematical result is that the <m>i^{th}</m> Fibonacci number
+            can be found using Binet's formula:</p>
+        <me>F_i = \frac{\Phi^i - (1 - \Phi)^i}{\sqrt{5}}</me>.
+
+        <p>You can consult a math text if you want to see a derivation of the
+        previous formula. <m>\Phi</m> is the golden ratio and as is defined as:</p>
+        <me>\Phi = \frac{1 + \sqrt{5}}{2} \approx 1.618</me>.
+
+        <p>In Binet's formula, as <m>i</m> grows large, the term <m>(1 - \Phi)^i</m>
+            approaches zero, so we can use the following approximation to obtain a
+            value close to the <m>i^{th}</m> Fibonacci number:</p>
+        <me>F_i \approx \frac{\Phi^i}{\sqrt{5}}</me>.
+
+
+
         <p>By replacing the Fibonacci reference with its golden ratio approximation
             we get:</p>
-        <me>N_h = \frac{\Phi^{h+2}}{\sqrt{5}} - 1</me>
+        <me>N_h = \frac{\Phi^{h+3}}{\sqrt{5}} - 1</me>
         <p>If we rearrange the terms, and take the base 2 log of both sides and
             then solve for <m>h</m> we get the following derivation:</p>
         <me>\begin{split}
-            \log{N_h+1} &amp;= (h+2)\log{\Phi} - \frac{1}{2} \log{5} \\
-            h &amp;= \frac{\log{N_h+1} - 2 \log{\Phi} + \frac{1}{2} \log{5}}{\log{\Phi}} \\
-            h &amp;= 1.44 \log{N_h}
+            \log_2{(N_h + 1)} &amp;= (h+3)\log_2{\Phi} - \frac{1}{2} \log_2{5} \\
+            h &amp;= \frac{\log_2{(N_h + 1)} - 3 \log_2{\Phi} + \frac{1}{2} \log_2{5}}{\log_2{\Phi}} \\
+            h &amp;\approx 1.44 \log_2{(N_h + 1) - 2.57}
             \end{split}
         </me>
         <p>This derivation shows us that at any time the height of our AVL tree is


### PR DESCRIPTION
# Description
I'm trying to clean up the description of AVL tree performance. This diff only deals with the mathematics, but more work needs to happen on the description above the math.

## Related Issue
This started because of #202, but this does not fix it.

## How Has This Been Tested?
local build