### PR TITLE
xml fixups: intro chapter

### DIFF
--- a/pretext/Introduction/BuiltInAtomicDataTypes.ptx
+++ b/pretext/Introduction/BuiltInAtomicDataTypes.ptx
@@ -250,7 +250,7 @@ main()
       </task>
     </exploration>
     <p>Boolean data objects are also used as results for comparison operators
-                such as equality (==) and greater than (<math>&gt;</math>). In addition,
+                such as equality (==) and greater than (<m>&gt;</m>). In addition,
                 relational operators and logical operators can be combined together to
                 form complex logical questions. <xref ref="introduction_tab-relational"/> shows the relational
                 and logical operators with examples shown in the session that follows.</p>
@@ -269,103 +269,49 @@ main()
           </cell>
         </row>
         <row>
-          <cell>
-                                less than
-                            </cell>
-          <cell>
-            <math>&lt;</math>
-          </cell>
-          <cell>
-                                Less than operator
-                            </cell>
+          <cell>less than</cell>
+          <cell><c>&lt;</c></cell>
+          <cell>Less than operator</cell>
         </row>
         <row>
-          <cell>
-                                greater than
-                            </cell>
-          <cell>
-            <math>&gt;</math>
-          </cell>
-          <cell>
-                                Greater than operator
-                            </cell>
+          <cell>greater than</cell>
+          <cell><c>&gt;</c></cell>
+          <cell>Greater than operator</cell>
         </row>
         <row>
-          <cell>
-                                less than or equal
-                            </cell>
-          <cell>
-            <math>&lt;=</math>
-          </cell>
-          <cell>
-                                Less than or equal to operator
-                            </cell>
+          <cell>less than or equal</cell>
+          <cell><c>&lt;=</c></cell>
+          <cell>Less than or equal to operator</cell>
         </row>
         <row>
-          <cell>
-                                greater than or equal
-                            </cell>
-          <cell>
-            <math>&gt;=</math>
-          </cell>
-          <cell>
-                                Greater than or equal to operator
-                            </cell>
+          <cell>greater than or equal</cell>
+          <cell><c>&gt;=</c></cell>
+          <cell>Greater than or equal to operator</cell>
         </row>
         <row>
-          <cell>
-                                equal
-                            </cell>
-          <cell>
-            <math>==</math>
-          </cell>
-          <cell>
-                                Equality operator
-                            </cell>
+          <cell>equal</cell>
+          <cell><c>==</c></cell>
+          <cell>Equality operator</cell>
         </row>
         <row>
-          <cell>
-                                not equal
-                            </cell>
-          <cell>
-            <math>!=</math>
-          </cell>
-          <cell>
-                                Not equal operator
-                            </cell>
+          <cell>not equal</cell>
+          <cell><c>!=</c></cell>
+          <cell>Not equal operator</cell>
         </row>
         <row>
-          <cell>
-                                logical and
-                            </cell>
-          <cell>
-            <math>&amp;&amp;</math>
-          </cell>
-          <cell>
-                                Both operands true for result to be true
-                            </cell>
+          <cell>logical and</cell>
+          <cell><c>&amp;&amp;</c></cell>
+          <cell>Both operands true for result to be true</cell>
         </row>
         <row>
-          <cell>
-                                logical or
-                            </cell>
-          <cell>
-            <math>||</math>
-          </cell>
-          <cell>
-                                One or the other operand is true for the result to be true
-                            </cell>
+          <cell>logical or</cell>
+          <cell><c>||</c></cell>
+          <cell>One or the other operand is true for the result to be true</cell>
         </row>
         <row>
-          <cell>
-                                logical not
-                            </cell>
-          <cell>
-            <math>!</math>
-          </cell>
-          <cell>
-                                Negates the truth value, false becomes true, true becomes false
-                            </cell>
+          <cell>logical not</cell>
+          <cell><c>!</c></cell>
+          <cell>Negates the truth value, false becomes true, true becomes false</cell>
         </row>
       </tabular>
     </table>
@@ -830,7 +776,7 @@ int main() {
       <p>which is expected because you changed where ptrN is pointing to and
                     NOT the contents of where it is pointing.</p>
       <p>The second <c>cout</c> instruction is a disaster because</p>
-      <ol marker="1">
+      <p><ol marker="1">
         <li>
           <p>You don<rsq/>t know what is stored in location 100 in memory, and</p>
         </li>
@@ -840,7 +786,7 @@ int main() {
             errors, the reason is fairly localized.
           </p>
         </li>
-      </ol>
+      </ol></p>
     </subsubsection>
     <subsubsection xml:id="introduction_the-null-pointer">
       <title>The null pointer</title>

--- a/pretext/Introduction/CollectionData.ptx
+++ b/pretext/Introduction/CollectionData.ptx
@@ -511,7 +511,7 @@ main()
             <xref ref="vector_no_reserve_cpp"/>.</p>
 
             <listing xml:id="vector_no_reserve_cpp">
-                <caption><c>reserve</c> is optional</caption>
+                <title><c>reserve</c> is optional</title>
                 <program interactive="activecode" language="cpp" label="vector_no_reserve_cpp-prog"><code>
 //code from above but without the reserve
 #include &lt;iostream&gt;

--- a/pretext/Introduction/DefiningFunctions.ptx
+++ b/pretext/Introduction/DefiningFunctions.ptx
@@ -203,7 +203,7 @@ int main( ) {
     </program></listing>
             <p>For the program in <xref ref="activepassrefcpp"/> to reverse the order of the integers the users types in, the function <c>swap_values(...)</c> must be able to change the values of the arguments. Try removing one or both of the <c>&amp;</c><rsq/>s in this code to see what happens.</p>
         </subsection>
-        <transition/>
+
         <subsection xml:id="introduction_arrays-as-parameters-in-functions">
             <title>Arrays as Parameters in Functions</title>
             <p><idx>array parameters</idx>Functions can be used with <term>array parameters</term> to maintain a structured design.

--- a/pretext/Introduction/Glossary.ptx
+++ b/pretext/Introduction/Glossary.ptx
@@ -1,7 +1,7 @@
 <section xml:id="introduction_glossary">
-        <title>Glossary</title>
-        <glossary sorted="False">
-            
+    <title>Glossary</title>
+    <p>The following terms were defined in this chapter.</p>
+    <glossary>
                 <gi>
                     <title>abstract data type/ADT</title>
                     
@@ -419,7 +419,7 @@
                 </gi>
             
         </glossary>
-        <conclusion><p>
+        <p>
             <!-- extra space before the progress bar -->
-        </p></conclusion>
+        </p>
 </section>

--- a/pretext/Introduction/ObjectOrientedProgrammingDefiningClasses.ptx
+++ b/pretext/Introduction/ObjectOrientedProgrammingDefiningClasses.ptx
@@ -772,7 +772,7 @@ def __eq__(self, other):
             </exploration>
 
             <p>The complete <c>Fraction</c> class, up to this point, is shown in
-                <xref ref="fraction_class_cpp"/>. We leave the remaining arithmetic and relational
+                <xref ref="fraction_class_cpp" />. We leave the remaining arithmetic and relational
                 methods as exercises.</p>
 
 

--- a/pretext/Introduction/WhatIsComputerScience.ptx
+++ b/pretext/Introduction/WhatIsComputerScience.ptx
@@ -115,7 +115,7 @@ print(math.sqrt(16))
             parameters), and what will be returned. The details are hidden inside
             (see <xref ref="fig-procabstraction"/>).</p>
 
-        <figure align="center" xml:id="fig-procabstraction">
+        <figure xml:id="fig-procabstraction">
             <caption>Procedural Abstraction</caption>
                 <image source="Introduction/blackbox.png" width="50%">
                 <description><p>Diagram illustrating the concept of procedural abstraction with a central box labeled 'sqrt()' representing a function. An arrow labeled 'n' points to the box, indicating the input, and another arrow points away from the box, labeled 'square root of n', indicating the output.</p></description>

--- a/pretext/Introduction/WhyStudyDataStructuresandAbstractDataTypes.ptx
+++ b/pretext/Introduction/WhyStudyDataStructuresandAbstractDataTypes.ptx
@@ -29,7 +29,7 @@
             hidden one level deeper. The user is not concerned with the details of
             the implementation.</p>
         
-        <figure align="center" xml:id="fig-adt">
+        <figure xml:id="fig-adt">
             <caption>Abstract Data Type</caption>
                 <image source="Introduction/adt.png" width="50%">
                 <description><p>Concentric circles diagram representing an Abstract Data Type (ADT) structure. The innermost circle is labeled 'Implementation', surrounded by a middle layer labeled 'Operations', and an outer layer labeled 'Interface'. An arrow from the top points to the 'Interface' layer, labeled 'User', illustrating the interaction flow.</p></description>


### PR DESCRIPTION
# Description
a bunch of easy xml fixes:
- align="center" is not a thing
- use code markup for C++ operators
- ol's have to be in p's
- a glossary has to have at least one paragraph
- s/caption/title

## Related Issue
<!--- This project prefers pull requests related to open issues -->
<!--- If suggesting a change, please discuss it in an issue first -->
<!--- Please link to the issue here: -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
