### PR TITLE
xml fixes: alg analysis chapter

### DIFF
--- a/pretext/AlgorithmAnalysis/BigONotation.ptx
+++ b/pretext/AlgorithmAnalysis/BigONotation.ptx
@@ -158,7 +158,7 @@
         definite relationship and it is easy to see how they compare with one
         another.</p>
     
-    <figure align="center" xml:id="fig-graphfigurecpp">
+    <figure xml:id="fig-graphfigurecpp">
         <caption>Common Big-O Functions</caption>
             <image source="AlgorithmAnalysis/newplot.png" width="50%">
                 <description><p>This figure shows graphs of the common functions from <xref ref="algorithm-analysis_algorithm-analysis_tbl-fntablecpp"/>.
@@ -235,7 +235,7 @@ main()
         the other terms as well as the coefficient on the dominant term can be
         ignored as <em>n</em> grows larger.</p>
     
-    <figure align="center" xml:id="fig_graphfigure2cpp">
+    <figure xml:id="fig_graphfigure2cpp">
         <caption>Comparing <m>T(n)</m> with Big-O Functions</caption>
             <image source="AlgorithmAnalysis/newplot2.png" width="50%">
                 <description><p>This figure shows a few of the common Big-O functions as they compare with the T(n) function discussed above. Note that T(n) is initially larger than the cubic function. However, as n grows, the cubic function quickly overtakes T(n). It is easy to see that T(n) then follows the quadratic function as n continues to grow.</p></description>
@@ -309,7 +309,7 @@ Reading Questions
     
     </exercise>
 
-    <exercise label="parsonsBigO" indent="show" language="python"><statement>
+    <exercise label="parsonsBigO" language="python"><statement>
         <p>Without looking at the graph above, from top to bottom order the following from most to least efficient.</p>
     </statement>
     <blocks><block order="1">

--- a/pretext/AlgorithmAnalysis/HashTableAnalysis.ptx
+++ b/pretext/AlgorithmAnalysis/HashTableAnalysis.ptx
@@ -104,12 +104,15 @@
         whether or not a number is in the hash table is not only much faster,
         but the time it takes to check should remain constant even as the
         hash table grows larger.</p>
-    <p><inline classes="xref std std-ref">Listing 6</inline> implements this comparison. Notice that we are
+    <p><xref ref="expl-hashtable-analysis"/> implements this comparison. Notice that we are
         performing exactly the same operation, <c>number in container</c>. The
         difference is that on line 7 <c>x</c> is vector, and on line 9 <c>x</c> is a
         hash table.</p>
-    <p><term>Listing 6</term></p>
-    <program language="cpp" label="HashTableAnalysis-prog"><code>
+    <exploration xml:id="expl-hashtable-analysis">
+        <title>Hash Table Analysis</title>
+        <task xml:id="lst-hashtable-analysis-cpp">
+            <title>C++ Implementation</title>
+            <statement><program language="cpp" label="HashTableAnalysis-prog"><code>
 #include &lt;iostream&gt;
 #include &lt;ctime&gt;
 #include &lt;vector&gt;
@@ -143,8 +146,11 @@ for(int a = 10000; a &lt; 1000001; a = a + 20000) {
 
 return 0;
 }
-</code></program>
-    <program language="python" label="HashTableAnalysis-prog-2"><code>
+            </code></program></statement>
+        </task>
+        <task xml:id="lst-hashtable-analysis-py">
+            <title>Python Implementation</title>
+            <statement><program language="python" label="HashTableAnalysis-prog-2"><code>
 import timeit
 import random
 
@@ -156,9 +162,11 @@ lst_time = t.timeit(number=1000)
 x = {j:None for j in range(i)}
 d_time = t.timeit(number=1000)
 print(&quot;%d,%10.3f,%10.3f&quot; % (i, lst_time, d_time))
-</code></program>
+            </code></program></statement>
+        </task>
+    </exploration>
     <p><xref ref="fig-vectvshash-cpp"/> summarizes the results of running
-        <inline classes="xref std std-ref">Listing 6</inline>. You can see that the hash table is consistently
+        <xref ref="expl-hashtable-analysis"/>. You can see that the hash table is consistently
         faster. For the smallest vector size of 10,000 elements a hash table is
         89.4 times faster than a vector. For the largest vector size of 990,000
         elements the hash table is 11,603 times faster! You can also see that
@@ -170,7 +178,7 @@ print(&quot;%d,%10.3f,%10.3f&quot; % (i, lst_time, d_time))
         contains operation took 0.004 milliseconds and for the hash table size
         of 990,000 it also took 0.004 milliseconds.</p>
 
-    <figure align="center" xml:id="fig-vectvshash-cpp">
+    <figure xml:id="fig-vectvshash-cpp">
         <caption>Comparing the <c>in</c> Operator for C++ vectors and Hash Tables</caption>
             <image source="AlgorithmAnalysis/vectvshash.png" width="50%">
                 <description><p>This figure summarizes the results of running Listing 6. You can see that the hash table is consistently faster. For the smallest vector size of 10,000 elements a hash table is 89.4 times faster than a vector. For the largest vector size of 990,000 elements the hash table is 11,603 times faster! You can also see that the time it takes for the contains operator on the vector grows linearly with the size of the vector. This verifies the assertion that the contains operator on a vector is . It can also be seen that the time for the contains operator on a hash table is constant even as the hash table size grows. In fact for a hash table size of 10,000 the contains operation took 0.004 milliseconds and for the hash table size of 990,000 it also took 0.004 milliseconds.</p></description>

--- a/pretext/AlgorithmAnalysis/StringAnalysis.ptx
+++ b/pretext/AlgorithmAnalysis/StringAnalysis.ptx
@@ -126,7 +126,7 @@
                 
             
         </tabular></table>
-        <p>Just like vectors, the <title_reference>push_back()</title_reference> operation is <m>O(1)</m> unless there is inadequate capacity,
+        <p>Just like vectors, the <c>push_back()</c> operation is <m>O(1)</m> unless there is inadequate capacity,
             in which case the entire
             string is moved to a larger contiguous underlying array, which
             is <m>O(n)</m>.</p>

--- a/pretext/AlgorithmAnalysis/VectorAnalysis.ptx
+++ b/pretext/AlgorithmAnalysis/VectorAnalysis.ptx
@@ -37,7 +37,7 @@
             making our vector.</p>
         
         <listing xml:id="ls_mkvectcpp">
-            <caption>Using <c>push_back()</c></caption>
+            <title>Using <c>push_back()</c></title>
             <program language="cpp" label="ls_mkvectcpp-prog"><code>
 #include &lt;iostream&gt;
 #include &lt;vector&gt;
@@ -69,7 +69,7 @@ int main() {
             of our test functions 10,000 times within a <c>for</c> loop.</p>
 
     <listing xml:id="lst-vectcpp2">
-        <caption>Timing <c>push_back()</c></caption>
+        <title>Timing <c>push_back()</c></title>
         <program xml:id="vectcpp2" interactive="activecode" language="cpp" label="vectcpp2-prog"><code>
 #include &lt;iostream&gt;
 #include &lt;vector&gt;
@@ -107,7 +107,7 @@ int main(){
             adequately sized space in memory.</p>
 
     <listing xml:id="lst-vectcpp3">
-        <caption>Reserved Versus Unreserved <c>push_back()</c></caption>
+        <title>Reserved Versus Unreserved <c>push_back()</c></title>
         <program xml:id="vectcpp3" interactive="activecode" language="cpp" label="vectcpp3-prog"><code>
 #include &lt;iostream&gt;
 #include &lt;vector&gt;
@@ -293,7 +293,7 @@ int main(){
             that the vector is decreasing in size by 1 each time through the loop.</p>
         
     <listing xml:id="lst_popmeascpp">
-        <caption>Timing of <c>push_back</c> Versus <c>erase</c></caption>
+        <title>Timing of <c>push_back</c> Versus <c>erase</c></title>
         <program xml:id="popbackvserase" interactive="activecode" language="cpp" label="popbackvserase-prog">
             <code>
 #include &lt;iostream&gt;

--- a/pretext/AlgorithmAnalysis/WhatIsAlgorithmAnalysis.ptx
+++ b/pretext/AlgorithmAnalysis/WhatIsAlgorithmAnalysis.ptx
@@ -227,7 +227,7 @@ main()
         required for the calculation.</p>
     <p>Consider the following code block:</p>
     <listing xml:id="n1000-how-many">
-        <caption>How many times?</caption>
+        <title>How many times?</title>
         <program language="cpp" label="n1000-how-many-prog"><code>
 int n = 1000;
 int theSum = 0;
@@ -245,13 +245,13 @@ for (int i=0; i&lt;n+1; i++){
             much like a mathematical loop typically with a counter.</p>
         <p>If we have
             <m>\sum_{i=1}^{5}</m>
-            the bottom index <title_reference>i=1</title_reference> tells us that the index <title_reference>i</title_reference> begins at 1
-            and that <title_reference>i</title_reference> will terminate at <title_reference>5</title_reference>.</p>
+            the bottom index <m>i=1</m> tells us that the index <m>i</m> begins at 1
+            and that <m>i</m> will terminate at <m>5</m>.</p>
         <p>What ever comes immediately afterwards is what
             we are summing. So,
             <m>\sum_{i=1}^{5} i</m>
             tells us to add the integers <m>1+2+3+4+5</m>
-            because just like in a <title_reference>for</title_reference> loop, we plug a value for each <title_reference>i</title_reference> value.
+            because just like in a <c>for</c> loop, we plug a value for each <m>i</m> value.
             Similarly, <m>\sum_{i=2}^{4} i^2</m> means <m>2^2+3^2+4^2</m>.</p>
 
 
@@ -262,10 +262,10 @@ for (int i=0; i&lt;n+1; i++){
             Let's consider the blue area in the
             following <m>8 \times 9</m>.rectangle.</p>
 
-        <figure align="center" xml:id="fig-sumof-n-integers">
-            <caption>Sum of <title_reference>n = 8</title_reference> integers</caption>
+        <figure xml:id="fig-sumof-n-integers">
+            <caption>Sum of <m>n = 8</m> integers</caption>
                 <image source="AlgorithmAnalysis/sumof-n-integers.png" width="50%">
-                    <description>This figure illustrates the sum of eight integers (Figure 1). Examining the blue area within the rectangle highlights various problem-solving approaches. The visual representation provides clarity, showcasing the intricacies involved in calculating the sum and emphasizing the value of diverse perspectives in mathematical problem-solving.</description>
+                    <description><p>This figure illustrates the sum of eight integers (Figure 1). Examining the blue area within the rectangle highlights various problem-solving approaches. The visual representation provides clarity, showcasing the intricacies involved in calculating the sum and emphasizing the value of diverse perspectives in mathematical problem-solving.</p></description>
                 </image>
         </figure>
 
@@ -277,12 +277,12 @@ for (int i=0; i&lt;n+1; i++){
             half of the rectangle.
             So, the area with blue squares
             is also just <m>\sum_{i=1}^{8} i = \frac {(8)(8+1)}{2}</m>.</p>
-        <p>Hence, when we have a variable <title_reference>n</title_reference>, we have learned that we can just use the
+        <p>Hence, when we have a variable <m>n</m>, we have learned that we can just use the
             closed equation <m>\sum_{i=1}^{n} i = \frac {(n)(n+1)}{2}</m> to
             compute the sum of the first <c>n</c> integers without iterating.</p>
         <p>Consider the function in <xref ref="sum-of-n3"/>.</p>
         <listing xml:id="sum-of-n3">
-            <caption><c>sumOfN3</c></caption>
+            <title><c>sumOfN3</c></title>
             <program language="cpp" label="sum-of-n3-prog"><code>
 int sumOfN3(int n){
   int sum_n = (n*(n+1))/2; // how many times?


### PR DESCRIPTION
# Description
minor xml fixes for the alg analysis chapter
- align=center is not a thing
- remove manual reference to Listing 6
- indent=show is not a thing
- title_reference is not a thing

## Related Issue
standalone

## How Has This Been Tested?
local build