### PR TITLE
caption is title, align=center is not a thing

### DIFF
--- a/pretext/Introduction/BuiltInAtomicDataTypes.ptx
+++ b/pretext/Introduction/BuiltInAtomicDataTypes.ptx
@@ -593,7 +593,7 @@ main()
     <pre>// C++ variable declaration and assignment of an integer value
 int varN = 100;</pre>
     <p>In C++ the results of running this code will look like the diagram below:</p>
-    <figure align="center" xml:id="id2-fig-cpp-reference">
+    <figure xml:id="id2-fig-cpp-reference">
       <caption>C++ variable</caption>
       <image source="Introduction/cpp_var.png" width="50%">
         <description>
@@ -683,7 +683,7 @@ int varN = 100;
 int *ptrN;
 ptrN = &amp;varN;</pre>
       <p>The results of running this C++ code will look like the diagram below.</p>
-      <figure align="center" xml:id="id3-fig-point2">
+      <figure xml:id="id3-fig-point2">
         <caption>View into memory with pointers</caption>
         <image source="Introduction/new_point2.png" width="50%"> 
         <description>
@@ -810,7 +810,7 @@ int main() {
       <p>
         <term>This is BAD, BAD, BAD!</term>
       </p>
-      <figure align="center" xml:id="id4-fig-point3">
+      <figure xml:id="id4-fig-point3">
         <caption>Dangling pointer reference</caption>
         <image source="Introduction/new_point_broken.png" width="50%"> 
         <description>
@@ -856,7 +856,7 @@ int main() {
          On the first iteration of the loop, it is assigned the value of <c>nullptr</c> (i.e. 0)
          thereby ending the loop:</p>
       <listing xml:id="NULLexamplecpp">
-        <caption>Using the null pointer: <c>nullptr</c></caption>
+        <title>Using the null pointer: <c>nullptr</c></title>
         <program interactive="activecode" language="cpp" label="NULLexamplecpp-prog"><code>
 //showcases how you can use nullptr
 #include &lt;iostream&gt;

--- a/pretext/Introduction/DefiningFunctions.ptx
+++ b/pretext/Introduction/DefiningFunctions.ptx
@@ -8,7 +8,7 @@
             value you pass into it.</p>
         
         <listing xml:id="timesTwo">
-            <caption><c>timesTwo</c> Function</caption>
+            <title><c>timesTwo</c> Function</title>
             <program interactive="activecode" language="cpp" label="timesTwo-prog"><code>
 #include &lt;iostream&gt;
 using namespace std;
@@ -41,7 +41,7 @@ int main() {
         <p>Let us look at a similar function in <xref ref="timesTwoVoid"/>.</p>
 
         <listing xml:id="timesTwoVoid">
-            <caption><c>timesTwoVoid</c> Function Returns Nothing.</caption>
+            <title><c>timesTwoVoid</c> Function Returns Nothing.</title>
             <program interactive="activecode" language="cpp" label="timesTwoVoid-prog"><code>
 #include &lt;iostream&gt;
 using namespace std;
@@ -82,7 +82,7 @@ int main() {
             marker. Any characters that follow the // on a line are ignored.</p>
         
     <listing xml:id="introduction_lst-root" names="lst_root">
-        <caption>Newton's Method for Calculating Square Roots.</caption>
+        <title>Newton's Method for Calculating Square Roots.</title>
     <program xml:id="newtonsmethod" interactive="activecode" language="cpp" label="newtonsmethod-prog">
         <code>
 #include &lt;iostream&gt;
@@ -170,7 +170,7 @@ void callingFunction() { /*return type int which indicates
                 that calls <c>swap_values(...)</c>.</p>
             
     <listing xml:id="activepassrefcpp">
-        <caption>Pass By Reference Example</caption>
+        <title>Pass By Reference Example</title>
     <program interactive="activecode" language="cpp" label="activepassrefcpp-prog">
         <code>
 #include &lt;iostream&gt;

--- a/pretext/Introduction/Glossary.ptx
+++ b/pretext/Introduction/Glossary.ptx
@@ -419,7 +419,7 @@
                 </gi>
             
         </glossary>
-        <p>
+        <conclusion><p>
             <!-- extra space before the progress bar -->
-        </p>
-    </section>
+        </p></conclusion>
+</section>

--- a/pretext/Introduction/Graphics.ptx
+++ b/pretext/Introduction/Graphics.ptx
@@ -296,7 +296,7 @@ screen.bye();
             <p>Consider the example in <xref ref="lst-cturtle_4"/>.</p>
 
             <listing xml:id="lst-cturtle_4">
-                <caption>Using Turtle Speed Controls</caption>
+                <title>Using Turtle Speed Controls</title>
                 <program xml:id="cturtle_4" interactive="activecode" language="cpp" label="cturtle_4-prog"><code>
 #include &lt;CTurtle.hpp&gt;
 namespace ct = cturtle;
@@ -490,7 +490,7 @@ turtle.shape(&quot;square&quot;);
                 
             </tabular></table>
             <p>Using the default <c>indented_triangle</c> shape as an example, <xref ref="ccpolygon"/> shows the nature of the counter-clockwise order.</p>
-            <figure align="center" xml:id="ccpolygon">
+            <figure xml:id="ccpolygon">
                 <caption>Indented Triangle Definition</caption>
                     <image source="Introduction/cc_polygon.png" width="50%">
                     <description><p>Graphic illustrating an indented triangle with coordinate points. At the top vertex, the point is labeled '0, 0'. The bottom left vertex is labeled '-5, 10', and the bottom right vertex is labeled '5, 10'. An arrow curves above the triangle, indicating rotation or flipping. Each vertex is marked with a green circle. The image defines the shape and position of an indented triangle in a coordinate system.</p></description>
@@ -752,7 +752,7 @@ int main(){
     </choices>
     
         </exercise>
-        <exercise label="cturtle_question_3" indent="show" language="python"><statement>
+        <exercise label="cturtle_question_3" language="python"><statement>
             <p>Construct a program that fills a green triangle using begin_fill and end_fill
                 using the example code above as a guide.</p>
 </statement>

--- a/pretext/Introduction/ObjectOrientedProgrammingDefiningClasses.ptx
+++ b/pretext/Introduction/ObjectOrientedProgrammingDefiningClasses.ptx
@@ -156,7 +156,7 @@ myfraction = Fraction(3, 5)
                 <m>\frac {3}{5}</m> (three-fifths). <xref ref="fig-fraction1cpp"/> shows this
                 object as it is now implemented.</p>
             
-            <figure align="center" xml:id="fig-fraction1cpp">
+            <figure xml:id="fig-fraction1cpp">
                 <caption>An instance of the <c>Fraction</c> Class</caption>
                     <image source="Introduction/fraction1cpp.png" width="50%">
                     <description><p>Diagram showing an instance of the Fraction class. The instance is named 'myfraction' and is depicted as a set of concentric circles. The innermost circle is labeled 'State' and contains two segments: 'num' with the number 3 above 'den' with the number 5, representing the numerator and denominator of a fraction. The middle circle is labeled 'Methods', indicating the functionality associated with the fraction instance.</p></description>
@@ -210,7 +210,7 @@ myfraction = Fraction(3, 5)
                 to give us multiple ways to instantiate an object of a class as shown in <xref ref="frac-poly"/> for
                 the <c>Fraction</c> class.</p>
             <listing xml:id="frac-poly">
-                <caption>Example of Polymorphism</caption>
+                <title>Example of Polymorphism</title>
                 <program language="cpp" label="frac-poly-prog"><code>
 Fraction(int top, int bottom){
     num = top;
@@ -612,7 +612,7 @@ int main(){
                 <m>m</m> evenly, then the answer is the greatest common divisor of
                 <m>n</m> and the remainder of <m>m</m> divided by <m>n</m>. We
                 will simply provide an iterative implementation here (see
-                <inline classes="xref std std-ref">ActiveCode 1</inline>). Note that this implementation of the GCD algorithm only
+                <xref ref="gcdalg"/>). Note that this implementation of the GCD algorithm only
                 works when the denominator is positive. This is acceptable for our
                 fraction class because we have said that a negative fraction will be
                 represented by a negative numerator.</p>
@@ -667,7 +667,7 @@ print(gcd(20,10))
                 <xref ref="introduction_lst-newaddmethod"/>).</p>
             
     <listing xml:id="introduction_lst-newaddmethod">
-        <caption>New addition implementation using <c>gcd</c></caption>
+        <title>New addition implementation using <c>gcd</c></title>
         <program xml:id="gcdadd" label="gcdadd" interactive="activecode" language="cpp"><code>
 #include &lt;iostream&gt;
 using namespace std;
@@ -725,7 +725,7 @@ int main(){
 }
         </code></program>
     </listing>
-            <figure align="center" xml:id="fig-fraction2cpp">
+            <figure xml:id="fig-fraction2cpp">
                 <caption>An Instance of the <c>Fraction</c> Class with Two Methods</caption>
                     <image source="Introduction/fraction2cpp.png" width="50%">
                     <description><p>Visual representation of a Fraction class instance called 'myfraction'. It features concentric circles with the innermost labeled 'State' showcasing 'num' with a value of 3 above 'den' with a value of 5, indicating the fraction's numerator and denominator. The outer circle is labeled 'Methods', suggesting the object's functionality. Two symbols, '&lt;&lt;' and '+', are shown outside the Methods circle, implying additional methods.</p></description>
@@ -890,7 +890,7 @@ y = Fraction(2,3)
 print(x + y)
 print(x == y)
             </code></program></statement></task>
-        </exploration>&gt;
+        </exploration>
         </subsection>
         <subsection xml:id="introduction_self-check">
             <title>Self-Check</title>

--- a/pretext/Introduction/ObjectOrientedProgrammingDerivedClasses.ptx
+++ b/pretext/Introduction/ObjectOrientedProgrammingDerivedClasses.ptx
@@ -17,7 +17,7 @@
             sequential collection). This implies that strings inherit important
             characteristics from sequences, namely the ordering of the underlying
             data and operations such as concatenation, repetition, and indexing.</p>
-        <figure align="center" xml:id="fig-inherit1">
+        <figure xml:id="fig-inherit1">
                 <caption>An Inheritance Hierarchy for C++ Collections</caption>
                     <image source="Introduction/inheritance1.png" width="70%">
                     <description><p>Hierarchy chart showing the classification of C++ containers. The top of the hierarchy is labeled 'C++ Containers', branching into 'Sequence Containers' on the left and 'Associative Containers' on the right. Under 'Sequence Containers', there are three sub-categories: 'Arrays', 'Vectors', and 'Strings'. 'Associative Containers' has a single sub-category labeled 'Unordered Maps'. The layout suggests an inheritance structure where sequence and associative containers are types of C++ containers.</p></description>
@@ -47,7 +47,7 @@
             method from the Base class.</p>
 
         <listing xml:id="virtualfunction">
-            <caption>Virtual function example</caption>
+            <title>Virtual function example</title>
             <program language="cpp" label="virtualfunction-prog"><code>
 #include &lt;iostream&gt;
 using namespace std;
@@ -111,7 +111,7 @@ int main() {
                 values showing the input-to-output mapping that is performed by the
                 gate.</p>
 
-            <figure align="center" xml:id="ooderive_fig-truthtable">
+            <figure xml:id="ooderive_fig-truthtable">
                 <caption>Three Types of Logic Gates</caption>
                     <image source="Introduction/truthtable.png" width="50%">
                     <description><p>Image depicting three types of logic gates and their corresponding truth tables. On the left is the 'AND' gate symbol with a two-input truth table below it, showing outputs of '0' for all inputs except '1' and '1'. The center shows the 'OR' gate symbol with a truth table, displaying '1' when at least one input is '1'. On the right, the 'NOT' gate symbol is presented with a single-input truth table, showing an output inverse to the input.</p></description>
@@ -127,7 +127,7 @@ int main() {
                 result appears at the output of the <term>NOT</term> gate. <xref ref="ooderive_fig-circuit1"/> also
                 shows an example with values.</p>
 
-            <figure align="center" xml:id="ooderive_fig-circuit1">
+            <figure xml:id="ooderive_fig-circuit1">
                 <caption>Circuit</caption>
                     <image source="Introduction/circuit1.png" width="50%">
                     <description><p>Diagram of a logic circuit with labeled gates and sample inputs/outputs. The top part shows two 'AND' gates labeled 'g1' and 'g2' feeding into an 'OR' gate labeled 'g3', which in turn feeds into a 'NOT' gate labeled 'g4'. Below, the same circuit is shown with binary inputs and the resulting outputs: 'AND' gates receiving '0, 1' and '1, 1' inputs with '0' and '1' outputs respectively; the 'OR' gate then combines the two to output '1', which is inverted to '0' by the 'NOT' gate.</p></description>
@@ -145,7 +145,7 @@ int main() {
                 output line. The next level of subclasses breaks the logic gates into
                 two families, those that have one input line and those that have two.
                 Below that, the specific logic functions of each appear.</p>
-            <figure align="center" xml:id="ooderive_fig-circuit0">
+            <figure xml:id="ooderive_fig-circuit0">
                 <caption>Example Logic Circuit</caption>
                 <image source="Introduction/logicquestion.png" width="50%">
                         <description><p>
@@ -157,7 +157,7 @@ int main() {
 
          
     
-    <figure align="center" xml:id="ooderive_fig-gates">
+    <figure xml:id="ooderive_fig-gates">
         <caption>An Inheritance Hierarchy for Logic Gates</caption>
             <image source="Introduction/gates.png" width="50%">
             <description><p>Flowchart representing an inheritance hierarchy for logic gates. The topmost block is labeled 'Logic Gate', which branches down into two categories: 'Binary Gate' and 'Unary Gate'. Under 'Binary Gate', two further blocks represent 'AND' and 'OR' gates, each accompanied by their respective symbols. To the right, under 'Unary Gate', there's a block for the 'NOT' gate with its symbol. The structure implies that 'AND' and 'OR' gates inherit from 'Binary Gate', which along with 'Unary Gate' inherits from 'Logic Gate'.</p></description>
@@ -420,7 +420,7 @@ class AndGate(BinaryGate):
                 Once the values are provided, the correct output is shown.</p>
 
         <listing xml:id="introduction_fig-andusage">
-            <caption><c>AndGate</c> Usage</caption>
+            <title><c>AndGate</c> Usage</title>
             <program label="introduction_fig-andusage-prog"><code>
                 &gt;&gt;&gt; AndGate gand2(&quot;gand2&quot;)
                 &gt;&gt;&gt; gand2.getOutput()
@@ -433,7 +433,7 @@ class AndGate(BinaryGate):
                 0
             </code></program>
         </listing>
-.
+
            <p>The same development can be done for <term>OR</term> gates and <term>NOT</term> gates. The
                 <c>OrGate</c> class will also be a subclass of <c>BinaryGate</c> and the
                 <c>NotGate</c> class will extend the <c>UnaryGate</c> class. Both of these
@@ -444,7 +444,7 @@ class AndGate(BinaryGate):
                 need inputs to be provided). For example:</p>
 
             <listing xml:id="introduction_fig-ornotusage">
-                <caption>Usage of <c>OrGate</c> and <c>NotGate</c></caption>
+                <title>Usage of <c>OrGate</c> and <c>NotGate</c></title>
                 <program label="introduction_fig-ornotusage-prog"><code>
 &gt;&gt;&gt; g2 = OrGate(&quot;G2&quot;)
 &gt;&gt;&gt; g2.getOutput()
@@ -476,7 +476,7 @@ Enter Pin input for gate G3-&gt;0
                     Relationship</term>. Recall earlier that we used the phrase <q>IS-A
                 Relationship</q> to say that a child class is related to a parent class,
                 for example <c>UnaryGate</c> IS-A <c>LogicGate</c>.</p>
-        <figure align="center" xml:id="ooderive_fig-connector">
+        <figure xml:id="ooderive_fig-connector">
                 <caption>A Connector Connects the Output of One Gate to the Input of Another</caption>
                 <image source="Introduction/connector.png" width="50%">
                 <description><p>Diagram showing two logic gate symbols, 'AND' and 'OR', connected by a line labeled 'connector'. The 'AND' gate is on the left with an arrow pointing from its output to the 'connector'. Another arrow extends from the 'connector' to the input of the 'OR' gate on the right. This illustrates how the output of one gate serves as the input to another.</p></description>
@@ -499,7 +499,7 @@ Enter Pin input for gate G3-&gt;0
                 that each <c>togate</c> can choose the proper input line for the
                 connection.</p>
       
-            <figure align="center" xml:id="ooderive_fig-desired-circuit">
+            <figure xml:id="ooderive_fig-desired-circuit">
                 <caption>Circit of NOT(AND(ganda,gnadb)OR AND(gandc,gandd))</caption>
                     <image source="Introduction/desired_circuit.png" width="80%">
                     <description><p>Circuit diagram illustrating a logical expression with labeled components. Two 'AND' gates, labeled 'gand1' and 'gand2', are connected to an 'OR' gate labeled 'gor3' via lines labeled 'connector'. The output of 'gor3' is then fed into a 'NOT' gate labeled 'gnot4'. The connections suggest the logical operation NOT(AND(a,b)) OR AND(c,d).</p></description>
@@ -507,7 +507,7 @@ Enter Pin input for gate G3-&gt;0
                 </figure>
 
             <listing xml:id="ooderive_program">
-                <caption>Using the <c>Connector</c> Class</caption>
+                <title>Using the <c>Connector</c> Class</title>
                 <program interactive="activecode" language="cpp" label="ooderive_program-prog"><code>
 #include &lt;iostream&gt;
 #include &lt;string&gt;


### PR DESCRIPTION
# Description
minor fixes to xml for ch1:
 - align=center is not valid in pretext
 - caption should be title in most cases
(btw, nxml-mode in emacs is really cool... it highlights xml errors if you specify a validation schema... it's not perfect, but it's pretty good)

## Related Issue
standalone

## How Has This Been Tested?
local build
