### PR TITLE
Xml fixups trees

### DIFF
--- a/pretext/Trees/AVLTreeImplementation.ptx
+++ b/pretext/Trees/AVLTreeImplementation.ptx
@@ -294,13 +294,13 @@ void rotateLeft(TreeNode *rotRoot){
         <p><xref ref="trees-avl-fig-bfderive"/> shows a left rotation. B and D are the pivotal
             nodes and A, C, E are their subtrees. Let <m>h_x</m> denote the
             height of a particular subtree rooted at node <m>x</m>. By definition
-            we know the following:</p>
+            we know the following:
             <me>
                 \begin{split}
                 newBal(B) &amp; = h_A - h_C \\
                 oldBal(B) &amp;= h_A - h_D
                 \end{split}
-            </me>
+            </me></p>
         <p>But we know that the old height of D can also be given by <m>1 +
                 max(h_C,h_E)</m>, that is, the height of D is one more than the maximum
             height of its two children. Remember that <m>h_c</m> and
@@ -309,27 +309,27 @@ void rotateLeft(TreeNode *rotRoot){
         <p><me>oldBal(B) = h_A - (1 + max(h_C,h_E))</me></p>
         <p>and then subtract the two equations. The following steps
             do the subtraction and use some algebra to simplify the equation for
-            <m>newBal(B)</m>.</p>
+            <m>newBal(B)</m>.
             <me>\begin{split}
             newBal(B) - oldBal(B) &amp;= h_A - h_C - (h_A - (1 + max(h_C,h_E))) \\
             newBal(B) - oldBal(B) &amp;= h_A - h_C - h_A + (1 + max(h_C,h_E)) \\
             newBal(B) - oldBal(B) &amp;= h_A  - h_A + 1 + max(h_C,h_E) - h_C  \\
             newBal(B) - oldBal(B) &amp;=  1 + max(h_C,h_E) - h_C
-            \end{split}</me>
+            \end{split}</me></p>
         <p>Next we will move <m>oldBal(B)</m> to the right hand side of the
             equation and make use of the fact that
-            <m>max(a,b)-c = max(a-c, b-c)</m>.</p>
-        <me>newBal(B) = oldBal(B) + 1 + max(h_C - h_C ,h_E - h_C)</me>
+            <m>max(a,b)-c = max(a-c, b-c)</m>.
+        <me>newBal(B) = oldBal(B) + 1 + max(h_C - h_C ,h_E - h_C)</me></p>
         <p>But, <m>h_E - h_C</m> is the same as <m>-oldBal(D)</m>. So we can
             use another identity that says <m>max(-a,-b) = -min(a,b)</m>. So we
             can finish our derivation of <m>newBal(B)</m> with the following
-            steps:</p>
+            steps:
             <me>
                 \begin{split}
                 newBal(B) &amp; = oldBal(B) + 1 + max(0 , -oldBal(D)) \\
                 newBal(B) &amp; = oldBal(B) + 1 - min(0 , oldBal(D))
                 \end{split}
-            </me>
+            </me></p>
         <p>Now we have all of the parts in terms that we readily know. If we
             remember that B is <c>rotRoot</c> and D is <c>newRoot</c> then we can see this
             corresponds exactly to the statement on line<nbsp/>21, or:</p>

--- a/pretext/Trees/BalancedBinarySearchTrees.ptx
+++ b/pretext/Trees/BalancedBinarySearchTrees.ptx
@@ -13,8 +13,8 @@
             each node in the tree. We do this by looking at the heights of the left
             and right subtrees for each node. More formally, we define the balance
             factor for a node as the difference between the height of the left
-            subtree and the height of the right subtree.</p>
-        <me>balanceFactor = height(leftSubTree) - height(rightSubTree)</me>
+            subtree and the height of the right subtree.
+        <me>balanceFactor = height(leftSubTree) - height(rightSubTree)</me></p>
         <p>Using the definition for balance factor given above we say that a
             subtree is left-heavy if the balance factor is greater than zero. If the
             balance factor is less than zero then the subtree is right heavy. If the

--- a/pretext/Trees/ParseTree.ptx
+++ b/pretext/Trees/ParseTree.ptx
@@ -104,43 +104,59 @@
     
         <figure xml:id="parse_fig-bldexpstep">
             <caption>Tracing Parse Tree Construction.</caption>
-                <image source="Trees/buildExp1.png" width="15%">
+            <sbsgroup widths="25%">
+              <sidebyside>
+                <image source="Trees/buildExp1.png" width="25%">
                 <shortdescription>
                 First image of a vertical sequence of diagrams illustrating the construction of a binary search tree with numerical values. 
                 It shows a single circular node, shaded, representing the starting point of the tree.
                 </shortdescription>
                 </image>
+              </sidebyside>
+              <sidebyside>
                 <image source="Trees/buildExp2.png" width="25%">
                 <shortdescription>
                     Second image showing the addition of a new node below the initial node.
                 </shortdescription>
                 </image>
+              </sidebyside>
+              <sidebyside>
                 <image source="Trees/buildExp3.png" width="25%">
                 <shortdescription>
                     Third image showing the tree with an additional node labeled &quot;3&quot;.
                 </shortdescription>
                 </image>
+              </sidebyside>
+              <sidebyside>
                 <image source="Trees/buildExp4.png" width="25%">
                 <shortdescription>
                     Fourth image showing the partially constructed binary parse tree with a root node labeled &quot;+,&quot; two child nodes: the left child labeled &quot;3&quot; and a newly added right child, which is shaded to indicate it is the most recently added node.
                 </shortdescription>
                 </image>
+              </sidebyside>
+              <sidebyside>
                 <image source="Trees/buildExp5.png" width="25%">
                 <shortdescription>
                     Fifth image showing a binary parse tree with a root node labeled &quot;+.&quot; The left child is labeled &quot;3,&quot; the right child is connected to a newly added shaded node, which has a single child below it.
                 </shortdescription>
                 </image>
+              </sidebyside>
+              <sidebyside>
                 <image source="Trees/buildExp6.png" width="25%">
                 <shortdescription>
                     Sixth image showing the binary parse tree with a root node labeled &quot;+.&quot; The left child remains labeled &quot;3,&quot; while the right child is connected to a node that now has a newly added shaded child labeled &quot;4.&quot;
                 </shortdescription>
                 </image>
-                <image source="Trees/buildExp7.png" width="50%">
+              </sidebyside>
+              <sidebyside>
+                <image source="Trees/buildExp7.png" width="25%">
                 <shortdescription>
                     Seventh image showing a binary parse tree with a root node labeled &quot;+.&quot; The left child is labeled &quot;3,&quot; and the right child is labeled &quot;*.&quot; The node labeled &quot;*&quot; has two children: the left child labeled &quot;4&quot; and a newly added shaded right child.
                 </shortdescription>
                 </image>
-                <image source="Trees/buildExp8.png" width="50%">
+              </sidebyside>
+              <sidebyside>
+                <image source="Trees/buildExp8.png" width="25%">
                 <description>
                     <p>
                         A sequence of images showing the steps of completing a binary parse tree representing the construction of a mathematical expression. 
@@ -151,7 +167,8 @@
                     </p>
                 </description>
                 </image>
-            </figure>
+              </sidebyside>
+            </sbsgroup></figure>
 
 
         <p>Using <xref ref="parse_fig-bldexpstep"/>, let's walk through the example step by

--- a/pretext/Trees/SearchTreeAnalysis.ptx
+++ b/pretext/Trees/SearchTreeAnalysis.ptx
@@ -57,7 +57,21 @@
             work. Since doubling is a constant factor it does not change worst case</p>
 <reading-questions xml:id="rq-search-tree-analysis">
     <title>Reading Question</title>
-<exercise label="stanalysis_1">
-            <statement>
-    <p>The worst-case performance of the del function is O(<BlankNode/><var/>)?   </p></statement><setup><var><condition string="^\s*n\s*$"><feedback><p>Is the correct answer!</p></feedback></condition><condition string="^\s*.*\s*$"><feedback><p>Read carefully the restrictions of the the functions</p></feedback></condition></var></setup></exercise>  </reading-questions>  </section>
+    <exercise label="stanalysis_1">
+        <statement>
+            <p>The worst-case performance of the del function is O(<var/>)?   </p>
+        </statement>
+        <setup>
+            <var>
+                <condition string="^\s*n\s*$">
+                    <feedback><p>Is the correct answer!</p></feedback>
+                </condition>
+                <condition string="^\s*.*\s*$">
+                    <feedback><p>Read carefully the restrictions of the the functions</p></feedback>
+                </condition>
+            </var>
+        </setup>
+    </exercise>
+</reading-questions>
+</section>
 

--- a/pretext/Trees/SearchTreeImplementation.ptx
+++ b/pretext/Trees/SearchTreeImplementation.ptx
@@ -251,7 +251,7 @@ void _put(int key, string val, TreeNode *currentNode){
                 </p>
             </description>
             </image>
-            </figure>
+        </figure>
         <note>
             <title>Self Check</title>
 
@@ -1250,7 +1250,7 @@ main()
             
                         <choice>
                             <statement>
-                                <p><image source="Trees/bintree_a.png" width="50%"><description><p/></description></image></p>
+                                <image source="Trees/bintree_a.png" width="50%"><description><p/></description></image>
                             </statement>
                             <feedback>
                                 <p>Remember, starting at the root keys less than the root must be in the left subtree, while keys greater than the root go in the right subtree.</p>
@@ -1259,7 +1259,7 @@ main()
             
                         <choice correct="yes">
                             <statement>
-                                <p><image source="Trees/bintree_b.png" width="50%"><description><p/></description></image></p>
+                                <image source="Trees/bintree_b.png" width="50%"><description><p/></description></image>
                             </statement>
                             <feedback>
                                 <p>good job.</p>
@@ -1268,7 +1268,7 @@ main()
             
                         <choice>
                             <statement>
-                                <p><image source="Trees/bintree_c.png" width="50%"><description><p/></description></image></p>
+                                <image source="Trees/bintree_c.png" width="50%"><description><p/></description></image>
                             </statement>
                             <feedback>
                                 <p>This looks like a binary tree that satisfies the full tree property needed for a heap.</p>


### PR DESCRIPTION
# Description
several xml fixups:
- me tag belongs in a paragraph
- to use multiple images in a figure, you have to use sbsgroup/sidebyside
- images should not be in a paragraphs
- BlankNode isn't a thing

## Related Issue
standalone

## How Has This Been Tested?
local build