### PR TITLE
simplify xml, no unneeded xmlns stuff

### DIFF
--- a/pretext/LinearBasic/SimpleBalancedParentheses.ptx
+++ b/pretext/LinearBasic/SimpleBalancedParentheses.ptx
@@ -42,8 +42,9 @@
             from the inside out. This is a clue that stacks can be used to solve the
             problem.</p>
         
-        <figure align="center" xml:id="fig-parmatch"><caption xmlns:c="https://www.sphinx-doc.org/" xmlns:changeset="https://www.sphinx-doc.org/" xmlns:citation="https://www.sphinx-doc.org/" xmlns:cpp="https://www.sphinx-doc.org/" xmlns:index="https://www.sphinx-doc.org/" xmlns:js="https://www.sphinx-doc.org/" xmlns:math="https://www.sphinx-doc.org/" xmlns:py="https://www.sphinx-doc.org/" xmlns:rst="https://www.sphinx-doc.org/" xmlns:std="https://www.sphinx-doc.org/">Figure 4: Matching Parentheses</caption>
-        <image source="LinearBasic/simpleparcheck.png" width="50%"> 
+        <figure xml:id="fig-parmatch">
+            <caption>Matching Parentheses</caption>
+            <image source="LinearBasic/simpleparcheck.png" width="50%"> 
             <description>
                 <p>
                     The image illustrates the process of matching parentheses to determine if they are balanced. It shows 

--- a/pretext/LinearBasic/WhatIsaDeque.ptx
+++ b/pretext/LinearBasic/WhatIsaDeque.ptx
@@ -14,8 +14,9 @@
             and FIFO orderings that are enforced by those data structures. It is up
             to you to make consistent use of the addition and removal operations.</p>
         
-        <figure align="center" xml:id="fig-basicdeque"><caption xmlns:c="https://www.sphinx-doc.org/" xmlns:changeset="https://www.sphinx-doc.org/" xmlns:citation="https://www.sphinx-doc.org/" xmlns:cpp="https://www.sphinx-doc.org/" xmlns:index="https://www.sphinx-doc.org/" xmlns:js="https://www.sphinx-doc.org/" xmlns:math="https://www.sphinx-doc.org/" xmlns:py="https://www.sphinx-doc.org/" xmlns:rst="https://www.sphinx-doc.org/" xmlns:std="https://www.sphinx-doc.org/">Figure 1: A Deque of Python Data Objects</caption>
-        <image source="LinearBasic/basicdeque.png" width="50%"> 
+        <figure xml:id="fig-basicdeque">
+            <caption>A Deque of Python Data Objects</caption>
+            <image source="LinearBasic/basicdeque.png" width="50%"> 
             <description>
                 <p>
                     The image illustrates a deque (double-ended queue) of Python data objects. 

--- a/pretext/LinearBasic/WhatisaStack.ptx
+++ b/pretext/LinearBasic/WhatisaStack.ptx
@@ -23,13 +23,17 @@
             stack, we need to remove the ones that are sitting on top of them.
             <xref ref="fig-objectstack"/> shows another stack.</p>
         
-        <figure align="center" xml:id="fig-bookstack"><caption xmlns:c="https://www.sphinx-doc.org/" xmlns:changeset="https://www.sphinx-doc.org/" xmlns:citation="https://www.sphinx-doc.org/" xmlns:cpp="https://www.sphinx-doc.org/" xmlns:index="https://www.sphinx-doc.org/" xmlns:js="https://www.sphinx-doc.org/" xmlns:math="https://www.sphinx-doc.org/" xmlns:py="https://www.sphinx-doc.org/" xmlns:rst="https://www.sphinx-doc.org/" xmlns:std="https://www.sphinx-doc.org/">A Stack of Books</caption><image source="LinearBasic/bookstack2.png" width="50%"><description>
+        <figure xml:id="fig-bookstack">
+            <caption>A Stack of Books</caption>
+            <image source="LinearBasic/bookstack2.png" width="50%"><description>
             <p>
                 This image illustrates a stack of books. The books, from the bottom to the top, are: History, Music, Physics, Calculus and Python. 
             </p>
         </description></image></figure>
         
-        <figure align="center" xml:id="fig-objectstack"><caption xmlns:c="https://www.sphinx-doc.org/" xmlns:changeset="https://www.sphinx-doc.org/" xmlns:citation="https://www.sphinx-doc.org/" xmlns:cpp="https://www.sphinx-doc.org/" xmlns:index="https://www.sphinx-doc.org/" xmlns:js="https://www.sphinx-doc.org/" xmlns:math="https://www.sphinx-doc.org/" xmlns:py="https://www.sphinx-doc.org/" xmlns:rst="https://www.sphinx-doc.org/" xmlns:std="https://www.sphinx-doc.org/">A Stack of Primitive Python Objects</caption><image source="LinearBasic/primitive.png" width="50%"> <description>
+        <figure xml:id="fig-objectstack">
+            <caption>A Stack of Primitive Python Objects</caption>
+            <image source="LinearBasic/primitive.png" width="50%"><description>
         <p>
             This image depicts a stack data structure with labeled &quot;Top&quot; and &quot;Base&quot; sections. The stack contains four elements, each represented as a block with a string value. From bottom (Base) to top, the elements are: &quot;4&quot;, &quot;dog&quot;, &quot;True&quot;, and &quot;8.4&quot;. The &quot;Base&quot; of the stack is the bottom-most element (&quot;4&quot;), while the &quot;Top&quot; of the stack is the upper-most element (&quot;8.4&quot;). This structure visually represents how stacks operate in a Last-In-First-Out (LIFO) manner, where the last element added (&quot;8.4&quot;) is the first one to be accessed or removed.
         </p>
@@ -46,7 +50,9 @@
             created and then again as items are removed. Note the order of the
             objects.</p>
         
-        <figure align="center" xml:id="linear-basic-stack-fig-reversal"><caption xmlns:c="https://www.sphinx-doc.org/" xmlns:changeset="https://www.sphinx-doc.org/" xmlns:citation="https://www.sphinx-doc.org/" xmlns:cpp="https://www.sphinx-doc.org/" xmlns:index="https://www.sphinx-doc.org/" xmlns:js="https://www.sphinx-doc.org/" xmlns:math="https://www.sphinx-doc.org/" xmlns:py="https://www.sphinx-doc.org/" xmlns:rst="https://www.sphinx-doc.org/" xmlns:std="https://www.sphinx-doc.org/">The Reversal Property of Stacks</caption><image source="LinearBasic/simplereversal.png" width="50%"> <description>
+        <figure xml:id="linear-basic-stack-fig-reversal">
+            <caption>The Reversal Property of Stacks</caption>
+            <image source="LinearBasic/simplereversal.png" width="50%"><description>
               <p>
                 This image illustrates the process of reversing the order of elements in a stack. The stack contains four elements: &quot;8.4&quot;, &quot;True&quot;, &quot;dog&quot;, and &quot;4&quot;. The &quot;Original Order&quot; is represented at the bottom of the image, starting with &quot;8.4&quot; (4th element) at the top of the stack and ending with &quot;4&quot; (1st element) at the bottom. The &quot;Reversed Order&quot; is shown on the right side, where the elements have been rearranged such that &quot;4&quot; becomes the first element, &quot;dog&quot; the second, &quot;True&quot; the third, and &quot;8.4&quot; the fourth. The arrows illustrate the flow of elements from their positions in the stack to their corresponding reversed positions, emphasizing how a stack's Last-In-First-Out (LIFO) nature can be used to reverse a sequence of elements.
             </p>

--- a/pretext/Trees/BalancedBinarySearchTrees.ptx
+++ b/pretext/Trees/BalancedBinarySearchTrees.ptx
@@ -26,7 +26,8 @@
             back into balance. <xref ref="fig-unbal"/> shows an example of an unbalanced,
             right-heavy tree and the balance factors of each node.</p>
         
-        <figure align="center" xml:id="fig-unbal"><caption xmlns:c="https://www.sphinx-doc.org/" xmlns:changeset="https://www.sphinx-doc.org/" xmlns:citation="https://www.sphinx-doc.org/" xmlns:cpp="https://www.sphinx-doc.org/" xmlns:index="https://www.sphinx-doc.org/" xmlns:js="https://www.sphinx-doc.org/" xmlns:math="https://www.sphinx-doc.org/" xmlns:py="https://www.sphinx-doc.org/" xmlns:rst="https://www.sphinx-doc.org/" xmlns:std="https://www.sphinx-doc.org/">An Unbalanced Right-Heavy Tree with Balance Factors.</caption>
+        <figure xml:id="fig-unbal">
+            <caption>An Unbalanced Right-Heavy Tree with Balance Factors.</caption>
         <image source="Trees/unbalanced.png" width="50%">
         <description>
             <p>

--- a/pretext/Trees/ListofListsRepresentation.ptx
+++ b/pretext/Trees/ListofListsRepresentation.ptx
@@ -13,7 +13,9 @@
             storage technique, let's look at an example. <xref ref="fig-smalltree"/>
             shows a simple tree and the corresponding list implementation.</p>
         
-        <figure align="center" xml:id="fig-smalltree"><caption xmlns:c="https://www.sphinx-doc.org/" xmlns:changeset="https://www.sphinx-doc.org/" xmlns:citation="https://www.sphinx-doc.org/" xmlns:cpp="https://www.sphinx-doc.org/" xmlns:index="https://www.sphinx-doc.org/" xmlns:js="https://www.sphinx-doc.org/" xmlns:math="https://www.sphinx-doc.org/" xmlns:py="https://www.sphinx-doc.org/" xmlns:rst="https://www.sphinx-doc.org/" xmlns:std="https://www.sphinx-doc.org/">Figure 1: A Small Tree</caption><image source="Trees/Figures/smalltree.png" width="50%"/></figure>
+        <figure xml:id="fig-smalltree">
+            <caption>A Small Tree</caption>
+            <image source="Trees/Figures/smalltree.png" width="50%"/></figure>
         <pre>myTree = ['a',   #root
       ['b',  #left subtree
        ['d', [], []],


### PR DESCRIPTION
# Description
There were several cases where xmlns callouts were made for tags that aren't actually used (I suspect this was autogenerated xml pendantics). Remove and reformat for readability.

## Related Issue
standalone

## How Has This Been Tested?
local build