### PR TITLE
names= is not a thing

### DIFF
--- a/pretext/Graphs/BuildingtheKnightsTourGraph.ptx
+++ b/pretext/Graphs/BuildingtheKnightsTourGraph.ptx
@@ -23,7 +23,7 @@
             column into a linear vertex number similar to the vertex numbers shown
             in <xref ref="fig-knightmoves"/>.</p>
         
-        <listing xml:id="graphs_lst-knighttour1" names="lst_knighttour1">
+        <listing xml:id="graphs_lst-knighttour1">
             <title>Building The Full Knights Tour Graph.</title>
             <program language="cpp" label="graphs_lst-knighttour1-prog"><code>
 Graph knightGraph(int bdSize) {
@@ -49,7 +49,7 @@ Graph knightGraph(int bdSize) {
             helper function (<xref ref="graphs_lst-knighttour2"/>) makes sure that a particular move that is generated is
             still on the board.</p>
     
-        <listing xml:id="graphs_lst-knighttour2" names="lst_knighttour2">
+        <listing xml:id="graphs_lst-knighttour2">
             <title>Generating Legal Moves</title>
             <program language="cpp" label="graphs_lst-knighttour2-prog"><code>
 int coordToNum(int x, int y, int bdSize) {

--- a/pretext/Graphs/Implementation.ptx
+++ b/pretext/Graphs/Implementation.ptx
@@ -17,7 +17,7 @@
             we get a list of its connections, instead of an error. This function must be initialized
             as a <c>friend function</c> within the class definition, but is required to be defined outside of the class. This is specific to <c>operator overloading</c> in C++.</p>
         
-        <listing xml:id="lst_vertex" names="graphs_lst-vertex">
+        <listing xml:id="lst_vertex">
                 <title><c>Vertex</c> Class</title>
                 <program language="cpp" label="lst_vertex-prog"><code>
 class Vertex {
@@ -75,7 +75,7 @@ ostream &amp;operator&lt;&lt;(ostream &amp;stream, Vertex &amp;vert) {
             vertex to another. The <c>getVertices</c> method returns the names of all
             of the vertices in the graph.</p>
         
-        <listing xml:id="lst_graph" names="graphs_lst-graph">
+        <listing xml:id="lst_graph">
                 <title><c>Graph</c> Class</title>
                 <program language="cpp" label="lst_graph-prog"><code>
 class Graph {

--- a/pretext/Graphs/ImplementingBreadthFirstSearch.ptx
+++ b/pretext/Graphs/ImplementingBreadthFirstSearch.ptx
@@ -170,7 +170,7 @@ def bfs(g,start):
             the shortest word ladder from any word back to fool. The function below (<xref ref="graphs_lst-wordbucket3"/>) shows how to follow the predecessor links to
             print out the word ladder.</p>
         
-        <listing xml:id="graphs_lst-wordbucket3" names="lst_wordbucket3">
+        <listing xml:id="graphs_lst-wordbucket3">
             <title>Printing the Word Bucker</title>
             <program language="cpp" label="graphs_lst-wordbucket3-prog"><code>
 void traverse(Vertex *y) {

--- a/pretext/Graphs/KnightsTourAnalysis.ptx
+++ b/pretext/Graphs/KnightsTourAnalysis.ptx
@@ -115,7 +115,7 @@
             <video label="graphs_knighttour-video" source="Graphs/knights_tour_vis.webm" width="80%" preview="Graphs/kt_vis_thumb.png"/>
         </figure>
 
-        <listing xml:id="graphs_lst-avail" names="lst_avail">
+        <listing xml:id="graphs_lst-avail">
             <title>Implementation of <c>orderByAvail</c></title>
             <program language="python" label="graphs_lst-avail-prog"><code>
 def orderByAvail(n):

--- a/pretext/Introduction/DefiningFunctions.ptx
+++ b/pretext/Introduction/DefiningFunctions.ptx
@@ -81,7 +81,7 @@ int main() {
             <xref ref="introduction_lst-root"/> also shows the use of the // characters as a comment
             marker. Any characters that follow the // on a line are ignored.</p>
         
-    <listing xml:id="introduction_lst-root" names="lst_root">
+    <listing xml:id="introduction_lst-root">
         <title>Newton's Method for Calculating Square Roots.</title>
     <program xml:id="newtonsmethod" interactive="activecode" language="cpp" label="newtonsmethod-prog">
         <code>

--- a/pretext/LinearLinked/TheNodeClass.ptx
+++ b/pretext/LinearLinked/TheNodeClass.ptx
@@ -12,7 +12,7 @@
             <xref ref="id2-fig-node2"/>. The <c>Node</c> class also includes the usual methods
             to access and modify the data and the next reference.</p>
 
-  <listing xml:id="linear-linked_lst-nodeclass" names="lst_nodeclass">
+  <listing xml:id="linear-linked_lst-nodeclass">
     <title><c>Node</c> Class</title>
     <program language="cpp" label="linear-linked_lst-nodeclass-prog"><code>
 #include &lt;iostream&gt;

--- a/pretext/Recursion/pythondsintro-VisualizingRecursion.ptx
+++ b/pretext/Recursion/pythondsintro-VisualizingRecursion.ptx
@@ -115,7 +115,7 @@ main()
             <c>if</c> statement on line 2 as a check for the base case of <c>branchLen</c>
             getting too small. The C++ equivalent to this function is shown below and exists in <q>Turtle.cpp</q>.</p>
 
-        <listing xml:id="lst-fractree-py" names="lst_fractree">
+        <listing xml:id="lst-fractree-py">
             <title>Fractal Tree</title>
             <program language="python" label="lst-fractree-py-prog"><code>
 def tree(branchLen,t):
@@ -266,11 +266,5 @@ main()
                 </li>
             </ul></p>
 
-    <program xml:id="recursion_sc_3" interactive="activecode" language="cpp" label="recursion_sc_3-prog">
-        <code>
-
-
-        </code>
-    </program>
 </reading-questions>  
     </section>

--- a/pretext/Trees/BinaryHeapImplementation.ptx
+++ b/pretext/Trees/BinaryHeapImplementation.ptx
@@ -159,7 +159,7 @@ void percUp(int i){
                 </code></program>
             </listing>
 
-            <listing xml:id="binheap_lst-heap3" names="lst_heap3">
+            <listing xml:id="binheap_lst-heap3">
                 <title><c>insert</c> Method</title>
                 <program language="cpp" label="binheap_lst-heap3-prog"><code>
 void insert(int k){
@@ -250,7 +250,7 @@ int minChild(int i){
                 that once again the hard work is handled by a helper function, in this
                 case <c>percDown</c>.</p>
             
-            <listing xml:id="binheap_lst-heap5" names="lst_heap5">
+            <listing xml:id="binheap_lst-heap5">
                 <title><c>delMin</c> Implementation</title>
                 <program language="cpp" label="binheap_lst-heap5-prog"><code>
 int delMin(){

--- a/pretext/Trees/ListofListsRepresentation.ptx
+++ b/pretext/Trees/ListofListsRepresentation.ptx
@@ -61,7 +61,7 @@ print('right subtree = ', myTree[2])
             tree as the left child of the list we are adding. <xref ref="lst-linsleft"/>
             shows the Python code for inserting a left child.</p>
         
-        <p xml:id="trees_lst-linsleft" names="lst_linsleft"><term>Listing 1</term></p>
+        <p xml:id="trees_lst-linsleft"><term>Listing 1</term></p>
         <pre>def insertLeft(root,newBranch):
     t = root.pop(1)
     if len(t) &gt; 1:
@@ -76,7 +76,7 @@ print('right subtree = ', myTree[2])
             The code for <c>insertRight</c> is similar to <c>insertLeft</c> and is shown
             in <xref ref="lst-linsright"/>.</p>
         
-        <p xml:id="trees_lst-linsright" names="lst_linsright"><term>Listing 2</term></p>
+        <p xml:id="trees_lst-linsright"><term>Listing 2</term></p>
         <pre>def insertRight(root,newBranch):
     t = root.pop(2)
     if len(t) &gt; 1:
@@ -88,7 +88,7 @@ print('right subtree = ', myTree[2])
             access functions for getting and setting the root value, as well as
             getting the left or right subtrees.</p>
         
-        <p xml:id="trees_lst-treeacc" names="lst_treeacc"><term>Listing 3</term></p>
+        <p xml:id="trees_lst-treeacc"><term>Listing 3</term></p>
         <pre>def getRootVal(root):
     return root[0]
 

--- a/pretext/Trees/SearchTreeImplementation.ptx
+++ b/pretext/Trees/SearchTreeImplementation.ptx
@@ -200,7 +200,7 @@ class TreeNode{
             associated with the new key to replace the old value. We leave fixing
             this bug as an exercise for you.</p>
         
-        <listing xml:id="bst_lst-bst3" names="lst_bst3">
+        <listing xml:id="bst_lst-bst3">
             <title><c>put</c> and <c>_put</c> Methods</title>
             <program language="cpp" label="bst_lst-bst3-prog"><code>
 void put(int key, string val){
@@ -269,7 +269,7 @@ void _put(int key, string val, TreeNode *currentNode){
             <c>BinarySearchTree</c> methods that may need to make use of other data
             from the <c>TreeNode</c> besides the value.</p>
         
-        <listing xml:id="bst_lst-bst4" names="bst_lst-bst4">
+        <listing xml:id="bst_lst-bst4">
             <title><c>get</c> and <c>_get</c> Methods</title>
             <program language="cpp" label="bst_lst-bst4-prog"><code>
 string get(int key){
@@ -306,7 +306,7 @@ TreeNode  *_get(int key, TreeNode *currentNode){
             key of the root matches the key that is to be deleted. In either case if
             the key is not found the <c>del</c> operator raises an error.</p>
         
-        <listing xml:id="bst_lst-bst5" names="lst_bst5">
+        <listing xml:id="bst_lst-bst5">
             <title><c>del</c> Method</title>
             <program language="cpp" label="bst_lst-bst5-prog"><code>
 void del(int key){
@@ -494,7 +494,7 @@ else{ // this node has one child
             changes. We could call <c>delete</c> recursively, but then we would waste
             time re-searching for the key node.</p>
         
-        <listing xml:id="bst_lst-bst8" names="lst_bst8">
+        <listing xml:id="bst_lst-bst8">
             <title>Deleting a Node With Two Children</title>
             <program language="cpp" label="bst_lst-bst8-prog"><code>
 else if (currentNode-&gt;hasBothChildren()){ //interior
@@ -535,7 +535,7 @@ else if (currentNode-&gt;hasBothChildren()){ //interior
             method simply follows the <c>leftChild</c> references in each node of the
             subtree until it reaches a node that does not have a left child.</p>
         
-        <listing xml:id="bst_lst-bst9" names="lst_bst9">
+        <listing xml:id="bst_lst-bst9">
             <title><c>findSuccessor</c>, <c>findMin</c>, and <c>spliceOut</c> Methods</title>
             <program language="cpp" label="bst_lst-bst9-prog"><code>
 TreeNode *findSuccessor(){


### PR DESCRIPTION
# Description
the names attribute doesn't exist. I think this came over from the original tabbednode stuff and I just didn't delete it when I created the pretext version of tab nodes

In the recursion chapter, I also deleted an empty program stanza because it showed up as invalid xml, too.

## Related Issue
standalone

## How Has This Been Tested?
local build
