### PR TITLE
add premise/response paragraph test; listing has title

### DIFF
--- a/verifier.py
+++ b/verifier.py
@@ -41,6 +41,25 @@ class TabNodeIsNotAThing(CppsXmlTest):
             print(f"{fname} has {n} TabNode tags")
         return n == 0
 
+class DragNDropNoParagraph(CppsXmlTest):
+    """TabNode is something the automatic conversion tools emitted.
+    PreTeXt doesn't actually have the concept of a TabNode per se,
+    so everywhere this tag occurs we have to do some manual work.
+    """
+    @classmethod
+    def test_file(cls, fname, doc):
+        elemnames = ("response", "premise")
+        ok = True
+        for ele in elemnames:
+            for e in doc.getElementsByTagName(ele):
+                for child in e.childNodes:
+                    if child.nodeType != xml.dom.Node.ELEMENT_NODE:
+                        continue
+                    if child.nodeName == "p":
+                        ok = False
+                        print(f'{fname}: "{e.nodeName}" should not have paragraph')
+        return ok
+
 
 class ProgramInputDeprecated(CppsXmlTest):
     """TabNode is something the automatic conversion tools emitted.
@@ -62,7 +81,7 @@ class ProgramInputDeprecated(CppsXmlTest):
 
 class TagsNeedsCaption(CppsXmlTest):
     """The tags below should have a <caption> elements as a child"""
-    captioned_things = ('figure', 'listing')
+    captioned_things = ('figure',)
     @classmethod
     def test_file(cls, fname, doc):
         ret = True
@@ -81,7 +100,7 @@ class TagsNeedsCaption(CppsXmlTest):
 
 class TagsNeedsTitle(CppsXmlTest):
     """The tags below should have a <title> elements as a child"""
-    captioned_things = ('table', 'exploration', 'task')
+    captioned_things = ('table', 'exploration', 'task', 'listing')
     @classmethod
     def test_file(cls, fname, doc):
         ret = True


### PR DESCRIPTION
# Description
Added a test for response/premise having a paragraph (it shouldn't); also, listings require titles not captions

## Related Issue
standalone

## How Has This Been Tested?
local build