### PR TITLE
various xml fixes: search/sort chapters

### DIFF
--- a/pretext/SearchHash/Hashing.ptx
+++ b/pretext/SearchHash/Hashing.ptx
@@ -24,7 +24,7 @@
             <xref ref="search_hash-fig-hashtable1"/> shows a hash table of size <m>m=11</m>.
             In other words, there are <em>m</em> slots in the table, named 0 through 10.</p>
 
-        <figure align="center" xml:id="search_hash-fig-hashtable1">
+        <figure xml:id="search_hash-fig-hashtable1">
             <caption>Hash Table with 11 Empty Slots.</caption>
             <image source="SearchHash/hashtable.png" width="80%">
                 <description><p>Image depicting a hash table data structure with eleven empty slots. The slots
@@ -116,7 +116,7 @@
             <m>\lambda = \frac {numberofitems}{tablesize}</m>. For this example,
             <m>\lambda = \frac {6}{11}</m>.<idx>load factor</idx></p>
         
-        <figure align="center" xml:id="fig-hashtable2">
+        <figure xml:id="fig-hashtable2">
             <caption> Hash Table with Six Items.</caption>
             <image source="SearchHash/hashtable2.png" width="80%">
                 <description><p>Image showing a hash table with eleven slots, numbered from 0 to 10.
@@ -298,7 +298,7 @@ cout&lt;&lt;i&lt;&lt;endl;
                 string and a table size and returns the hash value in the range from 0
                 to <c>tablesize</c>-1.</p>
             
-            <figure align="center" xml:id="fig-stringhash">
+            <figure xml:id="fig-stringhash">
                 <caption>Hashing a String Using Ordinal Values.</caption>
                 <image source="SearchHash/stringhash.png" width="80%">
                     <description><p>Diagram illustrating the process of hashing a string using ordinal values.
@@ -312,7 +312,7 @@ cout&lt;&lt;i&lt;&lt;endl;
             </figure>
             
 <listing xml:id="search-hash_lst-hashfunction1">
-    <caption><c>hash</c> function</caption>
+    <title><c>hash</c> function</title>
 
     <program xml:id="simplehash" interactive="activecode" language="cpp" label="simplehash-prog"><code>
 #include &lt;iostream&gt;
@@ -346,7 +346,7 @@ int main() {
                 one possible way to use the positional value as a weighting factor. The
                 modification to the <c>hash</c> function is left as an exercise.</p>
             
-            <figure align="center" xml:id="fig-stringhash2">
+            <figure xml:id="fig-stringhash2">
                 <caption>Hashing a String Using Ordinal Values with Weighting.</caption>
                     <image source="SearchHash/stringhash2.png" width="80%">
                         <description><p>Image depicting a hashing algorithm that uses ordinal values
@@ -399,7 +399,7 @@ int main() {
                 the next open position. The final value of 20 hashes to slot 9. Since
                 slot 9 is full, we begin to do linear probing. We visit slots 10, 0, 1,
                 and 2, and finally find an empty slot at position 3.</p>
-            <figure align="center" xml:id="fig-linearprobing1">
+            <figure xml:id="fig-linearprobing1">
                 <caption>Collision Resolution with Linear Probing.</caption>
                 <image source="SearchHash/linearprobing1.png" width="80%">
                     <description><p>Image of a hash table illustrating collision resolution with linear probing.
@@ -430,7 +430,7 @@ int main() {
                 finally find an open position. This cluster is shown in
                 <xref ref="fig-clustering"/>.</p>
 
-            <figure align="center" xml:id="fig-clustering">
+            <figure xml:id="fig-clustering">
                 <caption>A Cluster of Items for Slot 0.</caption>
                 <image source="SearchHash/clustering.png" width="80%">
                     <description><p>Image of a hash table with a series of filled and empty slots.
@@ -451,7 +451,7 @@ int main() {
                 resolution is done with a <q>plus 3</q> probe. This means that once a
                 collision occurs, we will look at every third slot until we find one
                 that is empty.</p>
-            <figure align="center" xml:id="fig-linearprobing2">
+            <figure xml:id="fig-linearprobing2">
                 <caption>Collision Resolution Using <q>Plus 3</q>.</caption>
                 <image source="SearchHash/linearprobing2.png" width="80%">
                     <description><p>Image of a hash table with eleven slots, demonstrating collision
@@ -485,7 +485,7 @@ int main() {
                 <xref ref="fig-quadratic"/> shows our example values after they are placed using
                 this technique.</p> 
 
-            <figure align="center" xml:id="fig-quadratic">
+            <figure xml:id="fig-quadratic">
                 <caption>Collision Resolution with Quadratic Probing.</caption>
                 <image source="SearchHash/quadratic.png" width="80%">
                     <description><p>Image of a hash table with eleven numbered slots, illustrating
@@ -509,7 +509,7 @@ int main() {
                 increases. <xref ref="fig-chaining"/> shows the items as they are added to a hash
                 table that uses chaining to resolve collisions.</p>
                 
-            <figure align="center" xml:id="fig-chaining">
+            <figure xml:id="fig-chaining">
                 <caption>Collision Resolution with Chaining.</caption>
                 <image source="SearchHash/chaining.png" width="80%">
                     <description><p>Image of a hash table with eleven slots numbered from 0 to 10,
@@ -634,7 +634,7 @@ int main() {
                 can be as efficient as possible.</p>
     
             <listing xml:id="search-hash_lst-hashtablecodeconstructor">
-                <caption><c>HashTable</c> Class</caption>
+                <title><c>HashTable</c> Class</title>
                 <program language="cpp" label="search-hash_lst-hashtablecodeconstructor-prog"><code>
     class HashTable{
     public:
@@ -803,7 +803,7 @@ def __setitem__(self,key,data):
                 will create a hash table and store some items with integer keys and
                 string data values.</p>
             <listing xml:id="hashtable-output">
-                <caption>Example Use of <c>HashTable</c></caption>
+                <title>Example Use of <c>HashTable</c></title>
                 <program language="cpp" label="hashtable-output-prog"><code>
 int main() {
     HashTable h;
@@ -841,7 +841,7 @@ Output:
                 (<xref ref="hashtable-output2"/>). Note that
                 the value for the key 20 is being replaced.</p>
             <listing xml:id="hashtable-output2">
-                <caption>Continued use of <c>HashTable</c></caption>
+                <title>Continued use of <c>HashTable</c></title>
                 <program language="cpp" label="hashtable-output2-prog"><code>
 ...
 h.put(20,&quot;chicken&quot;);

--- a/pretext/SearchHash/SelfCheck.ptx
+++ b/pretext/SearchHash/SelfCheck.ptx
@@ -23,21 +23,21 @@
     <exercise label="hashcollisions">
         <statement><p>What creates hash collisions?</p></statement>
         <choices>
-            <choice correct="no" label="a">
-                <statement>when pairs of different hash values are mapped to the same key.</statement>
-                <feedback>Think about what keys refer to and what hash values refer to</feedback>
+            <choice correct="no">
+                <statement><p>when pairs of different hash values are mapped to the same key.</p></statement>
+                <feedback><p>Think about what keys refer to and what hash values refer to</p></feedback>
             </choice>
-            <choice correct="no" label="b">
-                <statement>when pairs of different hash values do not share the same key.</statement>
-                <feedback>Think about what keys refer to and what hash values refer to</feedback>
+            <choice correct="no">
+                <statement><p>when pairs of different hash values do not share the same key.</p></statement>
+                <feedback><p>Think about what keys refer to and what hash values refer to</p></feedback>
             </choice>
-            <choice correct="yes" label="c">
-                <statement>when pairs of different keys are mapped to the same hash value.</statement>
-                <feedback>Correct!</feedback>
+            <choice correct="yes">
+                <statement><p>when pairs of different keys are mapped to the same hash value.</p></statement>
+                <feedback><p>Correct!</p></feedback>
             </choice>
-            <choice correct="no" label="d">
-                <statement>when pairs of different keys do not share the same hash value.</statement>
-                <feedback>Think about what keys refer to and what hash values refer to</feedback>
+            <choice correct="no">
+                <statement><p>when pairs of different keys do not share the same hash value.</p></statement>
+                <feedback><p>Think about what keys refer to and what hash values refer to</p></feedback>
             </choice>
         </choices>
     </exercise>

--- a/pretext/SearchHash/TheBinarySearch.ptx
+++ b/pretext/SearchHash/TheBinarySearch.ptx
@@ -21,7 +21,7 @@
             algorithm can quickly find the value 54. The complete function is shown
             in <xref ref="lst-binary_search_cpp"/>.</p>
             
-        <figure align="center" xml:id="fig-binsearch">
+        <figure xml:id="fig-binsearch">
             <caption>Binary Search of an Ordered vector of Integers.</caption>
                 <image source="SearchHash/binsearch.png" width="80%">
                 <description><p>Diagram of an ordered sequence of boxes containing integers, indicative of a binary search algorithm. The numbers in the boxes are '17', '20', '26', '31', '44', '54', '55', '65', '77', and '93', arranged in ascending order. An arrow labeled 'Start' splits into two, pointing to the middle of the sequence, suggesting the initial step in binary search where the middle element is first compared with the target value.</p></description>
@@ -31,7 +31,7 @@
         <p>A similar implementation can be carried out using vectors in C++.</p>
 
     <listing xml:id="lst-binary_search_cpp">
-        <caption>Binary Search of a vector</caption>
+        <title>Binary Search of a vector</title>
     <program xml:id="binary_search_cpp" interactive="activecode" language="cpp" label="binary_search_cpp-prog">
         <code>
 #include &lt;iostream&gt;
@@ -90,7 +90,7 @@ int main() {
             however this can only be used when new vectors are created.</p>
 
     <listing xml:id="binarysearch-1">
-        <caption>Recursive Binary Search</caption>
+        <title>Recursive Binary Search</title>
     <program xml:id="binary_search_cpp_recursive" interactive="activecode" language="cpp" label="binary_search_cpp_recursive-prog">
         <code>
 #include &lt;iostream&gt;

--- a/pretext/SearchHash/TheSequentialSearch.ptx
+++ b/pretext/SearchHash/TheSequentialSearch.ptx
@@ -17,7 +17,7 @@
             for or run out of items. If we run out of items, we have discovered that
             the item we were searching for was not present.</p>
         
-        <figure align="center" xml:id="fig-seqsearch">
+        <figure xml:id="fig-seqsearch">
             <caption>Sequential Search of a List of Integers.</caption>
                 <image source="SearchHash/seqsearch.png" width="80%">
                 <description><p>Diagram showing a horizontal sequence of connected boxes containing integers, illustrating a sequential search algorithm. Each box contains a unique number, with values visible in the image including '54', '26', '93', '17', '77', '31', '44', '55', '20', and '65'. A curved arrow labeled 'Start' points to the first box '54', indicating the beginning of the search process. The arrangement suggests that the search will proceed through the list of numbers from left to right.</p></description>
@@ -25,42 +25,16 @@
             </figure>
 
             <p>Both the Python and C++ implementations for this algorithm are shown in
-                <xref ref="seqsearchonepy" text="ActiveCode Python"/> and <xref ref="seqsearchonecpp" text="ActiveCode C++"/> respectively. The function needs the list and the item we
+                <xref ref="seqsearchonepy" /> and <xref ref="seqsearchonecpp" />> respectively. The function needs the list and the item we
                 are looking for and returns a boolean value as to whether it is present.
                 The boolean variable <c>found</c> is initialized to <c>False</c> and is
                 assigned the value <c>True</c> if we discover the item in the list (or vector, in the case of C++).</p>
 
-            <listing xml:id="seqsearchonepy">
-                <caption>Python Implementation</caption>
-                <program interactive="activecode" language="python" label="seqsearchonepy-prog">
-                    <code>
-                    # Python implementation of sequential search
-                    def sequential_search(lst, item):
-                        found = False
-                        for i in range(len(lst)):
-                            if lst[i] == item:
-                                found = True
-                                break
-                        return found
-                    
-                    if __name__ == &quot;__main__&quot;:
-                        lst = [1, 2, 3, 4, 5]
-                        item = 3
-                        if sequential_search(lst, item):
-                            print(&quot;Item found!&quot;)
-                        else:
-                            print(&quot;Item not found.&quot;)
-                    </code>
-                </program>
-            </listing>
-
-
-
-            <listing xml:id="seqsearchonecpp">
-                <caption>C++ Implementation</caption>
-
-                <program xml:id="lst-seqsearchcpp" interactive="activecode" language="cpp" label="lst-seqsearchcpp-prog">
-                    <code>
+            <exploration xml:id="expl-seqsearch">
+                <title>Sequential Search</title>
+                <task xml:id="seqsearchonecpp" label="seqsearchonecpp">
+                    <title>C++ Implementation</title>
+                    <statement><program xml:id="lst-seqsearchcpp" interactive="activecode" language="cpp" label="lst-seqsearchcpp-prog"><code>
             #include &lt;iostream&gt;
             #include &lt;vector&gt;
             using namespace std;
@@ -93,9 +67,32 @@
             
                 return 0;
             }
-                </code>
-            </program>
-        </listing>
+                    </code></program></statement>
+                </task>
+                <task label="tsk-seqsearchpy" xml:id="seqsearchonepy">
+                    <title>Python Implementation</title>
+                    <statement><program interactive="activecode" language="python" label="seqsearchonepy-prog"><code>
+                    # Python implementation of sequential search
+                    def sequential_search(lst, item):
+                        found = False
+                        for i in range(len(lst)):
+                            if lst[i] == item:
+                                found = True
+                                break
+                        return found
+                    
+                    if __name__ == &quot;__main__&quot;:
+                        lst = [1, 2, 3, 4, 5]
+                        item = 3
+                        if sequential_search(lst, item):
+                            print(&quot;Item found!&quot;)
+                        else:
+                            print(&quot;Item not found.&quot;)
+                        </code></program></statement>
+                    </task>
+                </exploration>
+
+
         </introduction>
         <subsection xml:id="search-hash_analysis-of-sequential-search">
             <title>Analysis of Sequential Search</title>
@@ -116,7 +113,7 @@
                 scenarios that can occur. In the best case we will find the item in the
                 first place we look, at the beginning of the list. We will need only one
                 comparison. In the worst case, we will not discover the item until the
-                very last comparison, the <title_reference>nth</title_reference> comparison.</p>
+                very last comparison, the <m>n^{th}</m> comparison.</p>
             <p>What about the average case? On average, we will find the item about
                 halfway into the list; that is, we will compare against
                 <m>\frac{n}{2}</m> items. Recall, however, that as <em>n</em> gets large,
@@ -186,7 +183,7 @@
                 sequential search function.</p>
 
           
-            <figure align="center" xml:id="fig-seqsearch2">
+            <figure xml:id="fig-seqsearch2">
                 <caption>Sequential Search of an Ordered List of Integers.</caption>
                     <image source="SearchHash/seqsearch2.png" width="80%">
                     <description><p>Image of a sequence of connected boxes in a horizontal line, each containing a number, representing a sequential search on an ordered list of integers. The numbers, displayed in ascending order, are '17', '20', '26', '31', '44', '54', '55', '65', '77', and '93'. A curved arrow labeled 'Start' points to the first box with '17', indicating the point where the search begins. The sequence suggests a methodical approach to searching, where each element is checked in order until the desired number is found.</p></description>
@@ -195,7 +192,7 @@
             
 
             <listing xml:id="lst-orderedseq">
-                <caption>Ordered Sequential Search</caption>
+                <title>Ordered Sequential Search</title>
                 <program xml:id="search2_cpp" interactive="activecode" language="cpp" label="search2_cpp-prog"><code>
 #include &lt;iostream&gt;
 #include &lt;vector&gt;

--- a/pretext/SearchHash/searching.ptx
+++ b/pretext/SearchHash/searching.ptx
@@ -26,7 +26,9 @@ True
             stop), and the third argument value to <c>find</c> is the item
             to locate. If the item is not found, the second argument
             is returned. If it is found, an iterator is returned.</p>
-        <listing xml:id="find-example"><program language="cpp"><code>
+        <listing xml:id="find-example">
+            <title>Using <c>find</c></title>
+            <program language="cpp"><code>
 #include &lt;iostream&gt;
 #include &lt;algorithm&gt;
 #include &lt;vector&gt;

--- a/pretext/Sort/SelfCheck.ptx
+++ b/pretext/Sort/SelfCheck.ptx
@@ -5,20 +5,20 @@
         <statement><p>Which of the following sort algorithms are guaranteed to be <m>O(n \log n)</m> even in the worst case?</p></statement>
         <choices>
             <choice>
-                <statement>Shell Sort</statement>
-                <feedback>Incorrect! Shell sort is between <m>O(n)</m> and <m>O(n^2)</m></feedback>
+                <statement><p>Shell Sort</p></statement>
+                <feedback><p>Incorrect! Shell sort is between <m>O(n)</m> and <m>O(n^2)</m></p></feedback>
             </choice>
             <choice>
-                <statement>Quick Sort</statement>
-                <feedback>Incorrect! Quick sort can be <m>O(n \log n)</m>, but if the pivot points are not well chosen and the list is just so, it can be <m>O(n^2)</m>.</feedback>
+                <statement><p>Quick Sort</p></statement>
+                <feedback><p>Incorrect! Quick sort can be <m>O(n \log n)</m>, but if the pivot points are not well chosen and the list is just so, it can be <m>O(n^2)</m>.</p></feedback>
             </choice>
             <choice correct="yes">
-                <statement>Merge Sort</statement>
-                <feedback>Correct! Merge Sort is the only guaranteed <m>O(n \log n)</m> even in the worst case. The cost is that merge sort uses more memory.</feedback>
+                <statement><p>Merge Sort</p></statement>
+                <feedback><p>Correct! Merge Sort is the only guaranteed <m>O(n \log n)</m> even in the worst case. The cost is that merge sort uses more memory.</p></feedback>
             </choice>
             <choice>
-                <statement>Insertion Sort</statement>
-                <feedback>Incorrect! Insertion sort is <m>O(n^2)</m></feedback>
+                <statement><p>Insertion Sort</p></statement>
+                <feedback><p>Incorrect! Insertion sort is <m>O(n^2)</m></p></feedback>
             </choice>
         </choices>
     </exercise>
@@ -38,20 +38,20 @@
         <statement><p>Which sort should you use for best efficiency If you need to sort through 100,000 random items in a list?</p></statement>
         <choices>
             <choice correct="yes">
-                <statement>Merge</statement>
-                <feedback>Correct!</feedback>
+                <statement><p>Merge</p></statement>
+                <feedback><p>Correct!</p></feedback>
             </choice>
             <choice>
-                <statement>Selection</statement>
-                <feedback>Incorrect! Selection sort is inefficient in large lists.</feedback>
+                <statement><p>Selection</p></statement>
+                <feedback><p>Incorrect! Selection sort is inefficient in large lists.</p></feedback>
             </choice>
             <choice>
-                <statement>Bubble</statement>
-                <feedback>Incorrect! Bubble sort works best with mostly sorted lists.</feedback>
+                <statement><p>Bubble</p></statement>
+                <feedback><p>Incorrect! Bubble sort works best with mostly sorted lists.</p></feedback>
             </choice>
             <choice>
-                <statement>Insertion</statement>
-                <feedback>Incorrect! Insertion sort works best with either small or mostly sorted lists.</feedback>
+                <statement><p>Insertion</p></statement>
+                <feedback><p>Incorrect! Insertion sort works best with either small or mostly sorted lists.</p></feedback>
             </choice>
         </choices>
     </exercise>

--- a/pretext/Sort/TheBubbleSort.ptx
+++ b/pretext/Sort/TheBubbleSort.ptx
@@ -11,7 +11,7 @@
             the largest value in the array is part of a pair, it will continually be
             moved along until the pass is complete.</p>
         
-        <figure align="center" xml:id="fig-bubblepass">
+        <figure xml:id="fig-bubblepass">
             <caption><c>BubbleSort</c> The First Pass.</caption>
                 <image source="Sort/bubblepass.png" width="50%">
                 <description><p>Illustration of bubble sort algorithm during the first pass. A series of arrays showing the step-by-step process of sorting numbers in ascending order. Starting with the array [54, 26, 93, 17, 77, 31, 44, 55, 20], subsequent arrays demonstrate swapping of elements, marked as 'Exchange', or retention of position, marked as 'No Exchange', to progressively move the highest number, 93, to the correct position at the end of the array after the first pass. The final array in the sequence is [26, 54, 17, 77, 31, 44, 55, 20, 93], with the note '93 in place after first pass' indicating the completion of this sorting stage.</p></description>
@@ -31,14 +31,14 @@
         <pre>temp = alist[i];
 alist[i] = alist[j];
 alist[j] = temp;</pre>
-        <p>will exchange the <title_reference>ith</title_reference> and <title_reference>jth</title_reference> items in the array. Without the
+        <p>will exchange the <m>i^{th}</m> and <m>j^{th}</m> items in the array. Without the
             temporary storage, one of the values would be overwritten.</p>
         <p>Lines 5-7 in <xref ref="lst-bubble-cpp"/> perform the exchange of the <m>i</m> and
             <m>(i+1)th</m> items using the three<ndash/>step procedure described
             earlier. Note that we could also have used the simultaneous assignment
             to swap the items.</p>
         
-        <figure align="center" xml:id="fig-pythonswap">
+        <figure xml:id="fig-pythonswap">
             <caption>Exchanging Two Values in Python.</caption>
                 <image source="Sort/swap.png" width="50%">
                 <description><p>A diagram explaining the process of exchanging two values in a programming language with an

--- a/pretext/Sort/TheInsertionSort.ptx
+++ b/pretext/Sort/TheInsertionSort.ptx
@@ -7,7 +7,7 @@
             <xref ref="fig-insertionsort"/> shows the insertion sorting process. The shaded
             items represent the ordered subvectors as the algorithm makes each pass.</p>
         
-        <figure align="center" xml:id="fig-insertionsort">
+        <figure xml:id="fig-insertionsort">
             <caption>InsertionSort.</caption>
                 <image source="Sort/insertionsort.png" width="50%">
                 <description><p>A step-by-step visual representation of the insertion sort algorithm. The image shows a series of rows with numbers in boxes, illustrating the process of sorting the numbers in ascending order. Each row represents a step in the algorithm, with the text on the right indicating the action taken, such as 'inserted 26' or 'inserted 93'. The sequence begins with the numbers 54, 26, 93, and so on, and gradually transforms into a sorted sequence from left to right as the algorithm progresses. The caption 'Figure 7.5.1. insertionSort' is placed below the image.</p></description>
@@ -30,7 +30,7 @@
             have a sorted subvector of six items.</p>
         
 
-        <figure align="center" xml:id="fig-insertionpass">
+        <figure xml:id="fig-insertionpass">
             <caption><c>InsertionSort</c>: Fifth Pass of the Sort.</caption>
                 <image source="Sort/insertionpass.png" width="50%">
                 <description><p>An educational illustration depicting the fifth pass of the insertion sort algorithm. The diagram shows a series of rows with numerical values in boxes, each row representing a step in the sorting process. Arrows indicate the shifting of numbers to make space for the correctly positioned value. Descriptive text accompanies each step explaining the movement required, such as '93&gt;31 so shift it to the right' and 'Need to insert 31 back into the sorted list'. The final row shows the number 31 being inserted into its correct position in the sequence.</p></description>

--- a/pretext/Sort/TheMergeSort.ptx
+++ b/pretext/Sort/TheMergeSort.ptx
@@ -13,14 +13,14 @@
             vector as it is being split by <c>mergeSort</c>. <xref ref="fig-mergesortb"/> shows
             the simple vectors, now sorted, as they are merged back together.</p>
         
-        <figure align="center" xml:id="fig-mergesorta">
+        <figure xml:id="fig-mergesorta">
             <caption>Splitting the vector in a Merge Sort.</caption>
                 <image source="Sort/mergesortA.png" width="80%">
                 <description><p>An illustrative flowchart of the Merge Sort algorithm showing the process of splitting a vector into smaller parts. The chart starts with a single row of numbers at the top: 54, 26, 93, 17, 77, 31, 44, 55, 20, and branches downwards into increasingly smaller groups. Each branch represents a division of the list into two parts, progressively breaking down the numbers into individual elements. The flowchart visually demonstrates how Merge Sort recursively divides a list until each part contains a single element, preparing for the merge phase.</p></description>
                 </image>
             </figure>
         
-        <figure align="center" xml:id="fig-mergesortb">
+        <figure xml:id="fig-mergesortb">
             <caption>Vectors as They Are Merged Together.</caption>
                 <image source="Sort/mergesortB.png" width="80%">
                 <description><p>A diagram depicting the merging phase of the Merge Sort algorithm. The flowchart shows the combination of divided vectors into a sorted sequence. It starts with smaller groups of numbers at the top, each sorted individually: 26 and 54, 17 and 93, and so on. These groups are then merged into larger sorted sequences through a series of downward-pointing arrows, indicating the order of merging. The process continues until all numbers are combined into a single sorted list at the bottom: 17, 20, 26, 31, 44, 54, 55, 77, 93.</p></description>

--- a/pretext/Sort/TheQuickSort.ptx
+++ b/pretext/Sort/TheQuickSort.ptx
@@ -18,7 +18,7 @@
             at the same time move other items to the appropriate side of the list,
             either less than or greater than the pivot value.</p>
         
-        <figure align="center" xml:id="fig-splitvalue">
+        <figure xml:id="fig-splitvalue">
             <caption>The First Pivot Value for a Quick Sort.</caption>
                 <image source="Sort/firstsplit.png" width="80%">
                 <description><p>A single row of numbers shown in boxes with the number 54 highlighted and labeled as '54 will be the first pivot value'. This image is used to illustrate the initial step in the Quick Sort algorithm where a pivot value is chosen to partition the list. The rest of the numbers in the row are in lighter boxes and include 26, 93, 17, 77, 31, 44, 55, and 20.</p></description>
@@ -35,7 +35,7 @@
             of 54.</p>
         
 
-        <figure align="center" xml:id="fig-partitiona">
+        <figure xml:id="fig-partitiona">
             <caption>Finding the Split Point for 54.</caption>
                 <image source="Sort/partitionA.png" width="80%">
                 <description><p>A series of diagrams illustrating the process of finding the split point for the number 54 in a Quick Sort algorithm. The diagrams show a row of numbers with two markers, 'leftmark' and 'rightmark', that move towards each other from opposite ends. Each step of the process is annotated with instructions like 'leftmark and rightmark will converge on split point', '26 &lt;54 move to right, exchange 20 and 93, and so on. The movement of the markers and the exchanges of numbers are depicted with arrows and highlighted actions, detailing how the algorithm partitions the data around the pivot. The final diagram shows the leftmark and rightmark crossing over, indicating the split point has been found, and the pivot, 54, is in its correct position.</p></description>
@@ -60,7 +60,7 @@
             value. The list can now be divided at the split point and the quick sort
             can be invoked recursively on the two halves.</p>
         
-        <figure align="center" xml:id="fig-partitionb">
+        <figure xml:id="fig-partitionb">
             <caption>Completing the Partition Process to Find the Split Point for 54.</caption>
                 <image source="SearchHash/partitionB.png" width="80%">
                 <description><p>The image shows the final step in the partitioning process of the Quick Sort algorithm, where the split point for the pivot value 54 is established. Two separate groups of numbers are displayed. The first group to the left includes numbers less than 54: 31, 26, 20, 17, and 44, with the annotation 'quicksort left half'. The second group to the right includes numbers greater than 54: 77, 55, and 93, with the annotation 'quicksort right half'. The number 54 is positioned in the center, labeled '54 is in place', indicating that it is at its correct position in the sorted array.</p></description>

--- a/pretext/Sort/TheShellSort.ptx
+++ b/pretext/Sort/TheShellSort.ptx
@@ -16,7 +16,7 @@
             the subvectors, we have moved the items closer to where they actually
             belong.</p>
         
-        <figure align="center" xml:id="fig-incrementsa">
+        <figure xml:id="fig-incrementsa">
             <caption>A Shell Sort with Increments of Three</caption>
                 <image source="Sort/shellsortA.png" width="50%">
                 <description><p>Visual diagram showing three rows of numbers representing sublists in the Shell Sort algorithm with increments of three. Each row contains the same sequence of numbers: 54, 26, 93, 17, 77, 31, 44, 55, 20, categorized into 'sublist 1', 'sublist 2', and 'sublist 3'. This illustrates the initial stage of Shell Sort where the list is divided into sublists based on a specific increment, in this case, three, to be sorted individually.</p></description>
@@ -24,7 +24,7 @@
             </figure>
 
         
-        <figure align="center" xml:id="fig-incrementsb">
+        <figure xml:id="fig-incrementsb">
             <caption>A Shell Sort after Sorting Each subvector</caption>
                 <image source="Sort/shellsortB.png" width="50%">
                 <description><p>Illustration of a Shell Sort algorithm after sorting each subvector. Three rows of numbers in boxes, each labeled as 'sublist 1 sorted', 'sublist 2 sorted', and 'sublist 3 sorted', show the partial sorting within each sublist. Arrows point downwards from these sublists to a final sorted row, demonstrating the result of combining the sorted sublists at increment 3. The numbers in the final row are more ordered compared to the original sublists above.</p></description>
@@ -38,7 +38,7 @@
             this case, we need only four more shifts to complete the process.</p>
         
 
-        <figure align="center" xml:id="fig-incrementsc">
+        <figure xml:id="fig-incrementsc">
             <caption>ShellSort: A Final Insertion Sort with Increment of 1</caption>
                 <image source="Sort/shellsortC.png" width="50%">
                 <description><p>An instructional image of ShellSort's final insertion sort phase with an increment of 1, displaying a series of rows with numerical values in boxes. The top row shows the initial unsorted state of numbers. Subsequent rows depict the sorting process, with arrows indicating the shifting of numbers to insert them into their correct position. Descriptive text such as '1 shift for 20', '2 shifts for 31', and '1 shift for 54' explains the actions taken at each step. The final row shows the numbers in a fully sorted order.</p></description>
@@ -46,7 +46,7 @@
             </figure>
 
 
-        <figure align="center" xml:id="fig-incrementsd">
+        <figure xml:id="fig-incrementsd">
             <caption>Initial Subvectors for a Shell Sort</caption>
                 <image source="Sort/shellsortD.png" width="50%">
                 <description><p>The image illustrates the initial division of a list into subvectors for the Shell Sort algorithm. There are four rows of grey boxes, each representing a sublist, labeled from sublist 1 to sublist 4. Inside each row are the same sequence of numbers: 54, 26, 93, 17, 77, 31, 44, 55, 20, indicating the elements that will be sorted within each sublist.</p></description>


### PR DESCRIPTION
# Description
a bunch of easy xml fixes
- align=center is not a thing
- s/caption/title
- choice elements can't have label attr
- statement and feedback need paragraphs for text
- remove title_reference
- found another opportunity to use a tab interface in seq search

## Related Issue
standalone

## How Has This Been Tested?
local build