### PR TITLE
xml fixes for linked chapters

### DIFF
--- a/pretext/LinearBasic/BalancedSymbolsGeneralCase.ptx
+++ b/pretext/LinearBasic/BalancedSymbolsGeneralCase.ptx
@@ -163,9 +163,7 @@ main()
             uses for stacks exist in computer science. We will continue to explore them
             in the next sections.</p>
 <reading-questions xml:id="rq-balanced-sybols">
-  <title>
-    <p>Reading Question</p>
-  </title>
+  <title>Reading Question</title>
   <exercise label="stackclick">
     <statement><p>Using the program below, click on the line of code that adds an open parenthesis to the stack.</p></statement>
     <feedback><p>Remember that the function to do this would be the push function.</p></feedback>

--- a/pretext/LinearBasic/ConvertingDecimalNumberstoBinaryNumbers.ptx
+++ b/pretext/LinearBasic/ConvertingDecimalNumberstoBinaryNumbers.ptx
@@ -31,7 +31,7 @@
             reversal property that signals that a stack is likely to be the
             appropriate data structure for solving the problem.</p>
         
-        <figure align="center" xml:id="fig-decbin">
+        <figure xml:id="fig-decbin">
             <caption>Decimal-to-Binary Conversion</caption>
             <image source="LinearBasic/dectobin.png" width="50%"> 
                 <description>

--- a/pretext/LinearBasic/InfixPrefixandPostfixExpressions.ptx
+++ b/pretext/LinearBasic/InfixPrefixandPostfixExpressions.ptx
@@ -267,7 +267,7 @@
                 and the matching left parenthesis were removed, the complete postfix
                 expression would result (see <xref ref="xfix_fig-moveright"/>).</p>
             
-            <figure align="center" xml:id="xfix_fig-moveright">
+            <figure xml:id="xfix_fig-moveright">
                 <caption>Moving Operators to the Right for Postfix Notation</caption>
                 <image source="LinearBasic/moveright.png" width="50%"> 
                     <description>
@@ -283,7 +283,7 @@
                 (see <xref ref="xfix_fig-moveleft"/>). The position of the parenthesis pair is
                 actually a clue to the final position of the enclosed operator.</p>
             
-            <figure align="center" xml:id="xfix_fig-moveleft">
+            <figure xml:id="xfix_fig-moveleft">
                 <caption>Moving Operators to the Left for Prefix Notation</caption>
                 <image source="LinearBasic/moveleft.png" width="50%"> 
                     <description>
@@ -303,7 +303,7 @@
                 <xref ref="xfix_fig-complexmove"/> shows the conversion to postfix and prefix
                 notations.</p>
             
-            <figure align="center" xml:id="xfix_fig-complexmove">
+            <figure xml:id="xfix_fig-complexmove">
                 <caption>Converting a Complex Expression to Prefix and Postfix Notations</caption>
                 <image source="LinearBasic/complexmove.png" width="50%">
                     <description>
@@ -312,9 +312,9 @@
                         At the center, the fully parenthesized infix expression is displayed: (((A + B) * C) - ((D - E) * (F + G))). 
                         Two arrows branch out from the central expression. The first arrow points to the prefix notation, 
                         where the operators are moved to the left of their operands, resulting in:
-                        <math display="inline">-*+A B C *-D E +F G</math>. 
+                        <m>-*+A B C *-D E +F G</m>. 
                         The second arrow points to the postfix notation, where the operators are moved to the right of their operands, resulting in:
-                        <math display="inline">A B + C * D E - F G + * -</math>. 
+                        <m>A B + C * D E - F G + * -</m>. 
                         This image demonstrates how to systematically rearrange operators based on the desired notation by using the position of parentheses as a guide.
  
                     </p>
@@ -421,7 +421,7 @@
                 of the infix expression the stack is popped twice, removing both
                 operators and placing + as the last operator in the postfix expression.</p>
             
-            <figure align="center" xml:id="xfix_fig-intopost">
+            <figure xml:id="xfix_fig-intopost">
                 <caption>Converting A * B + C * D to Postfix Notation</caption>
                 <image source="LinearBasic/intopost.png" width="50%">
                     <description>
@@ -608,7 +608,7 @@ main()
                 <xref ref="xfix_fig-evalpost1"/> shows the stack contents as this entire example
                 expression is being processed.</p>
             
-            <figure align="center" xml:id="xfix_fig-evalpost1">
+            <figure xml:id="xfix_fig-evalpost1">
                 <caption>Stack Contents During Evaluation</caption>
                 <image source="LinearBasic/evalpostfix1.png" width="50%"> 
                     <description>
@@ -634,7 +634,7 @@ main()
                 <m>15/5</m> is not the same as <m>5/15</m>, we must be sure that
                 the order of the operands is not switched.</p>
             
-            <figure align="center" xml:id="xfix_fig-evalpost2">
+            <figure xml:id="xfix_fig-evalpost2">
                 <caption>A More Complex Example of Evaluation</caption>
                 <image source="LinearBasic/evalpostfix2.png" width="50%"> 
                     <description>
@@ -789,7 +789,7 @@ main()
         Reading Questions
     </title>
 
-                <exercise label="question1_100_4" indent="show" language="python"><statement>
+                <exercise label="question1_100_4" language="python"><statement>
                     <p>What does the prefix expression of this infix expression look like: ((A+B)*(C-D)) if this were modeled using a stack with the top being the end of the expression and the bottom being the beginning of the expression?</p>
         </statement>
         <blocks><block order="1">

--- a/pretext/LinearBasic/PalindromeChecker.ptx
+++ b/pretext/LinearBasic/PalindromeChecker.ptx
@@ -13,7 +13,7 @@
             the first character of the string and the rear of the deque will hold
             the last character (see <xref ref="fig-palindrome"/>).</p>
         
-        <figure align="center" xml:id="fig-palindrome">
+        <figure xml:id="fig-palindrome">
             <caption>A Deque</caption>
             <image source="LinearBasic/palindromesetup.png" width="50%">
                 <description><p>
@@ -116,7 +116,7 @@ main()
         <p><xref ref="advanced-linear-basic_palinedrome-cpp"/>.</p>
         
         <listing xml:id="advanced-linear-basic_palinedrome-cpp">
-            <caption>Advanced Palindrome Checker</caption>
+            <title>Advanced Palindrome Checker</title>
             <program xml:id="advanced_palinedrome_cpp" interactive="activecode" language="cpp" label="advanced_palinedrome_cpp-prog"><code>
 //program that detects palindromes.
 

--- a/pretext/LinearBasic/SimulationHotPotato.ptx
+++ b/pretext/LinearBasic/SimulationHotPotato.ptx
@@ -9,7 +9,7 @@
             (the potato) is removed from the circle. Play continues until only one
             child is left.</p>
         
-        <figure align="center" xml:id="fig-quhotpotato">
+        <figure xml:id="fig-quhotpotato">
             <caption>A Six Person Game of Hot Potato</caption>
             <image source="LinearBasic/hotpotato.png" width="50%"> 
                 <description>
@@ -50,7 +50,7 @@
             permanently and another cycle will begin. This process will continue
             until only one name remains (the size of the queue is 1).</p>
         
-        <figure align="center" xml:id="fig-qupotatoqueue">
+        <figure xml:id="fig-qupotatoqueue">
             <caption>A Queue Implementation of Hot Potato</caption>
             <image source="LinearBasic/namequeue.png" width="50%"> 
                 <description>

--- a/pretext/LinearBasic/SimulationPrintingTasks.ptx
+++ b/pretext/LinearBasic/SimulationPrintingTasks.ptx
@@ -27,7 +27,7 @@
             to be printed. This is equal to the average amount of time a task waits
             in the queue.</p>
         
-        <figure align="center" xml:id="fig-qulabsim">
+        <figure xml:id="fig-qulabsim">
             <caption>Computer Science Laboratory Printing Queue</caption>
             <image source="LinearBasic/simulationsetup.png" width="50%"> 
                 <description>
@@ -127,7 +127,7 @@
                 the printer to idle (line 11) if the task is completed.</p>
 
             <listing xml:id="linear-basic_lst-printer">
-                <caption>The <c>Printer</c> class</caption>
+                <title>The <c>Printer</c> class</title>
                 <program language="cpp" label="linear-basic_lst-printer-prog"><code>
 class Printer {
 public:
@@ -185,7 +185,7 @@ private:
                 printing begins.</p>
             
             <listing xml:id="linear-basic_lst-task">
-                <caption>The <c>Task</c> class</caption>
+                <title>The <c>Task</c> class</title>
                 <program language="cpp" label="linear-basic_lst-task-prog"><code>
 class Task {
 public:
@@ -223,7 +223,7 @@ private:
                 printer.</p>
             
             <listing xml:id="linear-basic_lst-qumainsim">
-                <caption>The main simulation function</caption>
+                <title>The main simulation function</title>
                 <program language="cpp" label="linear-basic_lst-qumainsim-prog"><code>
 void simulation(int numSeconds, int pagesPerMinute) {
     Printer labprinter(pagesPerMinute);

--- a/pretext/LinearBasic/TheStackAbstractDataType.ptx
+++ b/pretext/LinearBasic/TheStackAbstractDataType.ptx
@@ -1,15 +1,15 @@
 <?xml version="1.0" ?><section xml:id="linear-basic_the-stack-abstract-data-type">
-    <idx>stack abstract data type</idx> <idx>stack ADT</idx>
         <title>The Stack Abstract Data Type</title>
         <p>The <term>stack abstract data type</term> or <term>stack ADT</term> is defined by the following structure and
             operations. A stack is structured, as described above, as an ordered
             collection of items where items are added to and removed from the end
             called the <q>top.</q> Stacks are ordered LIFO. The stack operations are
-            given below.</p>
+            given below.<idx>stack abstract data type</idx> <idx>stack ADT</idx>
+</p>
         <p><ul>
             <li>
                 <p><c>stack&lt;datatype&gt;</c> creates a new stack that is empty. It needs no parameters
-                    and returns an empty stack. It can only contain a certain type of data. e.g. <title_reference>int</title_reference>, <title_reference>string</title_reference> etc.</p>
+                    and returns an empty stack. It can only contain a certain type of data. e.g. <c>int</c>, <c>string</c> etc.</p>
             </li>
             <li>
                 <p><c>push(item)</c> adds a new item to the top of the stack. It needs the

--- a/pretext/LinearBasic/WhatisaStack.ptx
+++ b/pretext/LinearBasic/WhatisaStack.ptx
@@ -66,7 +66,7 @@
             Back button, you begin to move in reverse order through the pages.</p>
             <reading-questions xml:id="rq-stack-adt">
                 <title>Reading Question</title>
-                <exercise label="stack_prob" indent="show" language="python"><statement>
+                <exercise label="stack_prob" language="python"><statement>
                         <p>Say we create a stack by pushing numbers 1 to 4 from lowest to highest. What would the stack look like afterwards?</p>
                 </statement>
                 <blocks><block order="1">

--- a/pretext/LinearLinked/ImplementinganOrderedList.ptx
+++ b/pretext/LinearLinked/ImplementinganOrderedList.ptx
@@ -16,7 +16,7 @@
             <xref ref="fig-orderlinked"/>. Again, the node and link structure is ideal
             for representing the relative positioning of the items.</p>
     
-        <figure align="center" xml:id="fig-orderlinked">
+        <figure xml:id="fig-orderlinked">
             <caption>An Ordered Linked List.</caption>
                 <image source="LinearLinked/orderlinkedlist.png" width="80%">
                 <description><p>Image of an ordered linked list with rectangular nodes connected by arrows. The list begins with a node labeled 'head' pointing to '17', followed by sequential nodes labeled '26', '31', '54', '77', and '93', with arrows indicating the direction of linkage from left to right. The structure represents a series of linked elements in ascending order.</p></description>
@@ -29,7 +29,7 @@
             <xref ref="linear-linked_lst-orderlist"/>).</p>
         
         <listing xml:id="linear-linked_lst-orderlist">
-            <caption><c>OrderedList</c> Member Variable</caption>
+            <title><c>OrderedList</c> Member Variable</title>
             <program language="cpp" label="linear-linked_lst-orderlist-prog"><code>
 class OrderedList {
     Node* head;
@@ -62,7 +62,7 @@ class OrderedList {
             the search can stop and return <c>False</c>. There is no way the item could
             exist further out in the linked list.</p>
         
-        <figure align="center" xml:id="fig-stopearly">
+        <figure xml:id="fig-stopearly">
             <caption>Searching an Ordered Linked List.</caption>
                 <image source="LinearLinked/orderedsearch.png" width="80%">
                 <description><p>Diagram showing the process of searching an ordered linked list. The list includes rectangular nodes with numbers '17', '26', '31', '54', '77', and '93' connected by arrows from a 'head' node. Above each node except 'head' and '93', a dashed arrow points down, labeled 'current', indicating the position being checked. Over the '54' node, there is a magnifying glass symbol, suggesting it is the current focus of the search. The list is terminated by a vertical bar symbol.</p></description>
@@ -79,7 +79,7 @@ class OrderedList {
             the unordered linked list search.</p>
         
         <listing xml:id="linear-linked_lst-ordersearch">
-            <caption><c>search</c> Method</caption>
+            <title><c>search</c> Method</title>
             <program language="cpp" label="linear-linked_lst-ordersearch-prog"><code>
 bool search(int item) {
     Node *current = head;
@@ -117,7 +117,7 @@ bool search(int item) {
             the item we wish to add. In our example, seeing the value 54 causes us
             to stop.</p>
         
-        <figure align="center" xml:id="fig-orderinsert">
+        <figure xml:id="fig-orderinsert">
             <caption>Adding an Item to an Ordered Linked List.</caption>
                 <image source="LinearLinked/linkedlistinsert.png" width="80%">
                 <description><p>Diagram of an ordered linked list illustrating the addition of a new item. The list starts with 'head' pointing to '17', then '26', followed by '54', '77', and '93', ending with a vertical bar symbol. A separate node labeled '31' with an arrow pointing right is positioned below, with a label 'temp'. Dashed arrows labeled 'Step 1' and 'Step 2' show the process of inserting '31' between '26' and '54'. Arrows from above point to '26' and '54' labeled 'previous' and 'current' respectively, indicating their positions relative to the insertion.</p></description>
@@ -141,7 +141,7 @@ bool search(int item) {
             <c>previous == nullptr</c> (line 13) can be used to provide the answer.</p>
         
         <listing xml:id="linear-linked_lst-orderadd">
-            <caption><c>add</c> Method</caption>
+            <title><c>add</c> Method</title>
             <program language="cpp" label="linear-linked_lst-orderadd-prog"><code>
 void add(int item) {
     if (head == nullptr) {

--- a/pretext/LinearLinked/ImplementinganUnorderedListLinkedLists.ptx
+++ b/pretext/LinearLinked/ImplementinganUnorderedListLinkedLists.ptx
@@ -15,14 +15,14 @@
             relative position of each item can be expressed by simply following the
             link from one item to the next.</p>
 
-        <figure align="center" xml:id="fig-idea">
+        <figure xml:id="fig-idea">
             <caption>Items Not Constrained in Their Physical Placement.</caption>
                 <image source="LinearLinked/idea.png" width="50%">
                 <description><p>Image displaying a scattered set of numbers representing items not constrained in their physical placement. The numbers shown are '31' and '17' at the top, '26' to the right, '54' and '77' in the middle, and '93' at the bottom. They are arranged without a discernible pattern or alignment, suggesting a random or unstructured layout.</p></description>
                 </image>
             </figure>
 
-        <figure align="center" xml:id="fig-idea2">
+        <figure xml:id="fig-idea2">
             <caption>Relative Positions Maintained by Explicit Links.</caption>
                 <image source="LinearLinked/idea2.png" width="50%">
                 <description><p>Diagram showing a sequence of numbers connected by arrows, illustrating relative positions maintained by explicit links. The sequence starts with 'Head' pointing to '54', which links to '77', then to '31' labeled '(End)', '17', '26', and finally '93'. The arrows signify the direction of the linkage between the elements, depicting a linked structure. Captioned 'Figure 4.3.2. Relative Positions Maintained by Explicit Links'.</p></description>

--- a/pretext/LinearLinked/TheNodeClass.ptx
+++ b/pretext/LinearLinked/TheNodeClass.ptx
@@ -13,7 +13,7 @@
             to access and modify the data and the next reference.</p>
 
   <listing xml:id="linear-linked_lst-nodeclass" names="lst_nodeclass">
-    <caption><c>Node</c> Class</caption>
+    <title><c>Node</c> Class</title>
     <program language="cpp" label="linear-linked_lst-nodeclass-prog"><code>
 #include &lt;iostream&gt;
 using namespace std;
@@ -59,7 +59,7 @@ class Node {
                 we will use the standard ground symbol to denote a reference that is
                 referring to <c>nullptr</c>.</p>
   </blockquote>
-  <figure align="center" xml:id="id1-fig-node">
+  <figure xml:id="id1-fig-node">
     <caption>A Node Object Contains the Item and a Reference to the Next Node</caption>
     <image source="LinearLinked/node.png" width="50%">
     <description>
@@ -71,7 +71,7 @@ class Node {
     </description>
     </image>
   </figure>
-  <figure align="center" xml:id="id2-fig-node2">
+  <figure xml:id="id2-fig-node2">
     <caption>A Typical Representation for a Node</caption>
     <image source="LinearLinked/node2.png" width="50%">
     <description>

--- a/pretext/LinearLinked/UnorderedListClass.ptx
+++ b/pretext/LinearLinked/UnorderedListClass.ptx
@@ -11,7 +11,7 @@
         to the head of the list.</p>
 
     <listing xml:id="unordered-constructor">
-        <caption><c>UnorderedList</c> Constructor</caption>
+        <title><c>UnorderedList</c> Constructor</title>
         <program language="cpp" label="unordered-constructor-prog"><code>
 class UnorderedList {
     public:
@@ -34,7 +34,7 @@ class UnorderedList {
         It is very important to note that the list class itself does not contain any node objects.
         Instead it contains a single pointer to only the first node in the linked structure.</p>
 
-    <figure align="center" xml:id="fig-unordered-empty">
+    <figure xml:id="fig-unordered-empty">
         <caption>Newly constructed (empty) list.</caption>
         <image source="LinearLinked/initlinkedlist.png" width="50%">
         <description>
@@ -48,7 +48,7 @@ class UnorderedList {
         </image>
     </figure>
 
-    <figure align="center" xml:id="fig-unordered-full">
+    <figure xml:id="fig-unordered-full">
         <caption>Linked list with some items inserted.</caption>
         <image source="LinearLinked/linkedlist.png" width="50%">
         <description>
@@ -71,7 +71,7 @@ class UnorderedList {
         <q>end</q> of the linked structure. Two references are equal if they both refer to the same
         object. We will use this often in our remaining methods.</p>
     <listing xml:id="unordered-isempty">
-        <caption><c>UnorderedList</c> <c>isEmpty()</c> method</caption>
+        <title><c>UnorderedList</c> <c>isEmpty()</c> method</title>
         <program language="cpp" label="unordered-isempty-prog"><code>
 bool isEmpty() {
     return head == nullptr;
@@ -98,7 +98,7 @@ bool isEmpty() {
         the <c>add</c> method a number of times as in <xref ref="unordered-lst-add"/>.</p>
 
     <listing xml:id="unordered-lst-add">
-        <caption><c>UnorderedList</c> Adding Elements</caption>
+        <title><c>UnorderedList</c> Adding Elements</title>
         <program language="cpp" label="unordered-lst-add-prog"><code>
 mylist.add(31);
 mylist.add(77);
@@ -125,7 +125,7 @@ mylist.add(54);
         statement in line 4 sets the head of the linked list.</p>
             
     <listing xml:id="unordered-add">
-        <caption><c>UnorderedList</c> <c>add</c> Method</caption>
+        <title><c>UnorderedList</c> <c>add</c> Method</title>
         <program language="cpp" line-numbers="yes" label="unordered-add-prog"><code>
 void add(int item) {
     Node *temp = new Node(item);
@@ -135,7 +135,7 @@ void add(int item) {
         </code></program>
     </listing>
 
-    <figure align="center" xml:id="fig-unordered-add-correct">
+    <figure xml:id="fig-unordered-add-correct">
         <caption>Adding a Node.</caption>
         <image source="LinearLinked/addtohead.png" width="50%">
         <description>
@@ -159,7 +159,7 @@ void add(int item) {
     reference to the linked list nodes, all of the original nodes are lost and can
     no longer be accessed.</p>
 
-    <figure align="center" xml:id="fig-unordered-add-wrong">
+    <figure xml:id="fig-unordered-add-wrong">
         <caption>Incorrect Order for Adding a Node.</caption>
         <image source="LinearLinked/wrongorder.png" width="50%">
         <description>
@@ -198,7 +198,7 @@ void add(int item) {
         <xref ref="fig-traversal"/> shows this process as it proceeds down the linked list.</p>
 
     <listing xml:id="unordered-size">
-        <caption><c>UnorderedList</c> <c>size</c> Method</caption>
+        <title><c>UnorderedList</c> <c>size</c> Method</title>
         <program language="cpp" line-numbers="yes" label="unordered-size-prog"><code>
 int size() {
     Node *current = head;
@@ -213,7 +213,7 @@ int size() {
         </code></program>
     </listing>
 
-    <figure align="center" xml:id="fig-traversal">
+    <figure xml:id="fig-traversal">
         <caption>Traversing a Linked List.</caption>
         <image source="LinearLinked/traversal.png" width="50%">
         <description>
@@ -245,7 +245,7 @@ int size() {
         When we reach the end of the list and the item has not been found, we return <c>false</c>.</p>
 
     <listing xml:id="unordered-search">
-        <caption><c>UnorderedList</c> <c>search</c> Method</caption>
+        <title><c>UnorderedList</c> <c>search</c> Method</title>
         <program language="cpp" line-numbers="yes" label="unordered-search-prog"><code>
 bool search(int item) {
     Node *current = head;
@@ -273,7 +273,7 @@ bool search(int item) {
         <c>true</c> and the <c>while</c> condition will fail, leading to the return
         value seen above. This process can be seen in <xref ref="fig-unordered-search"/>.</p>
 
-    <figure align="center" xml:id="fig-unordered-search">
+    <figure xml:id="fig-unordered-search">
         <caption>Searching a Linked List.</caption>
         <image source="LinearLinked/search.png" width="50%">
     <description>
@@ -332,7 +332,7 @@ bool search(int item) {
         used to control the iteration.</p>
     
     <listing xml:id="unordered-remove">
-        <caption><c>UnorderedList</c> <c>remove</c> Method</caption>
+        <title><c>UnorderedList</c> <c>remove</c> Method</title>
         <program language="cpp" line-numbers="yes" label="unordered-remove-prog"><code>
 void remove(int item) {
     Node *current = head;
@@ -355,7 +355,7 @@ void remove(int item) {
         </code></program>
     </listing>
 
-    <figure align="center" xml:id="fig-unordered-removeinit">
+    <figure xml:id="fig-unordered-removeinit">
         <caption>Initialization of <c>remove</c> method.</caption>
         <image source="LinearLinked/removeinit.png" width="50%">
         <description>
@@ -382,7 +382,7 @@ void remove(int item) {
         the movement of <c>previous</c> and <c>current</c> as they progress down the linked
         list looking for the node containing the value 17.</p>
 
-    <figure align="center" xml:id="fig-unordered-prevcurr">
+    <figure xml:id="fig-unordered-prevcurr">
         <caption>Initialization of <c>remove</c> method.</caption>
         <image source="LinearLinked/prevcurr.png" width="50%">
 <description>
@@ -413,7 +413,7 @@ void remove(int item) {
         case, it is not <c>previous</c> but rather the head of the linked list that needs
         to be changed (see <xref ref="fig-unordered-removehead"/>).</p>
 
-    <figure align="center" xml:id="fig-unordered-remove">
+    <figure xml:id="fig-unordered-remove">
         <caption>Removing an Item from the Middle of the Linked List.</caption>
         <image source="LinearLinked/remove.png" width="50%">
         <description>
@@ -428,7 +428,7 @@ void remove(int item) {
         </image>
     </figure>
 
-    <figure align="center" xml:id="fig-unordered-removehead">
+    <figure xml:id="fig-unordered-removehead">
         <caption>Removing the First Node from the Linked List.</caption>
         <image source="LinearLinked/remove2.png" width="50%">
         <description>


### PR DESCRIPTION
# Description
xml fixes for the linked chapters
- align=center is not a thing
- paragraph doesn't belong in a title
- math is spelled m
- s/caption/title
- s/title_reference/c
- indent=show is not a thing

## Related Issue
standalone

## How Has This Been Tested?
local build