### PR TITLE
fix hash comparison text and code

### DIFF
--- a/pretext/AlgorithmAnalysis/HashTableAnalysis.ptx
+++ b/pretext/AlgorithmAnalysis/HashTableAnalysis.ptx
@@ -14,7 +14,7 @@
         More about this when we discuss implementations in more depth.</p>
     <p>Later in this
         book you will see that there are many ways to implement a hash table.
-        The thing that is most important to note  now is that the get
+        The thing that is most important to note now is that the get
         item and set item operations on a hash table are <m>O(1)</m>. Another
         important hash table operation is the <term>contains</term> operation. Unlike a vector, checking to
         see whether a value is in the hash table or not is also <m>O(1)</m>.</p>
@@ -45,34 +45,34 @@
             
                 <row>
                     <cell>
-                        find
+                        <c>find</c>
                     </cell>
                     <cell>
-                        O(1)
-                    </cell>
-                </row>
-                <row>
-                    <cell>
-                        insert
-                    </cell>
-                    <cell>
-                        O(1)
+                        <m>O(1)</m>
                     </cell>
                 </row>
                 <row>
                     <cell>
-                        erase
+                        <c>insert</c>
                     </cell>
                     <cell>
-                        O(1)
+                        <m>O(1)</m>
                     </cell>
                 </row>
                 <row>
                     <cell>
-                        contains
+                        <c>erase</c>
                     </cell>
                     <cell>
-                        O(1)
+                        <m>O(1)</m>
+                    </cell>
+                </row>
+                <row>
+                    <cell>
+                        <c>contains</c>
+                    </cell>
+                    <cell>
+                        <m>O(1)</m>
                     </cell>
                 </row>
                 <row>
@@ -80,7 +80,7 @@
                         iteration
                     </cell>
                     <cell>
-                        O(n)
+                        <m>O(n)</m>
                     </cell>
                 </row>
             
@@ -88,12 +88,12 @@
     </tabular></table>
     <p>Note that it is not typical to iterate through a hash table because it is
         a data structure designed for look-up, not for iteration. The big
-        advantage of the hash table is the constant speed of the contains
+        advantage of the hash table is the constant speed of the <c>contains</c>
         operation.</p>
     <p>For our last performance experiment we will compare the performance of
         the contains operation between vectors and hash tables. In the process we
-        will confirm that the contains operator for vectors is <m>O(n)</m> and
-        the contains operator for hash tables is <m>O(1)</m>. The experiment
+        will confirm that the contains operation for vectors is <m>O(n)</m> and
+        the contains operation for hash tables is <m>O(1)</m>. The experiment
         we will use to compare the two is simple. We'll make a vector with a range
         of numbers in it. Then we will pick numbers at random and check to see
         if the numbers are in the vector. If our performance tables are correct
@@ -112,7 +112,7 @@
         <title>Hash Table Analysis</title>
         <task xml:id="lst-hashtable-analysis-cpp" label="lst-hashtable-analysis-cpp">
             <title>C++ Implementation</title>
-            <statement><program language="cpp" label="HashTableAnalysis-prog"><code>
+            <statement><program language="cpp" label="HashTableAnalysis-prog" line-numbers="yes"><code>
 #include &lt;iostream&gt;
 #include &lt;ctime&gt;
 #include &lt;vector&gt;
@@ -120,48 +120,56 @@
 using namespace std;
 
 int main() {
+    for(int a = 10000; a &lt; 1000001; a = a + 20000) {
+        vector&lt;int&gt; avector;
+        unordered_map&lt;int, int&gt; amap;
 
-for(int a = 10000; a &lt; 1000001; a = a + 20000) {
-    // vector Part
-    clock_t begin = clock();
-    vector&lt;int&gt; avector;
-    for( int i = 0; i &lt; a; i++){
-        avector.push_back(i);
+        // create the vector and map
+        for( int i = 0; i &lt; a; i++){
+            avector.push_back(i);
+            amap[i] = -1;
+        }
+
+        // timing for vector access
+        srand(1);
+        clock_t begin = clock();
+        for( int i = 0; i &lt; a; i++){
+            find(avector.begin(), avector.end(), rand() % a);
+        }
+        clock_t end = clock();
+        double elapsed_secs = double(end - begin) / CLOCKS_PER_SEC;
+
+        // timing for hash table
+        srand(1);
+        clock_t  begin_ht = clock();
+        for( int i = 0; i &lt; a; i++ ){
+            amap.contains(rand() % a);
+        }
+        clock_t end_ht = clock();
+        double elapsed_secs_ht = double(end_ht - begin_ht) / CLOCKS_PER_SEC;
+
+        // Printing final output
+        cout &lt;&lt; a &lt;&lt; "\t" &lt;&lt; elapsed_secs &lt;&lt; "\t" &lt;&lt; elapsed_secs_ht &lt;&lt; endl;
     }
-    clock_t end = clock();
-    double elapsed_secs = double(end - begin) / CLOCKS_PER_SEC;
 
-    // Hash Table Part
-    clock_t  begin_ht = clock();
-    unordered_map&lt;int, int&gt; y;
-    for( int j = 0; j &lt; a; j++ ){
-        y[j] = nullptr;
-    }
-    clock_t end_ht = clock();
-    double elapsed_secs_ht = double(end_ht - begin_ht) / CLOCKS_PER_SEC;
-
-    // Printing final output
-    cout &lt;&lt; a &lt;&lt; &quot;\t&quot; &lt;&lt; elapsed_secs &lt;&lt; &quot;\t&quot; &lt;&lt; elapsed_secs_ht &lt;&lt; endl;
-}
-
-return 0;
+    return 0;
 }
             </code></program></statement>
         </task>
         <task xml:id="lst-hashtable-analysis-py" label="lst-hashtable-analysis-py">
             <title>Python Implementation</title>
-            <statement><program language="python" label="HashTableAnalysis-prog-2"><code>
+            <statement><program language="python" label="HashTableAnalysis-prog-2" line-numbers="yes"><code>
 import timeit
 import random
 
 for i in range(10000,1000001,20000):
-t = timeit.Timer(&quot;random.randrange(%d) in x&quot;%i,
-                 &quot;from __main__ import random,x&quot;)
-x = list(range(i))
-lst_time = t.timeit(number=1000)
-x = {j:None for j in range(i)}
-d_time = t.timeit(number=1000)
-print(&quot;%d,%10.3f,%10.3f&quot; % (i, lst_time, d_time))
+  t = timeit.Timer(&quot;random.randrange(%d) in x&quot;%i,
+                   &quot;from __main__ import random,x&quot;)
+  x = list(range(i))
+  lst_time = t.timeit(number=1000)
+  x = {j:None for j in range(i)}
+  d_time = t.timeit(number=1000)
+  print(&quot;%d,%10.3f,%10.3f&quot; % (i, lst_time, d_time))
             </code></program></statement>
         </task>
     </exploration>
@@ -179,9 +187,13 @@ print(&quot;%d,%10.3f,%10.3f&quot; % (i, lst_time, d_time))
         of 990,000 it also took 0.004 milliseconds.</p>
 
     <figure xml:id="fig-vectvshash-cpp">
-        <caption>Comparing the <c>in</c> Operator for C++ vectors and Hash Tables</caption>
-            <image source="AlgorithmAnalysis/vectvshash.png" width="50%">
-                <description><p>This figure summarizes the results of running Listing 6. You can see that the hash table is consistently faster. For the smallest vector size of 10,000 elements a hash table is 89.4 times faster than a vector. For the largest vector size of 990,000 elements the hash table is 11,603 times faster! You can also see that the time it takes for the contains operator on the vector grows linearly with the size of the vector. This verifies the assertion that the contains operator on a vector is . It can also be seen that the time for the contains operator on a hash table is constant even as the hash table size grows. In fact for a hash table size of 10,000 the contains operation took 0.004 milliseconds and for the hash table size of 990,000 it also took 0.004 milliseconds.</p></description>
+        <caption>Comparing the <c>contains</c> operation for C++ vectors and Hash Tables</caption>
+            <image source="AlgorithmAnalysis/vectvshash.png" width="90%">
+                <description><p>The primary take away is that the graph for vectors shows an almost linear climb from
+                0 elements taking almost 0 time to 1,000,000 elements taking approximately 45 seconds. For hash
+                tables, the function is also linear, but shows almost 0 slope from 0 elements to 1,000,000 elements
+                in the hash table. This reflects the linear versus constant time growth of the two
+                functions.</p></description>
             </image>
     </figure>
 


### PR DESCRIPTION

# Description
The comparison code wasn't actually comparing apples and oranges. It was comparing push_back in vector to index-assignment in map. I also reworked the text a bit to remove references to `in` from python.

## Related Issue
standalone

## How Has This Been Tested?
local build