### PR TITLE
various xml fixes: trees and graphs chapters

### DIFF
--- a/pretext/Trees/AVLTreeImplementation.ptx
+++ b/pretext/Trees/AVLTreeImplementation.ptx
@@ -144,7 +144,7 @@ class AVLTree:
             is out of balance with a balance factor of -2. To bring this tree into
             balance we will use a left rotation around the subtree rooted at node A.</p>
         
-        <figure align="center" xml:id="fig-unbalsimple">
+        <figure xml:id="fig-unbalsimple">
             <caption>Transforming an Unbalanced Tree Using a Left Rotation.</caption>
             <image source="Trees/simpleunbalanced.png" width="70%"> 
             <description>
@@ -200,7 +200,7 @@ class AVLTree:
             </li>
         </ul></p>
         
-        <figure align="center" xml:id="fig-rightrot1">
+        <figure xml:id="fig-rightrot1">
             <caption>Transforming an Unbalanced Tree Using a Right Rotation.</caption>
             <image source="Trees/rightrotate1.png" width="70%"> 
                 <description>
@@ -239,8 +239,8 @@ class AVLTree:
             it to you to study the code for <c>rotateRight</c>.</p>
 
         <listing xml:id="trees_lst-bothrotations">
-            <caption>Implementation of <c>rotateLeft</c> and <c>rotateRight</c></caption>
-            <program language="cpp" line-numbers="yes" open="yes" label="trees_lst-bothrotations-prog"><code>
+            <title>Implementation of <c>rotateLeft</c> and <c>rotateRight</c></title>
+            <program language="cpp" line-numbers="yes" label="trees_lst-bothrotations-prog"><code>
 void rotateLeft(TreeNode *rotRoot){
     TreeNode *newRoot = rotRoot-&gt;rightChild;
     rotRoot-&gt;rightChild = newRoot-&gt;leftChild;
@@ -275,7 +275,7 @@ void rotateLeft(TreeNode *rotRoot){
             the heights of the new subtrees? The following derivation should
             convince you that these lines are correct.</p>
         
-        <figure align="center" xml:id="trees-avl-fig-bfderive">
+        <figure xml:id="trees-avl-fig-bfderive">
             <caption>A Left Rotation.</caption>
             <image source="Trees/bfderive.png" width="70%"> 
             <description>
@@ -345,7 +345,7 @@ rotRoot.balanceFactor = rotRoot.balanceFactor + 1 - min(0,newRoot.balanceFactor)
             factor of -2 we should do a left rotation. But, what happens when we do
             the left rotation around A?</p>
         
-        <figure align="center" xml:id="avlimpl_fig-hardrotate">
+        <figure xml:id="avlimpl_fig-hardrotate">
             <caption>An Unbalanced Tree that is More Difficult to Balance.</caption>
             <image source="Trees/hardunbalanced.png" width="20%"> 
             <description>
@@ -363,7 +363,7 @@ rotRoot.balanceFactor = rotRoot.balanceFactor + 1 - min(0,newRoot.balanceFactor)
             out of balance the other way. If we do a right rotation to correct the
             situation we are right back where we started.</p>
         
-        <figure align="center" xml:id="avlimpl_fig-badrotate">
+        <figure xml:id="avlimpl_fig-badrotate">
             <caption>After a Left Rotation the Tree is Out of Balance in the Other Direction.</caption>
             <image source="Trees/badrotate.png" width="20%"> 
             <description>
@@ -397,7 +397,7 @@ rotRoot.balanceFactor = rotRoot.balanceFactor + 1 - min(0,newRoot.balanceFactor)
             with a right rotation around node C puts the tree in a position where
             the left rotation around A brings the entire subtree back into balance.</p>
         
-        <figure align="center" xml:id="avlimpl_fig-rotatelr">
+        <figure xml:id="avlimpl_fig-rotatelr">
             <caption>A Right Rotation Followed by a Left Rotation.</caption>
             <image source="Trees/rotatelr.png" width="80%"> 
             <description>
@@ -423,7 +423,7 @@ rotRoot.balanceFactor = rotRoot.balanceFactor + 1 - min(0,newRoot.balanceFactor)
             line 11.</p>
         
         <listing xml:id="avlimpl_lst-rebalance">
-            <caption>Implementation of <c>rebalance</c></caption>
+            <title>Implementation of <c>rebalance</c></title>
             <program language="cpp" line-numbers="yes" label="avlimpl_lst-rebalance-prog"><code>
 void rebalance(TreeNode *node){
     if (node-&gt;balanceFactor &lt; 0){

--- a/pretext/Trees/BinaryHeapImplementation.ptx
+++ b/pretext/Trees/BinaryHeapImplementation.ptx
@@ -12,7 +12,7 @@
                 the tree, which we fill in from left to right. <xref ref="binheap_fig-comptree"/>
                 shows an example of a complete binary tree.</p>
             
-            <figure align="center" xml:id="binheap_fig-comptree">
+            <figure xml:id="binheap_fig-comptree">
                 <caption>A Complete Binary Tree.</caption>
                     <image source="Trees/compTree.png" width="80%">
                     <description>
@@ -54,7 +54,7 @@
                 tree that has the heap order property.</p>
             
 
-            <figure align="center" xml:id="binheap_fig-heaporder">
+            <figure xml:id="binheap_fig-heaporder">
                 <caption>A Complete Binary Tree, along with its Vector Representation.</caption>
                     <image source="Trees/heapOrder.png" width="80%">
                     <description><p>The image depicts a complete binary tree at the top and its corresponding vector representation at the bottom. The binary tree has a root node labeled '5', which branches out to two nodes labeled '9' on the left and '11' on the right. The '9' node further branches into '14' and '18', which in turn have children '33' and '17', and '27', respectively. The '11' node branches into '19' and '21'. Below the binary tree, there is a vector representation with indexed positions from 0 to 11. The values in the vector are arranged as '5', '9', '11', '14', '18', '19', '21', '33', '17', '27', respecting the binary tree's structure. The image is labeled 'Figure 2: A Complete Binary Tree, along with its Vector Representation'.</p></description>
@@ -73,7 +73,7 @@
                 that simple integer division can be used in later methods.</p>
             
             <listing xml:id="binheap_lst-heap1a">
-                <caption><c>BinHeap</c> Class and Constructor</caption>
+                <title><c>BinHeap</c> Class and Constructor</title>
                 <program language="cpp" label="binheap_lst-heap1a-prog"><code>
 class BinHeap{
     private:
@@ -100,9 +100,9 @@ class BinHeap{
                 series of swaps needed to percolate the newly added item up to its
                 proper position in the tree.</p>
             
-            <figure align="center" xml:id="binheap_fig-percup">
+            <figure xml:id="binheap_fig-percup">
                 <caption>Percolate the New Node up to Its Proper Position.</caption>
-                <image source="Trees/percUp.png" width="50%" alt="image"> 
+                <image source="Trees/percUp.png" width="50%"> 
                 <description>
                 <p>
                     Image showing the process of percolating a newly added node to its proper position in a binary heap. The diagram consists of 
@@ -144,7 +144,7 @@ class BinHeap{
                 properly.</p>
             
             <listing xml:id="binheap_lst-heap2">
-                <caption><c>percUp</c> Method</caption>
+                <title><c>percUp</c> Method</title>
                 <program language="cpp" label="binheap_lst-heap2-prog"><code>
 void percUp(int i){
     while ((i / 2) &gt; 0){
@@ -160,7 +160,7 @@ void percUp(int i){
             </listing>
 
             <listing xml:id="binheap_lst-heap3" names="lst_heap3">
-                <caption><c>insert</c> Method</caption>
+                <title><c>insert</c> Method</title>
                 <program language="cpp" label="binheap_lst-heap3-prog"><code>
 void insert(int k){
     this-&gt;heapvector.push_back(k);
@@ -183,9 +183,9 @@ void insert(int k){
                 the series of swaps needed to move the new root node to its proper
                 position in the heap.</p>
             
-            <figure align="center" xml:id="binheap_fig-percdown">
+            <figure xml:id="binheap_fig-percdown">
                 <caption>Percolating the Root Node down the Tree.</caption>
-                <image source="Trees/percDown.png" width="50%" alt="image"> 
+                <image source="Trees/percDown.png" width="50%"> 
                 <description>
                 <p>
                 Image showing the process of percolating the root node down the tree in a binary heap after removing the minimum (root) value. 
@@ -217,7 +217,7 @@ void insert(int k){
                 <xref ref="binheap_lst-heap4"/>.</p>
             
             <listing xml:id="binheap_lst-heap4">
-                <caption><c>percDown</c> and <c>minChild</c> Methods</caption>
+                <title><c>percDown</c> and <c>minChild</c> Methods</title>
                 <program language="cpp" label="binheap_lst-heap4-prog"><code>
 void percDown(int i){
     while ((i*2) &lt;= this-&gt;currentSize){
@@ -251,7 +251,7 @@ int minChild(int i){
                 case <c>percDown</c>.</p>
             
             <listing xml:id="binheap_lst-heap5" names="lst_heap5">
-                <caption><c>delMin</c> Implementation</caption>
+                <title><c>delMin</c> Implementation</title>
                 <program language="cpp" label="binheap_lst-heap5-prog"><code>
 int delMin(){
     if (this-&gt;currentSize &gt; 1){
@@ -289,7 +289,7 @@ int delMin(){
                 to build the entire heap.</p>
             
             <listing xml:id="binheap_lst-heap6">
-                <caption><c>buildHeap</c> Implementation</caption>
+                <title><c>buildHeap</c> Implementation</title>
                 <program language="cpp" label="binheap_lst-heap6-prog"><code>
 void buildheap(vector&lt;int&gt; avector){
     int i = avector.size() / 2;
@@ -302,9 +302,9 @@ void buildheap(vector&lt;int&gt; avector){
 }
                 </code></program>
             </listing>
-            <figure align="center" xml:id="binheap_fig-buildheap">
+            <figure xml:id="binheap_fig-buildheap">
                 <caption>Building a Heap from the vector [9, 6, 5, 2, 3].</caption>
-                <image source="Trees/buildheap.png" width="50%" alt="image"> 
+                <image source="Trees/buildheap.png" width="50%"> 
                 <description>
                   <p>
                     Image showing the process of building a binary heap from the vector [9, 6, 5, 2, 3] using the `buildHeap` algorithm. 

--- a/pretext/Trees/BinaryHeapPriorityQExample.ptx
+++ b/pretext/Trees/BinaryHeapPriorityQExample.ptx
@@ -7,7 +7,7 @@
             and you are told the deadlines for those homeworks: 3, 10, 5, 8, 7, 2 days respectively. You can observe the insertion of these homeworks into our priority queue in <xref ref="fig-trees_pq-insertion"/>.</p>
         
 
-        <figure align="center" xml:id="fig-trees_pq-insertion">
+        <figure xml:id="fig-trees_pq-insertion">
             <caption>Homework insertion process into priority queue.</caption>
                 <image source="Trees/Homework_PQ.png" width="80%">
                 <description><p>A sequence of diagrams depicting the insertion process into a priority queue represented by a binary tree. Starting with a single node labeled '3', the first diagram shows 'Insert 10', leading to a new node '10' added as a child. The next step 'Insert 5' adds a new node '5', followed by 'Insert 8' which adds node '8'. Another step shows 'Insert 7' with a node '7' being added, and the sequence progresses with each insertion maintaining the binary tree structure. The diagrams show the dynamic reordering of nodes to maintain the priority queue property, with the final structure at the bottom left displaying a balanced binary tree with node '2' at the top, leading to nodes '3' and '7', which branch out to further nodes '10', '8', '5', and '2'. Arrows indicate the insertion order and the adjustments within the tree.</p></description>
@@ -16,7 +16,7 @@
         <p>Now that we have the priority queue of which homeworks we need to do in the order. Let us start by doing the homework with 2 day deadline. We would remove it from the root and put the left most leaf in its place and than rearange the heap back to the proper state, as shown in <xref ref="fig-trees_pq-del"/>.</p>
         
 
-        <figure align="center" xml:id="fig-trees_pq-del">
+        <figure xml:id="fig-trees_pq-del">
             <caption>After finishing the earliest homework, the root is removed and rearranges the priority queue.</caption>
                 <image source="Trees/PQ_Del.png" width="80%">
                 <description><p>Two diagrams showing the process of removing the root from a binary heap that represents a priority queue. The first diagram on the left shows a binary tree with the root node '3', which has two children: '7' on the left with its own children '10' and '8', and '5' on the right. An arrow points from this tree to the second diagram on the right, indicating the removal of the root node. The second diagram shows the tree after the root has been removed and the heap has been restructured: the node '5' has been moved to the root position, with '7' as its left child and '3' as its right child, maintaining the heap property. The nodes '10' and '8' remain as children of '7'. The tree restructuring is shown with curved arrows indicating the new parent-child relationships.</p></description>

--- a/pretext/Trees/DiscussionQuestions.ptx
+++ b/pretext/Trees/DiscussionQuestions.ptx
@@ -64,7 +64,7 @@
             </li>
             <li>
                 <p>Show the function calls needed to build the binary tree in <xref ref="exertree"/>.</p>
-                <figure align="center" xml:id="exertree">
+                <figure xml:id="exertree">
                     <caption>Tree of Programming Languages</caption>
                     <image source="Trees/exerTree.png" width="50%">
                         <description><p>A tree whose root node is language. The language node has two children: compiled and interpreted.
@@ -75,7 +75,7 @@
             </li>
             <li>
                 <p>Given the tree in <xref ref="rotexer1"/>, perform the appropriate rotations to bring it back into balance.</p>
-                <figure align="center" xml:id="rotexer1">
+                <figure xml:id="rotexer1">
                     <caption>Out of Balance Tree</caption>
                     <image source="Trees/rotexer1.png" width="20%">
                         <description><p>
@@ -88,7 +88,7 @@
             </li>
             <li>
                 <p>Using <xref ref="bfderive"/> as a starting point, derive the equation that gives the updated balance factor for node D.</p>
-                <figure align="center" xml:id="bfderive">
+                <figure xml:id="bfderive">
                     <caption>Compute Updated Balance Factor</caption>
                     <image source="Trees/bfderive.png" width="50%"> 
                     <description>

--- a/pretext/Trees/ExamplesofTrees.ptx
+++ b/pretext/Trees/ExamplesofTrees.ptx
@@ -23,7 +23,7 @@
             still animals.</p>
         
     
-        <figure align="center" xml:id="trees_examples-biotree">
+        <figure xml:id="trees_examples-biotree">
             <caption>Taxonomy of Some Common Animals Shown as a Tree.</caption>
                 <image source="Trees/biology.png" width="80%">
                 <description><p>The image displays a taxonomy tree diagram of some common animals, illustrating their scientific classification from kingdom to species. At the top, 'Animalia' branches into 'Chordate' and 'Arthropoda', leading down to classifications such as 'Mammal' and 'Insect'. Specific branches detail the classification of humans, chimpanzees, house cats, lions, and houseflies, listing their respective taxonomic ranks from 'Kingdom' down to 'Species'. Each species is paired with its common name, like 'Homo sapiens' for human, 'Pan troglodytes' for chimpanzee, 'Felis domestica' for house cat, 'Panthera leo' for lion, and 'Musca domestica' for housefly.</p></description>
@@ -58,7 +58,7 @@
             system hierarchy.</p>
         
 
-        <figure align="center" xml:id="trees_examples-filetree">
+        <figure xml:id="trees_examples-filetree">
             <caption>A Small Part of the Unix File System Hierarchy.</caption>
                 <image source="Trees/directory.png" width="90%">
                 <description><p>The image shows a hierarchical diagram representing a small part of the Unix file system structure. It starts from a single root node that branches out to various directories such as '/dev/', '/etc/', '/sbin/', '/tmp/', '/Users/', '/usr/', and '/var/'. Each of these main directories further branches into subdirectories like '/cups/' and '/httpd/' under '/dev/', or '/bin/', '/lib/', and '/local/' under '/usr/'. The diagram visually organizes the structure and relationships of these directories in a tree-like format, indicating how files and subdirectories are organized within a Unix-based operating system.</p></description>
@@ -96,7 +96,7 @@
 &lt;/html&gt;</pre>
         
 
-        <figure align="center" xml:id="trees_examples-htmltree">
+        <figure xml:id="trees_examples-htmltree">
             <caption>A Tree Corresponding to the Markup Elements of a Web Page.</caption>
                 <image source="Trees/htmltree.png" width="80%">
                 <description><p>A diagrammatic representation of a web page's Document Object Model (DOM) tree. The tree has 'html' as the root node, which branches off into 'head' and 'body' nodes. The 'head' node further branches into 'meta' and 'title', while the 'body' node extends into 'ul', 'h1', and 'h2' nodes. The 'ul' (unordered list) node has two 'li' (list item) child nodes, and the 'h2' node has an 'a' (anchor) child node, representing a hyperlink. This tree structure visually maps out the hierarchy and relationships of markup elements within a web page.</p></description>

--- a/pretext/Trees/ListofListsRepresentation.ptx
+++ b/pretext/Trees/ListofListsRepresentation.ptx
@@ -219,7 +219,6 @@ insertLeft(getRightChild(getRightChild(x)),'e')
             <p>Write a function <c>buildTree</c> that returns a tree using the list of lists functions that looks like this:</p>
             <image source="Trees/Figures/tree_ex.png" width="50%"/>
 
-    </statement>
     <program xml:id="mctree_2_editor" interactive="activecode" language="python" label="mctree_2_editor-prog">
         <code>
 from test import testEqual
@@ -235,6 +234,7 @@ def main():
 main()
         </code>
     </program>
+    </statement>
 </exercise>
         </note>
     </section>

--- a/pretext/Trees/NodesandReferences.ptx
+++ b/pretext/Trees/NodesandReferences.ptx
@@ -8,7 +8,7 @@
         <p>Using nodes and references, we might think of the tree as being
             structured like the one shown in <xref ref="fig-treerec"/>.</p>
         
-        <figure align="center" xml:id="fig-treerec">
+        <figure xml:id="fig-treerec">
             <caption>A Simple Tree Using a Nodes and References Approach.</caption>
                 <image source="Trees/treerecs.png" width="50%">
                 <description><p>Illustration of a binary tree structure with three levels. The top level shows a single node labeled 'a' with two pointers 'left' and 'right'. The second level has two nodes: 'b' on the left with its own 'left' and 'right' pointers, and 'c' on the right with pointers also labeled 'left' and 'right'. The third level shows three nodes: 'd' is the left child of 'b' with 'left' and 'right' pointers; 'e' is the right child of 'b' with pointers labeled 'left' and 'right'; 'f' is the right child of 'c' also with 'left' and 'right' pointers. Each pointer is represented by an arrow indicating the direction of the reference.</p></description>

--- a/pretext/Trees/ParseTree.ptx
+++ b/pretext/Trees/ParseTree.ptx
@@ -5,7 +5,7 @@
             some real problems. In this section we will look at parse trees. Parse
             trees can be used to represent real-world constructions like sentences or mathematical expressions.</p>
         
-        <figure align="center" xml:id="fig-nlparse">
+        <figure xml:id="fig-nlparse">
             <caption>A Parse Tree for a Simple Sentence.</caption>
                 <image source="Trees/nlParse.png" width="50%">
                 <description><p>Diagram of a parse tree for linguistic analysis. The root of the tree is labeled 'Sentence' which splits into two branches: 'Noun Phrase' and 'Verb Phrase'. The 'Noun Phrase' branch further breaks down into 'Proper Noun', which leads to the word 'Homer'. The 'Verb Phrase' branch divides into 'Verb', leading to the word 'Hit', and another 'Noun Phrase', which further breaks down into 'Proper Noun', leading to the word 'Bart'. The structure illustrates the grammatical relationships in a simple sentence.</p></description>
@@ -15,7 +15,7 @@
             sentence. Representing a sentence as a tree structure allows us to work
             with the individual parts of the sentence by using subtrees.</p>
         
-        <figure align="center" xml:id="fig-meparse">
+        <figure xml:id="fig-meparse">
             <caption>Parse Tree for <m>((7+3)*(5-2))</m>.</caption>
                 <image source="Trees/meParse.png" width="50%">
                 <description><p>Diagram of a parse tree for an arithmetic expression. The root node is an asterisk '*', indicating multiplication. It has two child nodes: on the left, a plus sign '+' connects the numbers 7 and 3, and on the right, a minus sign '-' connects the numbers 5 and 2. This tree represents the mathematical expression ((7 + 3) * (5 - 2)). The image is labeled 'Figure 2: Parse Tree for ((7 + 3) * (5 - 2)).</p></description>
@@ -41,7 +41,7 @@
         
 
 
-        <figure align="center" xml:id="fig-mesimple">
+        <figure xml:id="fig-mesimple">
             <caption>A Simplified Parse Tree for <m>((7+3)*(5-2))</m>.</caption>
                 <image source="Trees/meSimple.png" width="50%">
                 <description><p>Diagram of a simplified parse tree for an arithmetic expression after evaluation. The root node is an asterisk '*', indicating multiplication. It has two child nodes, which are the results of the arithmetic operations: the number 10 on the left, which is the sum of 7 and 3, and the number 3 on the right, which is the result of subtracting 2 from 5. This tree represents the evaluated mathematical expression ((7 + 3) * (5 - 2)). The image is labeled 'Figure 3: A Simplified Parse Tree for ((7 + 3) * (5 - 2)).</p></description>
@@ -102,7 +102,7 @@
             illustrates the structure and contents of the parse tree, as each new
             token is processed.</p>
     
-        <figure align="center" xml:id="parse_fig-bldexpstep">
+        <figure xml:id="parse_fig-bldexpstep">
             <caption>Tracing Parse Tree Construction.</caption>
                 <image source="Trees/buildExp1.png" width="15%">
                 <shortdescription>

--- a/pretext/Trees/SearchTreeAnalysis.ptx
+++ b/pretext/Trees/SearchTreeAnalysis.ptx
@@ -33,7 +33,7 @@
             such a tree is shown in <xref ref="fig-skewedtree-analysis"/>. In this case the
             performance of the <c>put</c> method is <m>O(n)</m>.</p>
         
-        <figure align="center" xml:id="fig-skewedtree-analysis">
+        <figure xml:id="fig-skewedtree-analysis">
             <caption>A skewed binary search tree would give poor performance.</caption>
             <image source="Trees/skewedTree.png" width="50%">
                 <description><p>

--- a/pretext/Trees/SearchTreeImplementation.ptx
+++ b/pretext/Trees/SearchTreeImplementation.ptx
@@ -11,7 +11,7 @@
             subtree are less than the key in the root. All of the keys in the right
             subtree are greater than the root.</p>
         
-        <figure align="center" xml:id="bst_fig-simplebst">
+        <figure xml:id="bst_fig-simplebst">
             <caption>A Simple Binary Search Tree.</caption>
             <image source="Trees/simpleBST.png" width="50%">
             <description>
@@ -56,7 +56,7 @@
             miscellaneous functions is shown in <xref ref="bst_lst-bst1"/>.</p>
         
         <listing xml:id="bst_lst-bst1">
-            <caption><c>BinarySearchTree</c> Class and Constructor</caption>
+            <title><c>BinarySearchTree</c> Class and Constructor</title>
             <program language="cpp" label="bst_lst-bst1-prog"><code>
 class BinarySearchTree{
     private:
@@ -97,7 +97,7 @@ class BinarySearchTree{
             are used.</p>
         
         <listing xml:id="bst_lst-bst2">
-            <caption><c>TreeNode</c> Class</caption>
+            <title><c>TreeNode</c> Class</title>
             <program language="cpp" label="bst_lst-bst2-prog"><code>
 class TreeNode{
     public:
@@ -201,7 +201,7 @@ class TreeNode{
             this bug as an exercise for you.</p>
         
         <listing xml:id="bst_lst-bst3" names="lst_bst3">
-            <caption><c>put</c> and <c>_put</c> Methods</caption>
+            <title><c>put</c> and <c>_put</c> Methods</title>
             <program language="cpp" label="bst_lst-bst3-prog"><code>
 void put(int key, string val){
     if (root){
@@ -237,7 +237,7 @@ void _put(int key, string val, TreeNode *currentNode){
             into a binary search tree. The lightly shaded nodes indicate the nodes
             that were visited during the insertion process.</p>
         
-        <figure align="center" xml:id="bst_fig-bstput">
+        <figure xml:id="bst_fig-bstput">
             <caption>Inserting a Node with Key = 19.</caption>
             <image source="Trees/bstput.png" width="80%">
             <description>
@@ -270,7 +270,7 @@ void _put(int key, string val, TreeNode *currentNode){
             from the <c>TreeNode</c> besides the value.</p>
         
         <listing xml:id="bst_lst-bst4" names="bst_lst-bst4">
-            <caption><c>get</c> and <c>_get</c> Methods</caption>
+            <title><c>get</c> and <c>_get</c> Methods</title>
             <program language="cpp" label="bst_lst-bst4-prog"><code>
 string get(int key){
     if (root){
@@ -307,7 +307,7 @@ TreeNode  *_get(int key, TreeNode *currentNode){
             the key is not found the <c>del</c> operator raises an error.</p>
         
         <listing xml:id="bst_lst-bst5" names="lst_bst5">
-            <caption><c>del</c> Method</caption>
+            <title><c>del</c> Method</title>
             <program language="cpp" label="bst_lst-bst5-prog"><code>
 void del(int key){
     if (size &gt; 1){
@@ -348,7 +348,7 @@ void del(int key){
             node in the parent. The code for this case is shown in here.</p>
         
         <listing xml:id="bst_lst-bst6">
-            <caption>Deleting a Node With No Children</caption>
+            <title>Deleting a Node With No Children</title>
             <program language="cpp" label="bst_lst-bst6-prog"><code>
 if (currentNode-&gt;isLeaf()){ //leaf
     if (currentNode == currentNode-&gt;parent-&gt;leftChild){
@@ -360,7 +360,7 @@ if (currentNode-&gt;isLeaf()){ //leaf
 }
             </code></program>
         </listing>
-        <figure align="center" xml:id="bst_fig-bstdel1">
+        <figure xml:id="bst_fig-bstdel1">
             <caption>Deleting Node 16, a Node without Children.</caption>
             <image source="Trees/bstdel1.png" width="80%">
             <description>
@@ -402,7 +402,7 @@ if (currentNode-&gt;isLeaf()){ //leaf
         </ol></p>
 
         <listing xml:id="bst_lst-bst7">
-            <caption>Handling One Child Node</caption>
+            <title>Handling One Child Node</title>
             <program language="cpp" label="bst_lst-bst7-prog"><code>
 else{ // this node has one child
     if (currentNode-&gt;hasLeftChild()){
@@ -442,7 +442,7 @@ else{ // this node has one child
             </code></program>
         </listing>
         
-        <figure align="center" xml:id="bst_fig-bstdel2">
+        <figure xml:id="bst_fig-bstdel2">
             <caption>Deleting Node 25, a Node That Has a Single Child.</caption>
             <image source="Trees/bstdel2.png" width="80%"> 
             <description>
@@ -469,7 +469,7 @@ else{ // this node has one child
             implemented. Once the successor has been removed, we simply put it in
             the tree in place of the node to be deleted.</p>
         
-        <figure align="center" xml:id="bst_fig-bstdel3">
+        <figure xml:id="bst_fig-bstdel3">
             <caption>Deleting Node 5, a Node with Two Children.</caption>
             <image source="Trees/bstdel3.png" width="80%">
             <description>
@@ -495,7 +495,7 @@ else{ // this node has one child
             time re-searching for the key node.</p>
         
         <listing xml:id="bst_lst-bst8" names="lst_bst8">
-            <caption>Deleting a Node With Two Children</caption>
+            <title>Deleting a Node With Two Children</title>
             <program language="cpp" label="bst_lst-bst8-prog"><code>
 else if (currentNode-&gt;hasBothChildren()){ //interior
     TreeNode *succ = currentNode-&gt;findSuccessor();
@@ -536,7 +536,7 @@ else if (currentNode-&gt;hasBothChildren()){ //interior
             subtree until it reaches a node that does not have a left child.</p>
         
         <listing xml:id="bst_lst-bst9" names="lst_bst9">
-            <caption><c>findSuccessor</c>, <c>findMin</c>, and <c>spliceOut</c> Methods</caption>
+            <title><c>findSuccessor</c>, <c>findMin</c>, and <c>spliceOut</c> Methods</title>
             <program language="cpp" label="bst_lst-bst9-prog"><code>
 TreeNode *findSuccessor(){
     TreeNode *succ = nullptr;

--- a/pretext/Trees/TreeTraversals.ptx
+++ b/pretext/Trees/TreeTraversals.ptx
@@ -12,14 +12,14 @@
             examples where these patterns are useful.</p>
         
 
-        <figure align="center" xml:id="fig-trav-tree">
+        <figure xml:id="fig-trav-tree">
             <caption>Example tree to be traversed.</caption>
                 <image source="Trees/trav_tree.png" width="50%">
                 <description><p>Illustration of a binary tree. The top node is labeled '1', and it splits into two child nodes labeled '3' on the left and '8' on the right. The '3' node further splits into two child nodes labeled '7' on the left and '5' on the right. The '8' node also splits into two children, with '2' on the left and '9' on the right. The nodes are connected by lines indicating the tree structure.</p></description>
                 </image>
             </figure>
 
-        <dl>
+        <p><dl>
             <li>
                 <title>preorder</title>
                 
@@ -28,9 +28,9 @@
                         a recursive preorder traversal of the right subtree.</p>
                 
             </li>
-        </dl>
+        </dl></p>
         
-        <figure align="center" xml:id="fig-pre-order-tree">
+        <figure xml:id="fig-pre-order-tree">
             <caption>Traversal pattern for preorder.</caption>
                 <image source="Trees/pre_order.gif" width="50%">
                 <description><p>Diagram of a binary tree to illustrate the preorder traversal pattern. The tree consists of a root node labeled '1', with a left child labeled '3', which in turn has two children labeled '7' and '5'. The root node also has a right child labeled '8', which has two children labeled '2' and '9'. The nodes '1', '3', '7', '5', '8', and '9' are circled, indicating the order of the preorder traversal. Arrows point from the root node '1' to the left child '3', then to '7', back up through '3' to '5', then to the right child '8', and finally to '9', following the preorder traversal pattern. The image is labeled 'Figure 6: Traversal pattern for preorder'.</p></description>
@@ -38,7 +38,7 @@
             </figure>
 
 
-        <dl>
+        <p><dl>
             <li>
                 <title>inorder</title>
                 
@@ -47,17 +47,17 @@
                         inorder traversal of the right subtree.</p>
                 
             </li>
-        </dl>
+        </dl></p>
         
 
-        <figure align="center" xml:id="fig-in-order-tree">
+        <figure xml:id="fig-in-order-tree">
             <caption>Traversal pattern for inorder.</caption>
                 <image source="Trees/in_order.gif" width="50%">
                 <description><p>Diagram of a binary tree to illustrate the inorder traversal pattern. The tree has a root node at the top labeled '1', which branches out to a left child labeled '3' and a right child labeled '8'. The '3' node has further children labeled '7' and '5', and the '8' node has children labeled '2' and '9'. The nodes are not circled, but the traversal pattern is indicated by a black arrow starting from the '3' node, moving to its left child '7', then up to '3', across to '5', up to '1', then to '8', down to '2', and finally to '9' on the far right. This pattern represents the inorder traversal where you visit the left subtree, the node itself, and then the right subtree.</p></description>
                 </image>
             </figure>
 
-        <dl>
+        <p><dl>
             <li>
                 <title>postorder</title>
                 
@@ -66,10 +66,10 @@
                         root node.</p>
                 
             </li>
-        </dl>
+        </dl></p>
         
 
-        <figure align="center" xml:id="fig-post-order-tree">
+        <figure xml:id="fig-post-order-tree">
             <caption>Traversal pattern for postorder.</caption>
                 <image source="Trees/post_order.gif" width="50%">
                 <description><p>Diagram of a binary tree to illustrate the postorder traversal pattern. The tree structure includes a root node labeled '1' at the top, with a left child labeled '3' and a right child labeled '8'. Node '3' has two children labeled '7' and '5', while node '8' has children labeled '2' and '9'. The traversal pattern is shown with black arrows starting at the leftmost child '7', moving up to '3', across to '5', back to '3', then to the root '1', over to the right child '8', down to '2', and finally to '9'. In postorder traversal, the nodes are visited from the bottom-up, starting with the left subtree, then the right subtree, and ending with the root node.</p></description>
@@ -87,7 +87,7 @@
             traversal algorithm works for trees with any number of children, but we
             will stick with binary trees for now.</p>
  
-        <figure align="center" xml:id="fig-booktree">
+        <figure xml:id="fig-booktree">
             <caption>Representing a Book as a Tree.</caption>
                 <image source="Trees/booktree.png" width="50%">
                 <description><p>Diagram of a hierarchical tree representing the structure of a book. The root node at the top is labeled 'Book', which branches out to two child nodes labeled 'Chapter1' and 'Chapter2'. Each chapter node further divides into sections: 'Chapter1' into 'Section 1.1' and 'Section 1.2', while 'Chapter2' splits into 'Section 2.1' and 'Section 2.2'. Each section node also branches into subsections, with 'Section 1.1' leading to 'Section 1.2.1' and 'Section 1.2.2', and 'Section 2.2' leading to 'Section 2.2.1' and 'Section 2.2.2'. The nodes are connected by lines that represent the tree structure, demonstrating the organizational hierarchy of the book's contents.</p></description>
@@ -124,7 +124,7 @@
             <title>Preorder Traversal</title>
             <task xml:id="lst-preorder1-cpp" label="lst-preorder1-cpp">
                 <title>C++ Implementation</title>
-                <statement><program language="cpp" label="lst-preorder1-cpp-prog">C++ Implementation<code>
+                <statement><program language="cpp" label="lst-preorder1-cpp-prog"><code>
 void preorder(BinaryTree *tree){
     if (tree){
         cout &lt;&lt; tree-&gt;getRootVal() &lt;&lt; endl;
@@ -157,7 +157,7 @@ def preorder(tree):
             <title>Preorder Traversal as a Method</title>
             <task xml:id="lst-preorder2-cpp" label="lst-preorder2-cpp">
                 <title>C++ Implementation</title>
-                <statement><program language="cpp" label="lst-preorder2-cpp-prog">C++ Implementation<code>
+                <statement><program language="cpp" label="lst-preorder2-cpp-prog"><code>
 void preorder(){
     cout &lt;&lt; this-&gt;key &lt;&lt; endl;
     if (this-&gt;leftChild){
@@ -198,7 +198,7 @@ def preorder(self):
             <title>Postorder Traversal</title>
             <task xml:id="lst-postorder1-cpp" label="lst-postorder1-cpp">
                 <title>C++ Implementation</title>
-                <statement><program language="cpp" label="lst-postorder1-cpp-prog">C++ Implementation<code>
+                <statement><program language="cpp" label="lst-postorder1-cpp-prog"><code>
 void postorder(BinaryTree *tree){
     if (tree != nullptr){
         postorder(tree-&gt;getLeftChild());

--- a/pretext/Trees/VocabularyandDefinitions.ptx
+++ b/pretext/Trees/VocabularyandDefinitions.ptx
@@ -2,7 +2,7 @@
     <title>Vocabulary and Definitions</title>
     <p>Now that we have looked at examples of trees, we will formally define a
         tree and its components.</p>
-    <dl>
+    <p><dl>
         <li>
             <title>Node</title>
             <idx><h>Tree Components</h><h>node</h></idx>
@@ -93,7 +93,7 @@
                     the tree. The height of the tree in <xref ref="trees_examples-filetree"/> is two.</p>
             
         </li>
-    </dl>
+    </dl></p>
     <p>With the basic vocabulary now defined, we can move on to a formal
         definition of a tree. In fact, we will provide two definitions of a
         tree. One definition involves nodes and edges. The second definition,
@@ -120,7 +120,7 @@
     <p><xref ref="fig-nodeedgetree"/> illustrates a tree that fits definition one.
         The arrowheads on the edges indicate the direction of the connection.</p>
 
-    <figure align="center" xml:id="fig-nodeedgetree">
+    <figure xml:id="fig-nodeedgetree">
         <caption>A Tree Consisting of a Set of Nodes and Edges.</caption>
             <image source="Trees/treedef1.png" width="50%">
             <description><p>The image shows a basic conceptual diagram of a tree data structure, consisting of a set of nodes connected by edges. The top of the tree features a 'rootnode', which branches into 'child1' and 'child2'. Below 'child1', there is 'node1' with three children labeled 'child1', 'child2', and 'child3', while 'child2' branches into 'node2' with a single 'child1'. Further down, 'node1' branches into 'node3', 'node4', and 'node5', and 'node2' branches into 'node6'. The nodes are represented by rectangles, and the connecting lines represent the edges of the tree.</p></description>
@@ -136,7 +136,7 @@
         nodes than that, but we do not know unless we look deeper into the tree.</p>
     
    
-    <figure align="center" xml:id="fig-recursivetree">
+    <figure xml:id="fig-recursivetree">
         <caption>A recursive Definition of a tree.</caption>
             <image source="Trees/TreeDefRecursive.png" width="50%">
             <description><p>The image presents a simplified diagram of a tree data structure with a single 'root' node at the top, branching out into three 'subtrees' labeled 'subtree-1', 'subtree-2', and 'subtree-3'. This visual model illustrates the concept of recursion in data structures, where each subtree can be seen as a smaller instance of the larger structure.</p></description>


### PR DESCRIPTION
# Description
A bunch of easy xml fixes:
- align=center is not a thing
- s/caption/title
- alt=image is not valid
- move one statement to the right place
- remove a few stray figure titles
- dl's need to be in p's

## Related Issue
standalone

## How Has This Been Tested?
local build