### PR TITLE
xml fixes: m attrs, algn=center not a thing, s/caption/title/ (recursion chapter)

### DIFF
--- a/pretext/Recursion/DynamicProgramming.ptx
+++ b/pretext/Recursion/DynamicProgramming.ptx
@@ -46,7 +46,7 @@
             amount minus ten cents, and so on. So the number of coins needed to make
             change for the original amount can be computed according to the
             following:</p>
-        <m docname="Recursion/DynamicProgramming" nowrap="False" number="True" xml:space="preserve">numCoins =
+        <m>numCoins =
  min
  \begin{cases}
  1 + numCoins(original amount - 1) \\
@@ -143,7 +143,7 @@ main()
             Clearly we are wasting a lot of time and effort recalculating old
             results.</p>
         
-        <figure align="center" xml:id="fig-c1ctcpp">
+        <figure xml:id="fig-c1ctcpp">
             <caption>Call Tree for <xref ref="lst-change1-cpp"/></caption>
                 <image source="Recursion/callTree.png" width="80%">
                 <description><p>Diagram of a call tree for a recursive process, as seen in <xref ref="lst-change1-cpp"/>.
@@ -293,14 +293,14 @@ main()
         <p>Either option 1 or 3 will give us a total of two coins which is the
             minimum number of coins for 11 cents.</p>
         
-        <figure align="center" xml:id="fig-dpcoins">
+        <figure xml:id="fig-dpcoins">
             <caption>Minimum Number of Coins Needed to Make.</caption>
                 <image source="Recursion/changeTable.png" width="80%">
                 <description><p>Image of a table representing the minimum number of coins needed to make change. The columns are labeled with the 'Change to Make' values from 1 to 11. The rows correspond to 'Steps of the Algorithm', with each cell filled with the minimum number of coins needed at that step for the corresponding amount of change. Initial rows are partially filled with increasing sequences of numbers, indicating the progression of the algorithm. The bottom rows are blurred and continue with an ellipsis, suggesting the continuation of the process beyond what is shown. </p></description>
                 </image>
             </figure>
         
-        <figure align="center" xml:id="fig-eleven">
+        <figure xml:id="fig-eleven">
             <caption>Three Options to Consider for the Minimum Number of Coins for Eleven Cents.</caption>
                 <image source="Recursion/elevenCents.png" width="80%">
                 <description><p>Image of a curved numerical table representing three options to calculate the minimum number of coins for eleven cents. The table is labeled with numbers from 1 to 5 corresponding to the counts of coins used. Below the table, there are three curved arrows pointing to the number '11' from '11-1', '11-5', and '11-10', indicating the subtraction of 1, 5, and 10 cents from 11 cents to determine the next step in the calculation. The last cell under '11' is labeled with '??' to indicate the unknown minimum number of coins needed.</p></description>

--- a/pretext/Recursion/ExploringaMaze.ptx
+++ b/pretext/Recursion/ExploringaMaze.ptx
@@ -215,7 +215,7 @@ def searchFrom(maze, startRow, startColumn):
             For the data file in <xref ref="lst-exmaze"/> the
             internal representation looks like the following:</p>
         <listing xml:id="lst-exmaze">
-            <caption>Example Maze</caption>
+            <title>Example Maze</title>
             <program language="cpp" label="lst-exmaze-prog"><code>
 {
     &quot;++++++++++++++++++++++&quot;,

--- a/pretext/Recursion/StackFramesImplementingRecursion.ptx
+++ b/pretext/Recursion/StackFramesImplementingRecursion.ptx
@@ -79,7 +79,7 @@ main()
             that now we can simply pop the characters off the stack and concatenate
             them into the final result, <c>&quot;1010&quot;</c>.</p>
         
-        <figure align="center" xml:id="fig-recstack">
+        <figure xml:id="fig-recstack">
             <caption>Strings Placed on the Stack During Conversion.</caption>
                 <image source="Recursion/recstack.png" width="50%">
                 <description><p>Image of a stack with character strings representing the result of a conversion process. The stack shows four blocks, each containing a single character. From top to bottom, the blocks are labeled '1', '0', '1', and '0', aligned vertically above a horizontal line that represents the base of the stack. This illustrates the sequence of characters placed on the stack during a number conversion, presumably from a recursive process.</p></description>
@@ -93,7 +93,7 @@ main()
             the calling function to access. <xref ref="fig-callstack"/> illustrates the
             call stack after the return statement on line 4.</p>
         
-        <figure align="center" xml:id="fig-callstack">
+        <figure xml:id="fig-callstack">
             <caption>Call Stack Generated from <c>toStr(10,2).</c></caption>
                 <image source="Recursion/newcallstack.png" width="50%">
                 <description><p>Diagram illustrating a call stack generated from the function toStr(10,2), which converts the number 10 into a base 2 string. The bottom of the stack shows 'toStr(10/2, 2) + convertString[10%2]', then above it 'toStr(5,2) n = 5 base = 2' with 'toStr(5/2,2) + convertString[5%2]', followed by 'toStr(2,2) n = 2 base = 2' and at the top 'toStr(2/2,2) + convertString[2%2]'. A single character '1' floats above the stack, indicating the start of the conversion process.</p></description>

--- a/pretext/Recursion/TheThreeLawsofRecursion.ptx
+++ b/pretext/Recursion/TheThreeLawsofRecursion.ptx
@@ -52,7 +52,7 @@
             of recursive functions are largely dependent on how they're implemented.</p>
 
     <listing xml:id="ackermann">
-        <caption>Ackermann Function</caption>
+        <title>Ackermann Function</title>
         <program interactive="activecode" language="cpp" label="ackermann-prog"><code>
 //ackermann function example
 #include &lt;iostream&gt;

--- a/pretext/Recursion/TowerofHanoi.ptx
+++ b/pretext/Recursion/TowerofHanoi.ptx
@@ -23,7 +23,7 @@
             this puzzle before, you should try it now. You do not need fancy disks
             and poles<ndash/>a pile of books or pieces of paper will work.</p>
         
-        <figure align="center" xml:id="fig-hanoicpp">
+        <figure xml:id="fig-hanoicpp">
             <caption>An Example Arrangement of Disks for the Tower of Hanoi.</caption>
                 <image source="Recursion/hanoi.png" width="80%">
                 <description><p>Image depicting the initial setup of the Tower of Hanoi puzzle. It shows three vertical poles labeled 'fromPole', 'withPole', and 'toPole' on a horizontal base. The 'fromPole' has three disks stacked on it, with the largest at the bottom and the smallest at the top, while the other two poles are empty. This is a classic configuration for the start of the puzzle, which involves moving the disks to another pole under certain rules.</p></description>
@@ -73,7 +73,7 @@
             Tower of Hanoi puzzle.</p>
         
         <listing xml:id="lst-movetower">
-            <caption><c>moveTower</c> Function</caption>
+            <title><c>moveTower</c> Function</title>
             <program language="cpp" label="lst-movetower-prog"><code>
 int moveTower(int height, char fromPole, char toPole, char withPole){
     if (height &gt;= 1){

--- a/pretext/Recursion/pythondsCalculatingtheSumofaListofNumbers.ptx
+++ b/pretext/Recursion/pythondsCalculatingtheSumofaListofNumbers.ptx
@@ -151,7 +151,7 @@ main()
             recursive call we are solving a smaller problem, until we reach the
             point where the problem cannot get any smaller.</p>
 
-        <figure align="center" xml:id="fig-recsumin">
+        <figure xml:id="fig-recsumin">
             <caption>Series of Recursive Calls Adding a List of Numbers.</caption>
                 <image source="Recursion/sumlistIn.png" width="50%">
                 <description><p>Stacked visualization of recursive function calls to sum a list of numbers. The top box shows 'sum(1,3,5,7,9)' with an arrow pointing to '1 +'. The next box down shows 'sum(3,5,7,9)' with an arrow pointing to '3 +', followed by boxes for 'sum(5,7,9)' with '5 +', 'sum(7,9)' with '7 +', and the last box 'sum(9)' with just '9'. Each box is connected to the next, representing the recursive nature of the calls.</p></description>
@@ -166,7 +166,7 @@ main()
             through the series of calls. When <c>vectsum</c> returns from the topmost
             problem, we have the solution to the whole problem.</p>
         
-        <figure align="center" xml:id="fig-recsumout">
+        <figure xml:id="fig-recsumout">
             <caption>Series of Recursive Returns from Adding a List of Numbers.</caption>
                 <image source="Recursion/sumlistOut.png" width="50%">
                 <description><p>Diagram illustrating the resolution of recursive function calls summing a list of numbers. The bottom box shows 'sum(9)' equaling '9', with an arrow pointing left to the next box 'sum(7,9)' showing '7 + 9'. Above that, 'sum(5,7,9)' equals '5 + 16', then 'sum(3,5,7,9)' with '3 + 21', and at the top, 'sum(1,3,5,7,9)' resulting in '1 + 24'. Each function call resolves to a value that is used in the computation of the previous call, with the final sum at the top being '25'.</p></description>

--- a/pretext/Recursion/pythondsConvertinganIntegertoaStringinAnyBase.ptx
+++ b/pretext/Recursion/pythondsConvertinganIntegertoaStringinAnyBase.ptx
@@ -51,7 +51,7 @@
             the numbers we want to remember are in the remainder boxes along the
             right side of the diagram.</p>
         
-        <figure align="center" xml:id="fig-tostr">
+        <figure xml:id="fig-tostr">
             <caption>Converting an Integer to a String in Base 10.</caption>
                 <image source="Recursion/toStr.png" width="50%">
                 <description><p>Flowchart demonstrating the conversion of an integer to a string in base 10 using recursion. The process starts with 'toStr(769)', which divides '769' by '10' and adds the remainder 'g'. The result feeds into 'toStr(76)', which again divides by '10' to add the remainder '6'. The final call is 'toStr(7)', which is less than '10' and therefore converts directly to '7'. The remainders at each step are used to build the string representation of the integer.</p></description>
@@ -113,7 +113,7 @@ main()
         <p>Let's trace the algorithm again; this time we will convert the number 10
             to its base 2 string representation (<c>&quot;1010&quot;</c>).</p>
     
-        <figure align="center" xml:id="fig-tostr2">
+        <figure xml:id="fig-tostr2">
             <caption>Converting the Number 10 to its Base 2 String Representation.</caption>
                 <image source="Recursion/toStrBase2.png" width="50%">
                 <description><p>Flowchart depicting the recursive process of converting the number 10 to its binary (base 2) string representation. The topmost operation 'toStr(10)' shows the division '10 / 2' with a remainder '0'. This leads to 'toStr(5)', with division '5 / 2' and remainder '1', followed by 'toStr(2)' with division '2 / 2' and remainder '0', and finally 'toStr(1)' indicating '1 &lt; 2' and yielding a remainder '1'. The remainders collected at each step form the binary representation of the number 10.</p></description>

--- a/pretext/Recursion/pythondsProgrammingExercises.ptx
+++ b/pretext/Recursion/pythondsProgrammingExercises.ptx
@@ -82,10 +82,8 @@
             </li>
             <li>
                 <p>Pascal's triangle is a number triangle with numbers arranged in
-                    staggered rows such that</p>
-                <m docname="Recursion/pythondsProgrammingExercises" nowrap="False" number="True" xml:space="preserve">a_{nr} = {n! \over{r! (n-r)!}}
-
-</m>
+                    staggered rows such that
+                    <me>a_{nr} = {n! \over{r! (n-r)!}}</me></p>
                 <p>This equation is the equation for a binomial coefficient. You can
                     build Pascal's triangle by adding the two numbers that are diagonally
                     above a number in the triangle. An example of Pascal's triangle is

--- a/pretext/Recursion/pythondsSierpinskiTriangle.ptx
+++ b/pretext/Recursion/pythondsSierpinskiTriangle.ptx
@@ -13,7 +13,7 @@
             sharp enough pencil. Before you continue reading, you may want to try
             drawing the Sierpinski triangle yourself, using the method described.</p>
         
-        <figure align="center" xml:id="fig-sierpinski">
+        <figure xml:id="fig-sierpinski">
             <caption>The Sierpinski Triangle.</caption>
                 <image source="Recursion/sierpinski.png" width="50%">
                 <description><p>Image of the Sierpinski Triangle, a fractal composed of colored triangles. 
@@ -160,7 +160,7 @@ main()
             triangles. The function finishes drawing one level at a time; once it is
             finished with the bottom left it moves to the bottom middle, and so on.</p>
         
-        <figure align="center" xml:id="fig-stcalltree">
+        <figure xml:id="fig-stcalltree">
             <caption>Building a Sierpinski Triangle.</caption>
                 <image source="Recursion/stCallTree.png" width="50%">
                 <description><p>Diagram showing the recursive construction of a Sierpinski Triangle using a tree structure. The diagram starts with a single top circle labeled 'top', branching out into three interconnected circles labeled 'left', 'top', and 'right'. Each of these circles further branches out in a similar pattern, with the process repeating for several iterations. The circles decrease in size from top to bottom, representing the fractal's recursive nature. The grayscale shading of the circles suggests depth or iteration levels.</p></description>

--- a/pretext/Recursion/pythondsintro-VisualizingRecursion.ptx
+++ b/pretext/Recursion/pythondsintro-VisualizingRecursion.ptx
@@ -116,7 +116,7 @@ main()
             getting too small. The C++ equivalent to this function is shown below and exists in <q>Turtle.cpp</q>.</p>
 
         <listing xml:id="lst-fractree-py" names="lst_fractree">
-            <caption>Fractal Tree</caption>
+            <title>Fractal Tree</title>
             <program language="python" label="lst-fractree-py-prog"><code>
 def tree(branchLen,t):
     if branchLen &gt; 5:
@@ -221,14 +221,14 @@ main()
             right side of the left tree is drawn until we finally make our way out
             to the smallest twig on the left.</p>
         
-        <figure align="center" xml:id="fig-tree1">
+        <figure xml:id="fig-tree1">
             <caption>The Beginning of a Fractal Tree.</caption>
                 <image source="Recursion/tree1.png" width="50%">
                 <description><p>Screenshot of a computer window titled 'Python Turtle Graphics' showing the initial stage of a fractal tree drawing. The window displays a simple black curve on a white background, representing the trunk of the tree starting to branch off. This image captures the first step in a programming exercise to draw a complex fractal tree using recursive functions.</p></description>
                 </image>
             </figure>
 
-        <figure align="center" xml:id="fig-tree2">
+        <figure xml:id="fig-tree2">
             <caption>The First Half of the Tree.</caption>
                 <image source="Recursion/tree2.png" width="50%">
                 <description><p>Screenshot of a computer window with the title 'Python Turtle Graphics', depicting a partially completed fractal tree drawing. The graphic shows a black tree with a simple trunk that splits into several branching limbs and smaller branches, all rendered on a white background. The image visually represents the midpoint of a recursive drawing process in programming, with the tree structure becoming increasingly complex towards the top.</p></description>


### PR DESCRIPTION
# Description
simple xml fixes: <m> doesn't have an attrs, s/caption/title, and align=center isn't a pretext thing

## Related Issue
standalone

## How Has This Been Tested?
local build